### PR TITLE
Fix grub configuration

### DIFF
--- a/app/bank.py
+++ b/app/bank.py
@@ -12,6 +12,7 @@ from logging import getLogger, INFO, DEBUG
 logger = getLogger(__name__)
 logger.setLevel(INFO)
 
+
 class BankInfo:
     """
     OTA Bank device info class
@@ -170,7 +171,9 @@ class BankInfo:
                 logger.debug(f"no ext4: {blk}")
         if boot_devfile == "" or root_devfile == "" or stby_devfile == "":
             logger.error("device info error!")
-            logger.info(f"root: {root_devfile} boot: {boot_devfile} stby: {stby_devfile}")
+            logger.info(
+                f"root: {root_devfile} boot: {boot_devfile} stby: {stby_devfile}"
+            )
             return False
         else:
             with tempfile.NamedTemporaryFile(delete=False) as ftmp:
@@ -330,7 +333,7 @@ class BankInfo:
         """
         logger.debug(f"bank: {bank}")
         # passwd = (getpass.getpass() + '\n').encode()
-        command_line = "sudo blkid " + bank
+        command_line = "blkid " + bank
         logger.debug(f"command_line: {command_line}")
         out = subprocess.check_output(shlex.split(command_line))
         out_decode = out.decode("utf-8")

--- a/app/grub_control.py
+++ b/app/grub_control.py
@@ -397,12 +397,3 @@ class GrubCtl:
         """
         # ToDo: implement
         return True
-
-
-if __name__ == "__main__":
-    # grub_ctl = GrubCtl(default_grub_file="grub", custom_config_file="custom.cfg")
-    grub_ctl = GrubCtl(default_grub_file="grub")
-    # grub_ctl.make_grub_custom_configuration_file(
-    # grub_ctl._grub_cfg_file, grub_ctl._custom_cfg_file
-    # )
-    grub_ctl.grub_configuration()

--- a/app/grub_control.py
+++ b/app/grub_control.py
@@ -207,20 +207,15 @@ class GrubCtl:
                 with open(self._default_grub_file, mode="r") as fgrub:
                     lines = fgrub.readlines()
                     for l in lines:
-                        pos = l.find("GRUB_TIMEOUT_STYLE=")
-                        if pos >= 0:
-                            f.write(l[pos : (pos + 19)] + style_str)
+                        match = re.match(r"^(GRUB_TIMEOUT_STYLE=)", l)
+                        if match is not None:
+                            f.write(f"{match.group(1)}{style_str}\n")
                             continue
 
-                        pos = l.find("GRUB_TIMEOUT=")
-                        if pos >= 0:
-                            f.write(l[pos : (pos + 13)] + str(timeout))
+                        match = re.match(r"^(GRUB_TIMEOUT=)", l)
+                        if match is not None:
+                            f.write(f"{match.group(1)}{str(timeout)}\n")
                             continue
-
-                        # pos = l.find("GRUB_DISABLE_LINUX_UUID=")
-                        # if(pos >= 0):
-                        #    f.write(l[pos:(pos + 24)] + disable_uuid_str)
-                        #    continue
 
                         f.write(l)
                         f.flush()
@@ -402,3 +397,12 @@ class GrubCtl:
         """
         # ToDo: implement
         return True
+
+
+if __name__ == "__main__":
+    # grub_ctl = GrubCtl(default_grub_file="grub", custom_config_file="custom.cfg")
+    grub_ctl = GrubCtl(default_grub_file="grub")
+    # grub_ctl.make_grub_custom_configuration_file(
+    # grub_ctl._grub_cfg_file, grub_ctl._custom_cfg_file
+    # )
+    grub_ctl.grub_configuration()

--- a/tests/test_grub_control.py
+++ b/tests/test_grub_control.py
@@ -1,0 +1,31 @@
+import os
+import pytest
+
+
+def test_grub_ctl_grub_configuration(tmpdir):
+    from app.grub_control import GrubCtl
+
+    default_grub_file = tmpdir.join("grub")
+    grub = """\
+GRUB_DEFAULT=0
+GRUB_TIMEOUT_STYLE=hidden
+GRUB_TIMEOUT=0
+GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
+GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"
+GRUB_CMDLINE_LINUX=""
+"""
+    default_grub_file.write(grub)
+
+    grub_ctl = GrubCtl(default_grub_file=default_grub_file)
+    r = grub_ctl.grub_configuration()
+    assert r
+
+    grub_exp = """\
+GRUB_DEFAULT=0
+GRUB_TIMEOUT_STYLE=menu
+GRUB_TIMEOUT=10
+GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
+GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"
+GRUB_CMDLINE_LINUX=""
+"""
+    assert default_grub_file.read() == grub_exp


### PR DESCRIPTION
```
GRUB_TIMEOUT_STYLE=menu
GRUB_TIMEOUT=10
GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
```
が
```
GRUB_TIMEOUT_STYLE=menuGRUB_TIMEOUT=10GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
```
に連結されてしまう問題を修正