### PR TITLE
_copytree_complete()でdirectoryのownerがコピーできていない問題の修正

### DIFF
--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -97,7 +97,7 @@ def _copydirs_complete(src, dst):
         logger.debug("mkdir: {dst}")
         os.mkdir(dst)
         shutil.copystat(src, dst, follow_symlinks=False)
-        st = os.stat(src)
+        st = os.stat(src, follow_symlinks=False)
         os.chown(dst, st[stat.ST_UID], st[stat.ST_GID])
         return True
     return False
@@ -122,7 +122,7 @@ def _copytree_complete(src, dst):
             if srcentry.is_symlink():
                 linkto = os.readlink(srcname)
                 os.symlink(linkto, dstname)
-                st = os.stat(srcname)
+                st = os.stat(srcname, follow_symlinks=False)
                 os.chown(dstname, st[stat.ST_UID], st[stat.ST_GID], follow_symlinks=False)
             elif srcentry.is_dir():
                 _copytree_complete(srcname, dstname)

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -122,6 +122,8 @@ def _copytree_complete(src, dst):
             if srcentry.is_symlink():
                 linkto = os.readlink(srcname)
                 os.symlink(linkto, dstname)
+                st = os.stat(srcname)
+                os.chown(dstname, st[stat.ST_UID], st[stat.ST_GID], follow_symlinks=False)
             elif srcentry.is_dir():
                 _copytree_complete(srcname, dstname)
             else:
@@ -130,12 +132,6 @@ def _copytree_complete(src, dst):
             errors.extend(e.args[0])
         except OSError as why:
             errors.append((srcname, dstname, str(why)))
-    try:
-        shutil.copystat(src, dst)
-        st = os.stat(src)
-        os.chown(dst, st[stat.ST_UID], st[stat.ST_GID])
-    except OSError as why:
-        errors.append((src, dst, str(why)))
     if errors:
         raise Error(errors)
     return dst

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -82,16 +82,37 @@ def _copy_complete(src_file, dest_file, follow_symlinks=False):
     os.chown(dest_file, st[stat.ST_UID], st[stat.ST_GID])
 
 
+def _copydirs_complete(src, dst):
+    """
+    copy directory path complete
+    """
+    if os.path.isdir(dst):
+        # directory exist
+        return True
+    # check parent directory
+    src_parent_dir = os.path.dirname(src)
+    dst_parent_dir = os.path.dirname(dst)
+    if os.path.isdir(dst_parent_dir) or _copydirs_complete(src_parent_dir, dst_parent_dir):
+        # parent exist, make directory
+        logger.debug("mkdir: {dst}")
+        os.mkdir(dst)
+        shutil.copystat(src, dst, follow_symlinks=False)
+        st = os.stat(src)
+        os.chown(dst, st[stat.ST_UID], st[stat.ST_GID])
+        return True
+    return False
+
+
 def _copytree_complete(src, dst):
     """
     directory complete copy from src directory to dst directory.
     dst directory should not exist.
     """
+    # make directory on the destination
+    _copydirs_complete(src, dst)
     # get directory entories
     with os.scandir(src) as itr:
         entries = list(itr)
-    # make directory on the destination
-    os.makedirs(dst)
     errors = []
     # copy entries
     for srcentry in entries:


### PR DESCRIPTION
_copytree_complete()でdirectoryのownerがコピーできていないケースが発生。
directoryの作成にos.makedirs()を使用した場合、複数改装ある場合に最終改装以外のownerが変更できていない。
すべての階層でownerを変更するため_copydirs_complete()を作成し、os.makedirs()の代わりに使用するように変更。