### PR TITLE
[T4PB-13100] clear failure. wait update inittialized.

### DIFF
--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -176,10 +176,10 @@ class OtaClient:
         # statistics
         self._statistics = OtaClientStatistics()
 
-    def update(self, version, url_base, cookies_json: str):
+    def update(self, version, url_base, cookies_json: str, event=None):
         try:
             cookies = json.loads(cookies_json)
-            self._update(version, url_base, cookies)
+            self._update(version, url_base, cookies, event)
             return self._result_ok()
         except OtaErrorBusy:  # there is an on-going update
             # not setting ota_status
@@ -193,6 +193,9 @@ class OtaClient:
             logger.exception("unrecoverable")
             self._ota_status.set_ota_status(OtaStatus.FAILURE)
             return self._result_unrecoverable(e)
+        finally:
+            if event:
+                event.set()
 
     def rollback(self):
         # check if there is an on-going rollback
@@ -250,7 +253,7 @@ class OtaClient:
         self._failure_reason = str(e)
         return OtaClientFailureType.UNRECOVERABLE
 
-    def _update(self, version, url_base, cookies):
+    def _update(self, version, url_base, cookies, event):
         logger.info(f"{version=},{url_base=},{cookies=}")
         """
         e.g.
@@ -263,11 +266,12 @@ class OtaClient:
         # enter update
         with self._lock:
             self._ota_status.enter_updating(version, self._mount_point)
-
-        self._update_phase = OtaClientUpdatePhase.INITIAL
-        self._failure_type = OtaClientFailureType.NO_FAILURE
-        self._failure_reason = ""
-        self._statistics.clear()
+            self._update_phase = OtaClientUpdatePhase.INITIAL
+            self._failure_type = OtaClientFailureType.NO_FAILURE
+            self._failure_reason = ""
+            self._statistics.clear()
+        if event:
+            event.set()
 
         # process metadata.jwt
         self._update_phase = OtaClientUpdatePhase.METADATA
@@ -310,33 +314,34 @@ class OtaClient:
         # enter rollback
         with self._lock:
             self._ota_status.enter_rollbacking()
-        self._failure_type = OtaClientFailureType.NO_FAILURE
-        self._failure_reason = ""
+            self._failure_type = OtaClientFailureType.NO_FAILURE
+            self._failure_reason = ""
         # leave rollback
         self._ota_status.leave_rollbacking()
 
     def _status(self):
-        return {
-            "status": self._ota_status.get_ota_status().name,
-            "failure_type": self._failure_type.name,
-            "failure_reason": self._failure_reason,
-            "version": self._ota_status.get_version(),
-            "update_progress": {
-                "phase": self._update_phase.name,
-                "total_regular_files": self._statistics.total_files,
-                "regular_files_processed": self._statistics.files_processed,
-                "files_processed_copy": self._statistics.files_processed_copy,
-                "files_processed_link": self._statistics.files_processed_link,
-                "files_processed_download": self._statistics.files_processed_download,
-                "file_size_processed_copy": self._statistics.file_size_processed_copy,
-                "file_size_processed_link": self._statistics.file_size_processed_link,
-                "file_size_processed_download": self._statistics.file_size_processed_download,
-                "elapsed_time_copy": self._statistics.elapsed_time_copy,
-                "elapsed_time_link": self._statistics.elapsed_time_link,
-                "elapsed_time_download": self._statistics.elapsed_time_download,
-                "errors_download": self._statistics.errors_download,
-            },
-        }
+        with self._lock:
+            return {
+                "status": self._ota_status.get_ota_status().name,
+                "failure_type": self._failure_type.name,
+                "failure_reason": self._failure_reason,
+                "version": self._ota_status.get_version(),
+                "update_progress": {
+                    "phase": self._update_phase.name,
+                    "total_regular_files": self._statistics.total_files,
+                    "regular_files_processed": self._statistics.files_processed,
+                    "files_processed_copy": self._statistics.files_processed_copy,
+                    "files_processed_link": self._statistics.files_processed_link,
+                    "files_processed_download": self._statistics.files_processed_download,
+                    "file_size_processed_copy": self._statistics.file_size_processed_copy,
+                    "file_size_processed_link": self._statistics.file_size_processed_link,
+                    "file_size_processed_download": self._statistics.file_size_processed_download,
+                    "elapsed_time_copy": self._statistics.elapsed_time_copy,
+                    "elapsed_time_link": self._statistics.elapsed_time_link,
+                    "elapsed_time_download": self._statistics.elapsed_time_download,
+                    "errors_download": self._statistics.errors_download,
+                },
+            }
 
     @staticmethod
     def _download(url, cookies, dst, digest):

--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -1,5 +1,6 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
+from threading import Event
 
 import otaclient_v2_pb2
 from ota_client import OtaClient
@@ -50,9 +51,12 @@ class OtaClientStub:
         logger.info(f"{entry=}")
         if entry:
             # we only dispatch the request, so we don't process the returned future object
+            event = Event()
             self._executor.submit(
-                self._ota_client.update, entry.version, entry.url, entry.cookies
+                self._ota_client.update, entry.version, entry.url, entry.cookies, event
             )
+            # wait until update is initialized or error occured.
+            event.wait()
 
             main_ecu_update_result = {
                 "ecu_id": entry.ecu_id,

--- a/app/ota_error.py
+++ b/app/ota_error.py
@@ -1,3 +1,7 @@
+class OtaErrorBusy(Exception):
+    pass
+
+
 class OtaErrorRecoverable(Exception):
     pass
 

--- a/app/ota_status.py
+++ b/app/ota_status.py
@@ -2,7 +2,7 @@ from enum import Enum, unique
 from pathlib import Path
 
 from ota_partition import OtaPartitionFile
-from ota_error import OtaErrorRecoverable, OtaErrorBusy
+from ota_error import OtaErrorBusy
 import configs as cfg
 import log_util
 

--- a/app/ota_status.py
+++ b/app/ota_status.py
@@ -2,7 +2,7 @@ from enum import Enum, unique
 from pathlib import Path
 
 from ota_partition import OtaPartitionFile
-from ota_error import OtaErrorRecoverable
+from ota_error import OtaErrorRecoverable, OtaErrorBusy
 import configs as cfg
 import log_util
 
@@ -49,9 +49,7 @@ class OtaStatusControl:
             OtaStatus.FAILURE,
             OtaStatus.ROLLBACK_FAILURE,
         ]:
-            raise OtaErrorRecoverable(
-                f"status={self._ota_status} is illegal for update"
-            )
+            raise OtaErrorBusy(f"status={self._ota_status} is illegal for update")
 
     def enter_updating(self, version, mount_path: Path):
         logger.info(f"{version=},{mount_path=}")
@@ -75,9 +73,7 @@ class OtaStatusControl:
             OtaStatus.SUCCESS,
             OtaStatus.ROLLBACK_FAILURE,
         ]:
-            raise OtaErrorRecoverable(
-                f"status={self._ota_status} is illegal for rollback"
-            )
+            raise OtaErrorBusy(f"status={self._ota_status} is illegal for rollback")
 
     def enter_rollbacking(self):
         self.check_rollback_status()


### PR DESCRIPTION
# What is this PR?
OTA client has a bug that OTA client doesn't clear failure_type and failure_reason even new update request is received.

Also, this RP changes to wait for update initialization.
When the user requests `update`, and polls `status`, the `status` may return the status which is before the update request.
This is difficult for the user to use `update` and after `status` call.

# issue
https://tier4.atlassian.net/browse/T4PB-13100
