### PR TITLE
bugfix: initialize error.

### DIFF
--- a/app/bank.py
+++ b/app/bank.py
@@ -159,6 +159,7 @@ class BankInfo:
             boot_uuid,
         ) = self._get_current_devfile_by_fstab(fstab_file)
         blks = self._get_ext4_blks_by_blkid()
+        stby_devfile = ""
         for blk in blks:
             if blk["TYPE"] == "ext4":
                 if blk["DEV"] == root_devfile or blk["UUID"] == root_uuid:


### PR DESCRIPTION
変数初期化エラーの修正

```
Jun 01 09:39:44 obi python3[15284]: device info error!
Jun 01 09:39:44 obi python3[15284]: Traceback (most recent call last):
Jun 01 09:39:44 obi python3[15284]:   File "/opt/ota/client/app/ota_client_service.py", line 275, in <module>
Jun 01 09:39:44 obi python3[15284]:     otaboot = OtaBoot()
Jun 01 09:39:44 obi python3[15284]:   File "/opt/ota/client/app/ota_boot.py", line 36, in _init_
Jun 01 09:39:44 obi python3[15284]:     self._grub_ctl = GrubCtl(
Jun 01 09:39:44 obi python3[15284]:   File "/opt/ota/client/app/grub_control.py", line 27, in _init_
Jun 01 09:39:44 obi python3[15284]:     self._bank_info = BankInfo(bank_info_file=bank_info_file, fstab_file=fstab_file)
Jun 01 09:39:44 obi python3[15284]:   File "/opt/ota/client/app/bank.py", line 29, in _init_
Jun 01 09:39:44 obi python3[15284]:     self._gen_bankinfo_file(self._fstab_file)
Jun 01 09:39:44 obi python3[15284]:   File "/opt/ota/client/app/bank.py", line 184, in _gen_bankinfo_file
Jun 01 09:39:44 obi python3[15284]:     + stby_devfile
Jun 01 09:39:44 obi python3[15284]: UnboundLocalError: local variable 'stby_devfile' referenced before assignment
```

受入条件
stby_devfileが初期化されて参照されること
