### PR TITLE
add systemd dependency

### DIFF
--- a/docker/build_image/Dockerfile
+++ b/docker/build_image/Dockerfile
@@ -16,6 +16,9 @@ RUN gpasswd -a autoware sudo
 RUN echo 'autoware ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/autoware
 
 COPY app /opt/ota/client/app
+COPY systemd/otaclient.service /etc/systemd/system
+RUN cd /etc/systemd/system/multi-user.target.wants && ln -s /etc/systemd/system/otaclient.service
+
 COPY app/requirements.txt /opt/ota/client/app/requirements.txt
 
 RUN python3 -m pip install -r /opt/ota/client/app/requirements.txt

--- a/systemd/otaclient.service
+++ b/systemd/otaclient.service
@@ -2,6 +2,8 @@
 
 [Unit]
 Description=OTA Client
+After=network-online.target nss-lookup.target
+Wants=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
# what is this PR?
This PR adds systemd dependency.
bootの最初のフェーズでgrub-mkconfigが期待しない, standby partitionのUUIDをgrub.cfgに出力することがあった。
以前現象を確認して、その後再現しなくて、昨日 PR#61 を動作確認していたときに再現したと思って今朝確認したら全然再現しなかった。PR#61の確認は、PR#61が最新のmainを取り込んでいなかったため、間違った確認をしていたかもしれない。
bootの最初でgrub-mkconfigを実行すると問題がある場合がありそうなため、systemdの依存を追加して起動を少し後にする。

# issue
https://tier4.atlassian.net/browse/T4PB-11938