### PR TITLE
improvement for dockerfiles of e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 __pycache__/
-.coverage*

--- a/app2/ota_client.py
+++ b/app2/ota_client.py
@@ -298,13 +298,14 @@ class OtaClient:
 
                         pool.apply_async(
                             _create_regfile_func,
-                            reginf, prev_reginf, event=event, first_copy=first_copy,
+                            (reginf, prev_reginf), 
+                            {"event": event, "first_copy": first_copy},
                             error_callback=error_callback,
                         )
                     else:
                         pool.apply_async(
                             _create_regfile_func,
-                            reginf,
+                            (reginf,),
                             error_callback=error_callback,
                         )
                 
@@ -319,14 +320,16 @@ class OtaClient:
     def _create_regular_file(
         self,
         reginf: RegularInf,
-        prev_reginf: RegularInf,
+        prev_reginf: RegularInf=None,
         *,
+        # required options
         url_base: str,
         cookies: dict,
         standby_path: Path,
         processed_list,
+        # for hardlink file
         first_copy=True,
-        event,
+        event=None,
     ):
         ishardlink = reginf.nlink >= 2
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,10 +16,11 @@ services:
       context: .
       dockerfile: ./docker/client/Dockerfile
     image: ota-client
-    command: python3 -m pytest tests2 --cov=app2 --log-cli-level=INFO
+    command: |
+      bash -c "cp -av /ota-client-origin/* /ota-client && python3 -m pytest tests2 --cov=app2 --log-cli-level=INFO"
     container_name: ota-client
     volumes:
-      - .:/ota-client
+      - .:/ota-client-origin:ro
     depends_on:
       - server
 

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -3,13 +3,13 @@ SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 ARG KERNEL_VERSION="5.8.0-53-generic"
 
-RUN apt-get update
-RUN apt-get install -y python3 python3-pip
-
 COPY ./app/requirements.txt requirements.txt
-RUN python3 -m pip install -r requirements.txt
-
 COPY ./tests/requirements.txt requirements-dev.txt
-RUN python3 -m pip install -r requirements-dev.txt
+
+RUN \
+    apt-get update && \
+    apt-get install -y python3 python3-pip && \
+    python3 -m pip install -r requirements.txt && \
+    python3 -m pip install -r requirements-dev.txt
 
 WORKDIR /ota-client

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -3,23 +3,31 @@ SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 ARG KERNEL_VERSION="5.8.0-53-generic"
 
-RUN apt-get update
-RUN apt-get install -y linux-image-${KERNEL_VERSION}
-RUN apt-get install -y wget git python3 python3-pip
+RUN \
+    apt-get update && \
+    apt-get install -y linux-image-${KERNEL_VERSION} && \
+    apt-get install -y wget git python3 python3-pip
 
-RUN mkdir /ota-server
 WORKDIR /ota-server
 
+# prepare environment
+RUN \
+    wget http://cdimage.ubuntu.com/ubuntu-base/releases/20.04/release/ubuntu-base-20.04.1-base-amd64.tar.gz && \
+    mkdir -p data && \
+    tar zxf ubuntu-base-20.04.1-base-amd64.tar.gz -C data && \
+    cp /boot/vmlinuz-${KERNEL_VERSION} /boot/initrd.img-${KERNEL_VERSION} /boot/config-${KERNEL_VERSION} /boot/System.map-${KERNEL_VERSION} data/boot
 
-RUN wget http://cdimage.ubuntu.com/ubuntu-base/releases/20.04/release/ubuntu-base-20.04.1-base-amd64.tar.gz
-RUN mkdir -p data
-RUN tar zxf ubuntu-base-20.04.1-base-amd64.tar.gz -C data
-RUN cp /boot/vmlinuz-${KERNEL_VERSION} /boot/initrd.img-${KERNEL_VERSION} /boot/config-${KERNEL_VERSION} /boot/System.map-${KERNEL_VERSION} data/boot
-RUN git clone https://github.com/tier4/ota-metadata
-RUN python3 -m pip install -r ota-metadata/metadata/ota_metadata/requirements.txt
-RUN python3 ota-metadata/metadata/ota_metadata/metadata_gen.py --target-dir data --ignore-file ota-metadata/metadata/ignore.txt 
-RUN ./ota-metadata/metadata/key-gen.sh
-RUN python3 ota-metadata/metadata/ota_metadata/metadata_sign.py --sign-key privatekey.pem --cert-file certificate.pem --persistent-file ota-metadata/metadata/persistents.txt --rootfs-directory data
-RUN cp ota-metadata/metadata/persistents.txt .
+# create ota-baseimage
+RUN \
+    git clone https://github.com/tier4/ota-metadata && \
+    python3 -m pip install -r ota-metadata/metadata/ota_metadata/requirements.txt && \
+    python3 ota-metadata/metadata/ota_metadata/metadata_gen.py --target-dir data --ignore-file ota-metadata/metadata/ignore.txt && \
+    ./ota-metadata/metadata/key-gen.sh && \
+    python3 ota-metadata/metadata/ota_metadata/metadata_sign.py \
+        --sign-key privatekey.pem \
+        --cert-file certificate.pem \
+        --persistent-file ota-metadata/metadata/persistents.txt \
+        --rootfs-directory data && \
+    cp ota-metadata/metadata/persistents.txt .
 
 

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -11,22 +11,19 @@ RUN \
 WORKDIR /ota-server
 
 # prepare ubuntu base
-RUN \
-    wget http://cdimage.ubuntu.com/ubuntu-base/releases/20.04/release/ubuntu-base-20.04.1-base-amd64.tar.gz && \
+RUN wget http://cdimage.ubuntu.com/ubuntu-base/releases/20.04/release/ubuntu-base-20.04.1-base-amd64.tar.gz && \
     mkdir -p data && \
     tar zxf ubuntu-base-20.04.1-base-amd64.tar.gz -C data && \
     cp /boot/vmlinuz-${KERNEL_VERSION} /boot/initrd.img-${KERNEL_VERSION} /boot/config-${KERNEL_VERSION} /boot/System.map-${KERNEL_VERSION} data/boot
 
 # prepare build environment
-RUN \
-    git clone https://github.com/tier4/ota-metadata && \
+RUN git clone https://github.com/tier4/ota-metadata && \
     python3 -m pip install -r ota-metadata/metadata/ota_metadata/requirements.txt
     
 # create ota-baseimage
-RUN \
-    python3 ota-metadata/metadata/ota_metadata/metadata_gen.py --target-dir data --ignore-file ota-metadata/metadata/ignore.txt && \
-    ./ota-metadata/metadata/key-gen.sh && \
-    python3 ota-metadata/metadata/ota_metadata/metadata_sign.py \
+RUN python3 ota-metadata/metadata/ota_metadata/metadata_gen.py --target-dir data --ignore-file ota-metadata/metadata/ignore.txt
+RUN ./ota-metadata/metadata/key-gen.sh
+RUN python3 ota-metadata/metadata/ota_metadata/metadata_sign.py \
         --sign-key privatekey.pem \
         --cert-file certificate.pem \
         --persistent-file ota-metadata/metadata/persistents.txt \

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -10,17 +10,20 @@ RUN \
 
 WORKDIR /ota-server
 
-# prepare environment
+# prepare ubuntu base
 RUN \
     wget http://cdimage.ubuntu.com/ubuntu-base/releases/20.04/release/ubuntu-base-20.04.1-base-amd64.tar.gz && \
     mkdir -p data && \
     tar zxf ubuntu-base-20.04.1-base-amd64.tar.gz -C data && \
     cp /boot/vmlinuz-${KERNEL_VERSION} /boot/initrd.img-${KERNEL_VERSION} /boot/config-${KERNEL_VERSION} /boot/System.map-${KERNEL_VERSION} data/boot
 
-# create ota-baseimage
+# prepare build environment
 RUN \
     git clone https://github.com/tier4/ota-metadata && \
-    python3 -m pip install -r ota-metadata/metadata/ota_metadata/requirements.txt && \
+    python3 -m pip install -r ota-metadata/metadata/ota_metadata/requirements.txt
+    
+# create ota-baseimage
+RUN \
     python3 ota-metadata/metadata/ota_metadata/metadata_gen.py --target-dir data --ignore-file ota-metadata/metadata/ignore.txt && \
     ./ota-metadata/metadata/key-gen.sh && \
     python3 ota-metadata/metadata/ota_metadata/metadata_sign.py \


### PR DESCRIPTION
Some improvement and code cleanup for e2e tests dockerfiles and docker-compose file.

* dockerfiles: combine related steps into one RUN to reduce unnecessary intermediate layers
* docker-compose file: 
  previously we mount the local code base as rw into the client container, that is not a good idea as
  the container may effect the host file system when we are running pytest. now we mount the local
  code base as ro, and copy the new code base to the working dir.
