### PR TITLE
[T4PUB-428] [T4PB-9255] fix kernel updating

### DIFF
--- a/app/grub_control.py
+++ b/app/grub_control.py
@@ -413,13 +413,11 @@ class GrubCtl:
         res = self.set_next_boot_entry(len(menus))
         return res
 
-    @staticmethod
-    def delete_custom_cfg_file():
+    def delete_custom_cfg_file(self):
         """
-        delete custom.cfg file
+        move custom.cfg file to custom.cfg.bak
         """
-        target_file = "/boot/grub/custom.cfg"
-        os.remove(target_file)
+        shutil.move(self._custom_cfg_file, f"{self._custom_cfg_file}.bak")
 
     @staticmethod
     def reboot():

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -724,15 +724,16 @@ class OtaClient:
         """
         generate /boot directory file
         """
+        staging_kernel_files = global_var_dict["staging-_kernel_files"]
         # starts with `/boot/vmlinuz-`.
         match = re.match(r"^/boot/(vmlinuz-.*)", regular_inf.path)
         if match is not None:
-            self._boot_vmlinuz = match.group(1)
+            staging_kernel_files["vmlinuz"] = match.group(1)
 
         # starts with `/boot/initrd.img-`, but doesnot end with `.old-dkms`.
         match = re.match(r"^(?!.*\.old-dkms$)/boot/(initrd\.img-.*)", regular_inf.path)
         if match is not None:
-            self._boot_initrd = match.group(1)
+            staging_kernel_files["initrd"] = match.group(1)
 
         if prev_inf and prev_inf.sha256hash == regular_inf.sha256hash:
             # create hard link
@@ -868,6 +869,8 @@ class OtaClient:
         except for _process_regular_files
         """
         setattr(self, "_rollback_dict", dict(gvar_dict["staging-dict-_rollback_dict"]))
+        setattr(self, "_boot_vmlinuz", gvar_dict["staging-_kernel_files"]["vmlinuz"])
+        setattr(self, "_boot_initrd", gvar_dict["staging-_kernel_files"]["initrd"])
 
     def _process_regular_files(self, rootfs_dir, rfiles_list, target_dir):
         with Manager() as manager:
@@ -879,6 +882,7 @@ class OtaClient:
             gvar_dict = {
                 "tmp-dict-hardlink_reg": manager.dict(),
                 "staging-dict-_rollback_dict": manager.dict(),
+                "staging-_kernel_files": manager.dict(),
             }
 
             # default to one worker per CPU core


### PR DESCRIPTION
# what is this PR
Current ota client cannot update kernel image(vmlinuz and initrd).
_boot_vmlinuz and _boot_initrd were set by sub-process, so global_var_dict is used to pass those value.

# issue
https://tier4.atlassian.net/browse/T4PUB-428
https://tier4.atlassian.net/browse/T4PB-9255
