### PR TITLE
Refactor of OtaClientStatistics collecting logic

### DIFF
--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -560,17 +560,18 @@ class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
             {"op": str}  # operation. "copy", "link" or "download"
             {"errors": int}  # number of errors that occurred when downloading.
         """
+        all_processed = len(sts)
         with self._statistics.modify_storage() as staging_storage:
             # failed to acquire lock for any reason
             if staging_storage is None:
                 return
 
             already_processed = staging_storage.get("files_processed", 0)
-            if already_processed >= len(sts):
+            if already_processed >= staging_storage.get("total_files",0):
                 return
 
-            staging_storage["files_processed"] += len(sts) - already_processed
-            for st in sts[already_processed:]:
+            staging_storage["files_processed"] += all_processed - already_processed
+            for st in sts[already_processed:all_processed]:
                 _suffix = st.get("op")
                 if _suffix in {"copy", "link", "download"}:
                     staging_storage[f"files_processed_{_suffix}"] += 1

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -207,30 +207,26 @@ class OtaClientUpdatePhase(Enum):
 
 class OtaClientStatistics(object):
     def __init__(self):
-        self._lock = Lock()       
-        self._slot: dict = self._init_statistics_storage()
+        self._lock = Lock()
+        self.clear()
 
     @staticmethod
     def _init_statistics_storage() -> dict:
         return {
             "total_files": 0,
             "files_processed": 0,
-
             "files_processed_copy": 0,
             "files_processed_link": 0,
             "files_processed_download": 0,
-
             "file_size_processed_copy": 0,
             "file_size_processed_link": 0,
             "file_size_processed_download": 0,
-
             "elapsed_time_copy": 0,  # in milliseconds
             "elapsed_time_link": 0,  # in milliseconds
             "elapsed_time_download": 0,  # in milliseconds
-
             "errors_download": 0,
         }
-    
+
     def __getattr__(self, attr: str) -> int:
         """
         get attribute from the storage area
@@ -271,6 +267,7 @@ class OtaClientStatistics(object):
                 self._slot = staging_slot.copy()
                 staging_slot.clear()
                 self._lock.release()
+
 
 class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
     def __init__(self):
@@ -452,7 +449,7 @@ class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
                 "elapsed_time_link": self._statistics.elapsed_time_link,
                 "elapsed_time_download": self._statistics.elapsed_time_download,
                 "errors_download": self._statistics.errors_download,
-            }
+            },
         }
 
     def _verify_metadata(self, url_base, cookies, list_info, metadata):
@@ -567,7 +564,7 @@ class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
                 return
 
             already_processed = staging_storage.get("files_processed", 0)
-            if already_processed >= staging_storage.get("total_files",0):
+            if already_processed >= staging_storage.get("total_files", 0):
                 return
 
             staging_storage["files_processed"] += all_processed - already_processed
@@ -575,8 +572,12 @@ class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
                 _suffix = st.get("op")
                 if _suffix in {"copy", "link", "download"}:
                     staging_storage[f"files_processed_{_suffix}"] += 1
-                    staging_storage[f"file_size_processed_{_suffix}"] += st.get("size", 0)
-                    staging_storage[f"elapsed_time_{_suffix}"] += int(st.get("elapsed", 0) * 1000)
+                    staging_storage[f"file_size_processed_{_suffix}"] += st.get(
+                        "size", 0
+                    )
+                    staging_storage[f"elapsed_time_{_suffix}"] += int(
+                        st.get("elapsed", 0) * 1000
+                    )
                     staging_storage[f"errors_{_suffix}"] = st.get("errors", 0)
 
     def _create_regular_files(self, url_base: str, cookies, list_file, standby_path):
@@ -647,7 +648,7 @@ class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
                         pool.terminate()
                         raise error
                     time.sleep(2)  # set pulling interval to 2 seconds
-                
+
                 # final statistics record
                 self._set_statistics(processed_list)
 

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -558,8 +558,9 @@ class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
         """
         all_processed = len(sts)
         with self._statistics.acquire_staging_storage() as staging_storage:
-            already_processed = staging_storage.get("files_processed", 0)
-            if already_processed >= staging_storage.get("total_files", 0):
+            # NOTE: "files_processed" key and "total_files" key should be presented!
+            already_processed = staging_storage["files_processed"]
+            if already_processed >= staging_storage["total_files"]:
                 return
 
             staging_storage["files_processed"] += all_processed - already_processed
@@ -573,7 +574,8 @@ class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
                     staging_storage[f"elapsed_time_{_suffix}"] += int(
                         st.get("elapsed", 0) * 1000
                     )
-                    staging_storage[f"errors_{_suffix}"] = st.get("errors", 0)
+                    if _suffix == "download":
+                        staging_storage[f"errors_{_suffix}"] = st.get("errors", 0)
 
     def _create_regular_files(self, url_base: str, cookies, list_file, standby_path):
         reginf_list_raw_lines = open(list_file).readlines()

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -575,7 +575,7 @@ class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
                         st.get("elapsed", 0) * 1000
                     )
                     if _suffix == "download":
-                        staging_storage[f"errors_{_suffix}"] = st.get("errors", 0)
+                        staging_storage[f"errors_{_suffix}"] += st.get("errors", 0)
 
     def _create_regular_files(self, url_base: str, cookies, list_file, standby_path):
         reginf_list_raw_lines = open(list_file).readlines()

--- a/tests/test_ota_client-status.py
+++ b/tests/test_ota_client-status.py
@@ -50,7 +50,7 @@ def test_ota_client_status(mocker, tmp_path):
     # test start
     ota_client_instance = ota_client.OtaClient()
     # thread-safe modifying the storage
-    with ota_client_instance._statistics.modify_storage() as staging_slot:
+    with ota_client_instance._statistics.acquire_staging_storage() as staging_slot:
         staging_slot["total_files"] = 99
         staging_slot["files_processed"] = 1
         staging_slot["files_processed_copy"] = 80

--- a/tests/test_ota_client-status.py
+++ b/tests/test_ota_client-status.py
@@ -49,18 +49,20 @@ def test_ota_client_status(mocker, tmp_path):
 
     # test start
     ota_client_instance = ota_client.OtaClient()
-    ota_client_instance._statistics.total_files = 99
-    ota_client_instance._statistics.files_processed = 1
-    ota_client_instance._statistics.files_processed_copy = 80
-    ota_client_instance._statistics.files_processed_link = 9
-    ota_client_instance._statistics.files_processed_download = 10
-    ota_client_instance._statistics.file_size_processed_copy = 1111
-    ota_client_instance._statistics.file_size_processed_link = 2222
-    ota_client_instance._statistics.file_size_processed_download = 3333
-    ota_client_instance._statistics.elapsed_time_copy = 1.01
-    ota_client_instance._statistics.elapsed_time_link = 2.02
-    ota_client_instance._statistics.elapsed_time_download = 3.03
-    ota_client_instance._statistics.errors_download = 10
+    # thread-safe modifying the storage
+    with ota_client_instance._statistics.modify_storage() as staging_slot:
+        staging_slot["total_files"] = 99
+        staging_slot["files_processed"] = 1
+        staging_slot["files_processed_copy"] = 80
+        staging_slot["files_processed_link"] = 9
+        staging_slot["files_processed_download"] = 10
+        staging_slot["file_size_processed_copy"] = 1111
+        staging_slot["file_size_processed_link"] = 2222
+        staging_slot["file_size_processed_download"] = 3333
+        staging_slot["elapsed_time_copy"] = 1.01
+        staging_slot["elapsed_time_link"] = 2.02
+        staging_slot["elapsed_time_download"] = 3.03
+        staging_slot["errors_download"] = 10
 
     result, ota_status = ota_client_instance.status()
     assert result == OtaClientFailureType.NO_FAILURE


### PR DESCRIPTION
## Description
The previous implementation of OtaClientStatistics collecting logic may cause the statistics not being updated properly or missing updates when grpc *status* API being called with very short interval.

This PR fixes this problem by refactoring the statistics collecting logic, and improves the performance. The format of OtaStatistics is not changed.

Unit tests are passed for this PR.