### PR TITLE
[T4PB-13258] adding sync operation

### DIFF
--- a/app/grub_control.py
+++ b/app/grub_control.py
@@ -3,6 +3,7 @@ import subprocess
 import shlex
 import tempfile
 import shutil
+import os
 from pathlib import Path
 from pprint import pformat
 
@@ -98,6 +99,8 @@ class GrubControl:
         with tempfile.NamedTemporaryFile("w", delete=False, prefix=__name__) as f:
             temp_name = f.name
             f.write(custom_cfg)
+            f.flush()
+            os.fsync(f.fileno())
         # should not be called within the NamedTemporaryFile context
         shutil.move(temp_name, self._custom_cfg_file)
 
@@ -193,6 +196,8 @@ class GrubControl:
         logger.info(f"{merged=}")
         with open(mount_point / "etc" / "fstab", "w") as f:
             f.writelines(merged)
+            f.flush()
+            os.fsync(f.fileno())
 
     def get_booted_vmlinuz_and_uuid(self):
         cmdline = self._get_cmdline()
@@ -284,8 +289,12 @@ class GrubControl:
 
         with open(self._default_grub_file, "w") as f:
             f.writelines(updated)
+            f.flush()
+            os.fsync(f.fileno())
 
     def _grub_reboot_cmd(self, num):
+        cmd = "sync"
+        subprocess.check_output(shlex.split(cmd))
         cmd = f"grub-reboot {num}"
         return subprocess.check_output(shlex.split(cmd))
 
@@ -304,4 +313,6 @@ class GrubControl:
 
     def _grub_mkconfig_cmd(self, outfile):
         cmd = f"grub-mkconfig -o {outfile}"
-        return subprocess.check_output(shlex.split(cmd)).decode().strip()
+        subprocess.check_output(shlex.split(cmd))
+        cmd = f"sync {outfile}"
+        subprocess.check_output(shlex.split(cmd))

--- a/app/ota_partition.py
+++ b/app/ota_partition.py
@@ -436,7 +436,7 @@ class OtaPartitionFile(OtaPartition):
         # NOTE:
         # If the system is reset here, grub has a problem of not starting with
         # the proper partition, so the sync below is required.
-        self._sync_cmd()
+        os.sync()
 
     def _fsync(self, path):
         try:
@@ -446,7 +446,3 @@ class OtaPartitionFile(OtaPartition):
         finally:
             if fd:
                 os.close(fd)
-
-    def _sync_cmd(self):
-        cmd = "sync"
-        subprocess.check_output(shlex.split(cmd))

--- a/app/ota_partition.py
+++ b/app/ota_partition.py
@@ -433,6 +433,7 @@ class OtaPartitionFile(OtaPartition):
         subprocess.check_output(shlex.split(cmd_mv))
         self._fsync(src.parent)
         self._fsync(dst.parent)
+        self._sync_cmd()
 
     def _fsync(self, path):
         try:
@@ -442,3 +443,7 @@ class OtaPartitionFile(OtaPartition):
         finally:
             if fd:
                 os.close(fd)
+
+    def _sync_cmd(self):
+        cmd = "sync"
+        subprocess.check_output(shlex.split(cmd))

--- a/app/ota_partition.py
+++ b/app/ota_partition.py
@@ -164,6 +164,9 @@ class OtaPartitionFile(OtaPartition):
             self._move_atomic(
                 str(temp_file), str(self._boot_dir / self._boot_ota_partition_file)
             )
+            logger.info(
+                f"switched: {os.readlink(temp_file)=} -> {(self._boot_dir / self._boot_ota_partition_file)}"
+            )
 
     def store_active_ota_status(self, status):
         """

--- a/app/ota_partition.py
+++ b/app/ota_partition.py
@@ -295,6 +295,8 @@ class OtaPartitionFile(OtaPartition):
         with tempfile.NamedTemporaryFile("w", delete=False, prefix=__name__) as f:
             temp_name = f.name
             f.write(string)
+            f.flush()
+            os.fsync(f.fileno())
         # should not be called within the NamedTemporaryFile context
         shutil.move(temp_name, path)
 

--- a/app/ota_partition.py
+++ b/app/ota_partition.py
@@ -161,12 +161,12 @@ class OtaPartitionFile(OtaPartition):
             temp_file.symlink_to(
                 self._boot_ota_partition_file.with_suffix(f".{standby_device}")
             )
+            ota_partition_file = self._boot_dir / self._boot_ota_partition_file
+            logger.info(f"switching: {os.readlink(temp_file)=} -> {ota_partition_file}")
             self._move_atomic(
                 str(temp_file), str(self._boot_dir / self._boot_ota_partition_file)
             )
-            logger.info(
-                f"switched: {os.readlink(temp_file)=} -> {(self._boot_dir / self._boot_ota_partition_file)}"
-            )
+            logger.info(f"switched: {os.readlink(ota_partition_file)=}")
 
     def store_active_ota_status(self, status):
         """

--- a/app/ota_partition.py
+++ b/app/ota_partition.py
@@ -433,6 +433,9 @@ class OtaPartitionFile(OtaPartition):
         subprocess.check_output(shlex.split(cmd_mv))
         self._fsync(src.parent)
         self._fsync(dst.parent)
+        # NOTE:
+        # If the system is reset here, grub has a problem of not starting with
+        # the proper partition, so the sync below is required.
         self._sync_cmd()
 
     def _fsync(self, path):

--- a/app/ota_partition.py
+++ b/app/ota_partition.py
@@ -163,7 +163,7 @@ class OtaPartitionFile(OtaPartition):
             )
             ota_partition_file = self._boot_dir / self._boot_ota_partition_file
             logger.info(f"switching: {os.readlink(temp_file)=} -> {ota_partition_file}")
-            self._move_atomic(str(temp_file), str(ota_partition_file))
+            self._move_atomic(temp_file, ota_partition_file)
             logger.info(f"switched: {os.readlink(ota_partition_file)=}")
 
     def store_active_ota_status(self, status):
@@ -394,7 +394,7 @@ class OtaPartitionFile(OtaPartition):
                 temp_file = Path(d) / "temp_link"
                 temp_file.symlink_to(Path("..") / "ota-partition" / "grub.cfg")
                 # move temp symlink to grub.cfg
-                self._move_atomic(str(temp_file), str(grub_cfg_file))
+                self._move_atomic(temp_file, grub_cfg_file)
 
         # update grub.cfg
         self._grub_control.update_grub_cfg(


### PR DESCRIPTION
# What is this PR?
When the system is force reset without poweroff or reboot command during the update sequence, the system will not boot.

The problems we faced:
- grub.cfg is corrupted.
- /boot/ota-partition isn't switched
- after rebooting(with force reset), grub loader uses unintended grub.cfg? and booted with unintended partition.
This PR fixes this issue.

# issue
https://tier4.atlassian.net/browse/T4PB-13258