### PR TITLE
[BugFix] ota-client.py: fix potential bug in _process_regular_files

### DIFF
--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -899,11 +899,11 @@ class OtaClient:
                 "staging-_kernel_files": manager.dict(),
             }
             await_c = manager.list()
-            terminate_event = manager.Event()
+            terminate_event = manager.Event()  # use in ecb and _process_regular_files
 
             # default to one worker per CPU core
             with Pool(
-                initializer=self._process_regular_files_pool_init, 
+                initializer=self._process_regular_files_pool_init,
                 initargs=(gvar_dict, await_c),
             ) as pool:
 
@@ -956,8 +956,9 @@ class OtaClient:
                 # if any exception being raised in any child processes,
                 # raise it again in the main process.
                 logger.error(
-                    f"process regular files failed: {ecb_queue.get()}. All sub processess terminated."
+                    f"process regular files failed. All sub processess terminated."
                 )
+                logger.error(f"last exception: {ecb_queue.get()}")
                 raise OtaError(f"process regular files failed!")
             else:  # everything is ALLRIGHT!
                 # update corresponding class attribute
@@ -990,7 +991,7 @@ class OtaClient:
         except Exception as e:
             logger.exception(f"worker[{os.getpid()}]: process regular file failed!")
             raise e
-        
+
         # if job finished successfully
         await_counter.append(os.getpid())
 

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -948,14 +948,15 @@ class OtaClient:
                     if not ecb_queue.empty():
                         pool.terminate()
 
-                        logger.error(f"process regular files failed. All sub processess terminated.")
+                        logger.error(
+                            f"process regular files failed. All sub processess terminated."
+                        )
                         logger.error(f"last exception: {ecb_queue.get()}")
                         raise OtaError(f"process regular files failed!")
 
             # everything is ALLRIGHT!
             # update corresponding class attribute
             self._process_regular_files_exit(gvar_dict)
-
 
     def _process_regular_file(self, rootfs_dir, target_dir, rfile_inf: RegularInf):
         """

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -993,7 +993,7 @@ class OtaClient:
             raise e
 
         # if job finished successfully
-        await_counter.append(os.getpid())
+        await_counter.append(True)
 
     def _setup_regular_files(self, target_dir):
         """

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -862,7 +862,7 @@ class OtaClient:
 
         return True
 
-    def _process_regular_files_pool_init(self, gvar_dict, awc, te):
+    def _process_regular_files_pool_init(self, gvar_dict, awc):
         """
         Used by _process_regular_files
         Init the worker pool with shared variables
@@ -873,7 +873,6 @@ class OtaClient:
         global global_var_dict, await_counter, terminate_event
         global_var_dict = gvar_dict
         await_counter = awc
-        terminate_event = te
 
     def _process_regular_files_exit(self, gvar_dict):
         """
@@ -900,12 +899,12 @@ class OtaClient:
                 "staging-_kernel_files": manager.dict(),
             }
             await_c = manager.list()
-            terminate_e = manager.Event()
+            terminate_event = manager.Event()
 
             # default to one worker per CPU core
             with Pool(
                 initializer=self._process_regular_files_pool_init, 
-                initargs=(gvar_dict, await_c, terminate_e),
+                initargs=(gvar_dict, await_c),
             ) as pool:
 
                 # error_callback for workers
@@ -945,7 +944,7 @@ class OtaClient:
                 pool.close()
                 # wait for all tasks to complete
                 # not apply timeout currently
-                while len(await_counter) < len(rfile_inf):
+                while len(await_c) < len(rfiles_list):
                     # if one of the subprocess raise error,
                     # terminate the whole pool
                     if terminate_event.is_set():


### PR DESCRIPTION
In previous implementation, **_process_regular_files** use **error_callback** to terminate the pool if any subprocess fails.
It may cause the main process hanging in some cases.

This bug fix use a synchronized **manager.event** to notify the main process to terminate the pool.
Along with this change, a **manager.list** object is used to act as await counter, to ensure that all subprocess finished their job, instead of using **pool.join**, since we need to actively polling that **manager.event**.

TODO: a timeout counter can be added to prevent hanging.