### PR TITLE
Feature/aws gglog to v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           sudo $pythonLocation/bin/python -m pytest --cov-report term-missing --cov=app ./tests --log-cli-level=INFO | tee pytest-coverage.txt
       - name: Teardown ota server
         run: |
-          docker-compose down
+          bash -c 'docker-compose down || true'
       # export the coverage report to the comment!
       - name: Add coverage report to PR comment
         continue-on-error: true

--- a/app/copy_tree.py
+++ b/app/copy_tree.py
@@ -2,13 +2,14 @@ import os
 import stat
 import shutil
 from pathlib import Path
-from logging import getLogger
 
 import configs as cfg
 from ota_error import OtaErrorUnrecoverable, OtaErrorRecoverable
+import log_util
 
-logger = getLogger(__name__)
-logger.setLevel(cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL))
+logger = log_util.get_logger(
+    __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)
+)
 
 
 class CopyTree:

--- a/app/ecu_info.py
+++ b/app/ecu_info.py
@@ -1,11 +1,12 @@
 import yaml
-from logging import getLogger
 
 from ota_error import OtaErrorUnrecoverable
 import configs as cfg
+import log_util
 
-logger = getLogger(__name__)
-logger.setLevel(cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL))
+logger = log_util.get_logger(
+    __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)
+)
 
 
 class EcuInfo:

--- a/app/grub_control.py
+++ b/app/grub_control.py
@@ -4,13 +4,14 @@ import shlex
 import tempfile
 import shutil
 from pathlib import Path
-from logging import getLogger
 
-from ota_error import OtaErrorUnrecoverable, OtaErrorRecoverable
+from ota_error import OtaErrorUnrecoverable
 import configs as cfg
+import log_util
 
-logger = getLogger(__name__)
-logger.setLevel(cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL))
+logger = log_util.get_logger(
+    __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)
+)
 
 
 class GrubCfgParser:

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,3 @@
-from logging import getLogger
-
 from ota_client_stub import OtaClientStub
 from ota_client_service import (
     OtaClientServiceV2,
@@ -9,9 +7,12 @@ from ota_client_service import (
 import otaclient_v2_pb2_grpc as v2_grpc
 
 import configs as cfg
+import log_util
 
-logger = getLogger(__name__)
-logger.setLevel(cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL))
+logger = log_util.get_logger(
+    __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)
+)
+
 
 if __name__ == "__main__":
     ota_client_stub = OtaClientStub()

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -5,8 +5,6 @@ import urllib.parse
 import re
 import os
 import time
-import subprocess
-import shlex
 import json
 from hashlib import sha256
 from pathlib import Path
@@ -15,16 +13,17 @@ from threading import Lock
 from functools import partial
 from enum import Enum, unique
 from concurrent.futures import ThreadPoolExecutor
-from logging import getLogger
 
 from ota_status import OtaStatusControl, OtaStatus
 from ota_metadata import OtaMetadata
 from ota_error import OtaErrorUnrecoverable, OtaErrorRecoverable
 from copy_tree import CopyTree
 import configs as cfg
+import log_util
 
-logger = getLogger(__name__)
-logger.setLevel(cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL))
+logger = log_util.get_logger(
+    __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)
+)
 
 
 def file_sha256(filename: Path) -> str:

--- a/app/ota_client_call.py
+++ b/app/ota_client_call.py
@@ -1,13 +1,12 @@
-from logging import getLogger
-
 import grpc
-import otaclient_v2_pb2 as v2
 import otaclient_v2_pb2_grpc as v2_grpc
 
 import configs as cfg
+import log_util
 
-logger = getLogger(__name__)
-logger.setLevel(cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL))
+logger = log_util.get_logger(
+    __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)
+)
 
 
 class OtaClientCall:

--- a/app/ota_client_service.py
+++ b/app/ota_client_service.py
@@ -1,13 +1,14 @@
 from concurrent import futures
-from logging import getLogger
 
 import grpc
 import otaclient_v2_pb2 as v2
 import otaclient_v2_pb2_grpc as v2_grpc
 import configs as cfg
+import log_util
 
-logger = getLogger(__name__)
-logger.setLevel(cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL))
+logger = log_util.get_logger(
+    __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)
+)
 
 
 class OtaClientServiceV2(v2_grpc.OtaClientServiceServicer):

--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -1,12 +1,12 @@
-from logging import getLogger
-
-from ota_client import OtaClient, OtaClientFailureType
+from ota_client import OtaClient
 from ota_client_call import OtaClientCall
 from ecu_info import EcuInfo
 import configs as cfg
+import log_util
 
-logger = getLogger(__name__)
-logger.setLevel(cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL))
+logger = log_util.get_logger(
+    __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)
+)
 
 
 class OtaClientStub:

--- a/app/ota_metadata.py
+++ b/app/ota_metadata.py
@@ -1,23 +1,18 @@
 #!/usr/bin/env python3
 
-import os
-from hashlib import sha256
 import base64
 import json
 from OpenSSL import crypto
 from pathlib import Path
-import glob
 import re
 from functools import partial
-from logging import getLogger
-
-from ota_error import OtaErrorUnrecoverable, OtaErrorRecoverable
+from ota_error import OtaErrorRecoverable
 import configs as cfg
+import log_util
 
-from logging import getLogger, INFO, DEBUG
-
-logger = getLogger(__name__)
-logger.setLevel(cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL))
+logger = log_util.get_logger(
+    __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)
+)
 
 
 class OtaMetadata:

--- a/app/ota_partition.py
+++ b/app/ota_partition.py
@@ -5,14 +5,15 @@ import shlex
 import tempfile
 import shutil
 from pathlib import Path
-from logging import getLogger
 
 from grub_control import GrubControl
-from ota_error import OtaErrorUnrecoverable, OtaErrorRecoverable
+from ota_error import OtaErrorUnrecoverable
 import configs as cfg
+import log_util
 
-logger = getLogger(__name__)
-logger.setLevel(cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL))
+logger = log_util.get_logger(
+    __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)
+)
 
 
 class OtaPartition:

--- a/app/ota_status.py
+++ b/app/ota_status.py
@@ -1,16 +1,14 @@
 from enum import Enum, unique
 from pathlib import Path
-import subprocess
-import shlex
-import shutil
-from logging import getLogger
 
 from ota_partition import OtaPartitionFile
-from ota_error import OtaErrorUnrecoverable, OtaErrorRecoverable
+from ota_error import OtaErrorRecoverable
 import configs as cfg
+import log_util
 
-logger = getLogger(__name__)
-logger.setLevel(cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL))
+logger = log_util.get_logger(
+    __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)
+)
 
 
 @unique

--- a/systemd/otaclient.service
+++ b/systemd/otaclient.service
@@ -5,7 +5,7 @@ Description=OTA Client
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 /opt/ota/client/app/ota_client_service.py
+ExecStart=/usr/bin/python3 /opt/ota/client/app/main.py
 Restart=always
 
 [Install]


### PR DESCRIPTION
# 変更点
- AWS CloudWatch Logに対応したloggerを*.pyで利用するようにしました。
- systemd service fileで起動するスクリプトを`main.py`にしました。
- 不要なimport文を削除しました。

# 動作確認
VirtualBox環境でログ出力が行われる事を確認しました。
```
Oct 12 12:07:25 autoware-ecu systemd[1]: Stopped OTA Client.
Oct 12 12:07:25 autoware-ecu systemd[1]: Started OTA Client.
Oct 12 12:07:26 autoware-ecu python3[2065245]: url: https://cfm5qkounell8.credentials.iot.ap-northeast-1.amazonaws.com/role-aliases/fms-dev-autoware-adapter-credentials-iot-secrets-access-role-alias/credentials, headers: {'x-amzn-iot-thingname': 'fms-dev-edge-d43fba9d-57b7-4c30-bbe8-04dbc8f26ea4-Core'}
Oct 12 12:07:26 autoware-ecu python3[2065245]: session is refreshed: expiry_time: 2021-10-12T04:07:26Z
Oct 12 12:07:26 autoware-ecu python3[2065245]: base logger is created
Oct 12 12:21:12 autoware-ecu python3[2065245]: [2021-10-12 12:21:12,308][INFO]-ota_client.py:234,version=1.2.3, url_base=http://192.168.11.109:8080/, cookies={}
Oct 12 12:21:12 autoware-ecu python3[2086982]: mount: /mnt/standby: /dev/sda3 already mounted on /mnt/standby.
(snip)
```

AWS CloudWatch Logsへのログ出力が行われることも確認しました。
![image](https://user-images.githubusercontent.com/8177676/136891815-4cd74682-28c4-40c1-ac06-75d75567f10f.png)
