### PR TITLE
[T4PB-13101] support persistent if src file -> dst dir, src dir -> dst file

### DIFF
--- a/app/copy_tree.py
+++ b/app/copy_tree.py
@@ -86,7 +86,8 @@ class CopyTree:
         if src.is_dir() and not src.is_symlink():
             # if plain file or symlink (which links to file or directory)
             if dst_path.is_file() or dst_path.is_symlink():
-                raise OtaErrorRecoverable(f"{dst_path} exists but is not a directory")
+                logger.info(f"{src}: {dst_path} exists but is not a directory")
+                dst_path.unlink()
             if dst_path.is_dir():  # dst_path exists as a directory
                 return  # keep it untouched
             logger.info(f"creating directory {dst_path}")
@@ -100,7 +101,8 @@ class CopyTree:
                 # To avoid these cases, remove destination file beforehand.
                 dst_path.unlink()
             if dst_path.is_dir():
-                raise OtaErrorRecoverable(f"{dst_path} exists as a directory")
+                logger.info(f"{src}: {dst_path} exists as a directory")
+                shutil.rmtree(dst_path)
 
             logger.info(f"copying file {dst_dir / src.name}")
             shutil.copy2(src, dst_path, follow_symlinks=False)

--- a/app/copy_tree.py
+++ b/app/copy_tree.py
@@ -4,7 +4,7 @@ import shutil
 from pathlib import Path
 
 import configs as cfg
-from ota_error import OtaErrorUnrecoverable, OtaErrorRecoverable
+from ota_error import OtaErrorUnrecoverable
 import log_util
 
 logger = log_util.get_logger(


### PR DESCRIPTION
# What is this PR?
when /opt/autoware/maps is symlink(or file in this case) and /mnt/standby/opt/autoware/maps is directory, persistent process failed.
This PR fixes this issue.
And also this PR support this scenario: if src is directory and dst is file or symlink, 

# issue
https://tier4.atlassian.net/browse/T4PB-13101

# test
OTA tested on the actual system.