### PR TITLE
[T4PUB-331] Mark step "Add coverage report to PR comment" as optional

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
           sudo $pythonLocation/bin/python -m pytest --cov-report term-missing --cov=app ./tests | tee pytest-coverage.txt
       # export the coverage report to the comment!
       - name: Add coverage report to PR comment
+        continue-on-error: true
         uses: coroo/pytest-coverage-commentator@v1.0.2
   python_lint_check:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Previous **test CI** workflow will always failed due to the fail of the step **Add coverage report to PR comment** when the PR creator is not listed as maintainer of the repo, or the PR is not from the branch within the main repo.
To solve the problem, this step can be mark as optional, A.K.A not failing the whole job even this step failed.
 