### PR TITLE
[T4PUB-663] Support nvme boot with ota-client on ROSCUBE-X

### DIFF
--- a/app/configs.py
+++ b/app/configs.py
@@ -7,22 +7,20 @@ from logging import INFO
 @dataclass(frozen=True)
 class _BaseConfig:
     DEFAULT_LOG_LEVEL: int = (INFO,)
-    LOG_LEVEL_TABLE: dict = (
-        field(
-            default_factory=lambda: {
-                "ecu_info": INFO,
-                "grub_control": INFO,
-                "grub_ota_partition": INFO,
-                "extlinux_control": INFO,
-                "main": INFO,
-                "ota_client": INFO,
-                "ota_client_call": INFO,
-                "ota_client_service": INFO,
-                "ota_client_stub": INFO,
-                "ota_metadata": INFO,
-                "ota_status": INFO,
-            }.copy()
-        ),
+    LOG_LEVEL_TABLE: dict = field(
+        default_factory=lambda: {
+            "ecu_info": INFO,
+            "grub_control": INFO,
+            "grub_ota_partition": INFO,
+            "extlinux_control": INFO,
+            "main": INFO,
+            "ota_client": INFO,
+            "ota_client_call": INFO,
+            "ota_client_service": INFO,
+            "ota_client_stub": INFO,
+            "ota_metadata": INFO,
+            "ota_status": INFO,
+        }.copy()
     )
     ECU_INFO_FILE: Path = (Path("/boot/ota/ecu_info.yaml"),)
     PASSWD_FILE: Path = (Path("/etc/passwd"),)
@@ -57,9 +55,7 @@ class CBootControlConfig(_BaseConfig):
     """
 
     BOOTLOADER: str = "cboot"
-    CHIP_ID_MODEL_MAP: dict = field(
-        default_factory=lambda: {0x19: "rqx_580"}.copy()
-    )
+    CHIP_ID_MODEL_MAP: dict = field(default_factory=lambda: {0x19: "rqx_580"}.copy())
     EXTLINUX_FILE: Path = ("/boot/extlinux/extlinux.conf",)
     SLOT_IN_USE_FILE: Path = ("/boot/ota-status/slot_in_use",)
     OTA_STATUS_DIR: Path = ("/boot/ota-status",)

--- a/app/configs.py
+++ b/app/configs.py
@@ -109,7 +109,7 @@ class CBootControlConfig(_BaseConfig):
                 "FDT": self.BOOT_DIR / "tegra194-rqx-580.dtb",
                 "FDT_HDR40": self.BOOT_DIR / "tegra194-rqx-580-hdr40.dtbo",
                 "EXTRA_CMDLINE": "console=ttyTCU0,115200n8 console=tty0 fbcon=map:0 net.ifnames=0",
-                "SEPERATE_BOOT_MOUNT_POINT": Path("/mnt/standby_boot")
+                "SEPERATE_BOOT_MOUNT_POINT": Path("/mnt/standby_boot"),
             }
         )
 

--- a/app/configs.py
+++ b/app/configs.py
@@ -1,137 +1,97 @@
+import dataclasses
 import platform
-from abc import ABC
 from pathlib import Path
-
 from logging import INFO
 
 
-class _BaseConfig(ABC):
-    def __init__(self):
-        # default settings(platform neutral)
-        default_log_level = INFO
-        log_level_table = {
-            "ecu_info": INFO,
-            "grub_control": INFO,
-            "grub_ota_partition": INFO,
-            "extlinux_control": INFO,
-            "main": INFO,
-            "ota_client": INFO,
-            "ota_client_call": INFO,
-            "ota_client_service": INFO,
-            "ota_client_stub": INFO,
-            "ota_metadata": INFO,
-            "ota_status": INFO,
-        }
-
-        boot_dir = Path("/boot")
-        etc_dir = Path("/etc")
-        mount_point = Path("/mnt/standby")
-
-        fstab_file = etc_dir / "fstab"
-        ecu_info_file = boot_dir / "ota" / "ecu_info.yaml"
-        passwd_file = etc_dir / "passwd"
-        group_file = etc_dir / "group"
-
-        ota_partition_dir = Path("ota-partition")
-
-        # properties map
-        self._properties_map = {
-            "DEFAULT_LOG_LEVEL": default_log_level,
-            "LOG_LEVEL_TABLE": log_level_table,
-            "BOOT_DIR": boot_dir,
-            "ETC_DIR": etc_dir,
-            "FSTAB_FILE": fstab_file,
-            "ECU_INFO_FILE": ecu_info_file,
-            "PASSWD_FILE": passwd_file,
-            "GROUP_FILE": group_file,
-            "BOOT_OTA_PARTITION_FILE": ota_partition_dir,
-            "OTA_STATUS_FNAME": "status",
-            "OTA_VERSION_FNAME": "version",
-            "LOG_FORMAT": "[%(asctime)s][%(levelname)s]-%(filename)s:%(funcName)s:%(lineno)d,%(message)s",
-            "MOUNT_POINT": mount_point,
-        }
-
-    def __getattr__(self, name: str):
-        if name not in self._properties_map:
-            raise AttributeError(f"config option {name} not found")
-        else:
-            return self._properties_map[name]
-
-    def set(self, __name: str, __value):
-        self._properties_map[__name] = __value
+@dataclasses.dataclass(frozen=True)
+class _BaseConfig:
+    DEFAULT_LOG_LEVEL: int = (INFO,)
+    LOG_LEVEL_TABLE: dict = (
+        dataclasses.field(
+            default_factory=lambda: {
+                "ecu_info": INFO,
+                "grub_control": INFO,
+                "grub_ota_partition": INFO,
+                "extlinux_control": INFO,
+                "main": INFO,
+                "ota_client": INFO,
+                "ota_client_call": INFO,
+                "ota_client_service": INFO,
+                "ota_client_stub": INFO,
+                "ota_metadata": INFO,
+                "ota_status": INFO,
+            }.copy()
+        ),
+    )
+    ECU_INFO_FILE: Path = (Path("/boot/ota/ecu_info.yaml"),)
+    PASSWD_FILE: Path = (Path("/etc/passwd"),)
+    GROUP_FILE: Path = (Path("/etc/group"),)
+    BOOT_OTA_PARTITION_FILE: Path = (Path("/boot/ota-partition"),)
+    OTA_STATUS_FNAME: str = ("status",)
+    OTA_VERSION_FNAME: str = ("version",)
+    LOG_FORMAT: str = (
+        "[%(asctime)s][%(levelname)s]-%(filename)s:%(funcName)s:%(lineno)d,%(message)s",
+    )
+    MOUNT_POINT: Path = Path("/mnt/standby")
 
 
+@dataclasses.dataclass
 class GrubControlConfig(_BaseConfig):
     """
     x86-64 platform, using grub
     """
 
-    PLATFORM = "grub"
-
-    def __init__(self):
-        super().__init__()
-
-        self.grub_dir = self.BOOT_DIR / "grub"
-        self.grub_cfg_file = self.grub_dir / "grub.cfg"
-        self.custom_cfg_file = self.grub_dir / "custom.cfg"
-        self.default_grub_file = self.ETC_DIR / "default/grub"
-
-        self._properties_map.update(
-            {
-                "GRUB_DIR": self.grub_dir,
-                "GRUB_CFG_FILE": self.grub_cfg_file,
-                "CUSTOM_CFG_FILE": self.custom_cfg_file,
-                "DEFAULT_GRUB_FILE": self.default_grub_file,
-            }
-        )
+    BOOTLOADER: str = "grub"
+    FSTAB_FILE: Path = (Path("/etc/fstab"),)
+    GRUB_DIR: Path = (Path("/boot/grub"),)
+    GRUB_CFG_FILE: Path = (Path("/boot/grub/grub.cfg"),)
+    CUSTOM_CFG_FILE: Path = (Path("/boot/grub/custom.cfg"),)
+    DEFAULT_GRUB_FILE: Path = (Path("/etc/default/grub"),)
 
 
+@dataclasses.dataclass
 class CBootControlConfig(_BaseConfig):
     """
-    NOTE: only for tegraid:0x19, jetson xavier platform
+    NOTE: only for tegraid:0x19, roscube-x platform(jetson-xavier-agx series)
     """
 
-    PLATFORM = "cboot"
-    CHIP_ID_MODEL_MAP = {0x19: "rqx_580"}
-
-    def __init__(self):
-        super().__init__()
-
-        self._properties_map.update(
-            {
-                "EXTLINUX_FILE": self.BOOT_DIR / "extlinux/extlinux.conf",
-                "SLOT_IN_USE_FILE": self.BOOT_DIR / "ota-status/slot_in_use",
-                "OTA_STATUS_DIR": self.BOOT_DIR / "ota-status",
-                "KERNEL": self.BOOT_DIR / "Image",
-                "KERNEL_SIG": self.BOOT_DIR / "Image.sig",
-                "INITRD": self.BOOT_DIR / "initrd",
-                "INITRD_IMG_LINK": self.BOOT_DIR / "initrd.img",
-                "FDT": self.BOOT_DIR / "tegra194-rqx-580.dtb",
-                "FDT_HDR40": self.BOOT_DIR / "tegra194-rqx-580-hdr40.dtbo",
-                "EXTRA_CMDLINE": "console=ttyTCU0,115200n8 console=tty0 fbcon=map:0 net.ifnames=0",
-                "SEPERATE_BOOT_MOUNT_POINT": Path("/mnt/standby_boot"),
-            }
-        )
+    BOOTLOADER: str = "cboot"
+    CHIP_ID_MODEL_MAP: dict = dataclasses.field(
+        default_factory=lambda: {0x19: "rqx_580"}.copy()
+    )
+    EXTLINUX_FILE: Path = ("/boot/extlinux/extlinux.conf",)
+    SLOT_IN_USE_FILE: Path = ("/boot/ota-status/slot_in_use",)
+    OTA_STATUS_DIR: Path = ("/boot/ota-status",)
+    KERNEL: Path = ("/boot/Image",)
+    KERNEL_SIG: Path = ("/boot/Image.sig",)
+    INITRD: Path = ("/boot/initrd",)
+    INITRD_IMG_LINK: Path = ("/boot/initrd.img",)
+    FDT: Path = ("/boot/tegra194-rqx-580.dtb",)
+    FDT_HDR40: Path = ("/boot/tegra194-rqx-580-hdr40.dtbo",)
+    SEPERATE_BOOT_MOUNT_POINT: Path = (Path("/mnt/standby_boot"),)
+    EXTRA_CMDLINE: str = (
+        "console=ttyTCU0,115200n8 console=tty0 fbcon=map:0 net.ifnames=0",
+    )
 
 
 # helper function to detect platform
-def _detect_platform():
+def _detect_bootloader():
     if platform.machine() == "x86_64" or platform.processor == "x86_64":
         return "grub"
     elif platform.machine() == "aarch64" or platform.processor == "aarch64":
         return "cboot"
     else:
-        raise NotImplementedError(
-            f"unsupported platform found {platform.machine()}, abort"
-        )
+        return ""
 
 
-def create_config(platform):
-    if platform == "grub":
+def create_config(bootloader):
+    if bootloader == "grub":
         return GrubControlConfig()
-    elif platform == "cboot":
+    elif bootloader == "cboot":
         return CBootControlConfig()
-    return None
+    else:
+        raise NotImplementedError(f"{bootloader=} not supported, abort")
 
 
-config = create_config(_detect_platform())
+config = create_config(_detect_bootloader())

--- a/app/configs.py
+++ b/app/configs.py
@@ -3,10 +3,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from logging import INFO
 
-
+# fmt: off
 @dataclass(frozen=True)
 class _BaseConfig:
-    DEFAULT_LOG_LEVEL: int = (INFO,)
+    DEFAULT_LOG_LEVEL: int = INFO
     LOG_LEVEL_TABLE: dict = field(
         default_factory=lambda: {
             "ecu_info": INFO,
@@ -22,14 +22,14 @@ class _BaseConfig:
             "ota_status": INFO,
         }.copy()
     )
-    ECU_INFO_FILE: Path = (Path("/boot/ota/ecu_info.yaml"),)
-    PASSWD_FILE: Path = (Path("/etc/passwd"),)
-    GROUP_FILE: Path = (Path("/etc/group"),)
-    BOOT_OTA_PARTITION_FILE: Path = (Path("/boot/ota-partition"),)
-    OTA_STATUS_FNAME: str = ("status",)
-    OTA_VERSION_FNAME: str = ("version",)
+    ECU_INFO_FILE: Path = Path("/boot/ota/ecu_info.yaml")
+    PASSWD_FILE: Path = Path("/etc/passwd")
+    GROUP_FILE: Path = Path("/etc/group")
+    BOOT_OTA_PARTITION_FILE: Path = Path("/boot/ota-partition")
+    OTA_STATUS_FNAME: str = "status"
+    OTA_VERSION_FNAME: str = "version"
     LOG_FORMAT: str = (
-        "[%(asctime)s][%(levelname)s]-%(filename)s:%(funcName)s:%(lineno)d,%(message)s",
+        "[%(asctime)s][%(levelname)s]-%(filename)s:%(funcName)s:%(lineno)d,%(message)s"
     )
     MOUNT_POINT: Path = Path("/mnt/standby")
 
@@ -41,11 +41,11 @@ class GrubControlConfig(_BaseConfig):
     """
 
     BOOTLOADER: str = "grub"
-    FSTAB_FILE: Path = (Path("/etc/fstab"),)
-    GRUB_DIR: Path = (Path("/boot/grub"),)
-    GRUB_CFG_FILE: Path = (Path("/boot/grub/grub.cfg"),)
-    CUSTOM_CFG_FILE: Path = (Path("/boot/grub/custom.cfg"),)
-    DEFAULT_GRUB_FILE: Path = (Path("/etc/default/grub"),)
+    FSTAB_FILE: Path = Path("/etc/fstab")
+    GRUB_DIR: Path = Path("/boot/grub")
+    GRUB_CFG_FILE: Path = Path("/boot/grub/grub.cfg")
+    CUSTOM_CFG_FILE: Path = Path("/boot/grub/custom.cfg")
+    DEFAULT_GRUB_FILE: Path = Path("/etc/default/grub")
 
 
 @dataclass(frozen=True)
@@ -56,18 +56,18 @@ class CBootControlConfig(_BaseConfig):
 
     BOOTLOADER: str = "cboot"
     CHIP_ID_MODEL_MAP: dict = field(default_factory=lambda: {0x19: "rqx_580"}.copy())
-    EXTLINUX_FILE: Path = ("/boot/extlinux/extlinux.conf",)
-    SLOT_IN_USE_FILE: Path = ("/boot/ota-status/slot_in_use",)
-    OTA_STATUS_DIR: Path = ("/boot/ota-status",)
-    KERNEL: Path = ("/boot/Image",)
-    KERNEL_SIG: Path = ("/boot/Image.sig",)
-    INITRD: Path = ("/boot/initrd",)
-    INITRD_IMG_LINK: Path = ("/boot/initrd.img",)
-    FDT: Path = ("/boot/tegra194-rqx-580.dtb",)
-    FDT_HDR40: Path = ("/boot/tegra194-rqx-580-hdr40.dtbo",)
-    SEPERATE_BOOT_MOUNT_POINT: Path = (Path("/mnt/standby_boot"),)
+    EXTLINUX_FILE: Path = "/boot/extlinux/extlinux.conf"
+    SLOT_IN_USE_FILE: Path = "/boot/ota-status/slot_in_use"
+    OTA_STATUS_DIR: Path = "/boot/ota-status"
+    KERNEL: Path = "/boot/Image"
+    KERNEL_SIG: Path = "/boot/Image.sig"
+    INITRD: Path = "/boot/initrd"
+    INITRD_IMG_LINK: Path = "/boot/initrd.img"
+    FDT: Path = "/boot/tegra194-rqx-580.dtb"
+    FDT_HDR40: Path = "/boot/tegra194-rqx-580-hdr40.dtbo"
+    SEPERATE_BOOT_MOUNT_POINT: Path = Path("/mnt/standby_boot")
     EXTRA_CMDLINE: str = (
-        "console=ttyTCU0,115200n8 console=tty0 fbcon=map:0 net.ifnames=0",
+        "console=ttyTCU0,115200n8 console=tty0 fbcon=map:0 net.ifnames=0"
     )
 
 
@@ -91,3 +91,4 @@ def create_config(bootloader):
 
 
 config = create_config(_detect_bootloader())
+# fmt: on

--- a/app/configs.py
+++ b/app/configs.py
@@ -1,10 +1,9 @@
 import platform
 from dataclasses import dataclass, field
-from pathlib import Path
 from logging import INFO
 
 # fmt: off
-@dataclass(frozen=True)
+@dataclass
 class _BaseConfig:
     DEFAULT_LOG_LEVEL: int = INFO
     LOG_LEVEL_TABLE: dict = field(
@@ -22,33 +21,34 @@ class _BaseConfig:
             "ota_status": INFO,
         }.copy()
     )
-    ECU_INFO_FILE: Path = Path("/boot/ota/ecu_info.yaml")
-    PASSWD_FILE: Path = Path("/etc/passwd")
-    GROUP_FILE: Path = Path("/etc/group")
-    BOOT_OTA_PARTITION_FILE: Path = Path("/boot/ota-partition")
+    BOOT_DIR: str = "/boot"
+    ECU_INFO_FILE: str = "/boot/ota/ecu_info.yaml"
+    PASSWD_FILE: str = "/etc/passwd"
+    GROUP_FILE: str = "/etc/group"
+    BOOT_OTA_PARTITION_FILE: str = str("ota-partition")
     OTA_STATUS_FNAME: str = "status"
     OTA_VERSION_FNAME: str = "version"
     LOG_FORMAT: str = (
         "[%(asctime)s][%(levelname)s]-%(filename)s:%(funcName)s:%(lineno)d,%(message)s"
     )
-    MOUNT_POINT: Path = Path("/mnt/standby")
+    MOUNT_POINT: str = "/mnt/standby"
 
 
-@dataclass(frozen=True)
+@dataclass
 class GrubControlConfig(_BaseConfig):
     """
     x86-64 platform, using grub
     """
 
     BOOTLOADER: str = "grub"
-    FSTAB_FILE: Path = Path("/etc/fstab")
-    GRUB_DIR: Path = Path("/boot/grub")
-    GRUB_CFG_FILE: Path = Path("/boot/grub/grub.cfg")
-    CUSTOM_CFG_FILE: Path = Path("/boot/grub/custom.cfg")
-    DEFAULT_GRUB_FILE: Path = Path("/etc/default/grub")
+    FSTAB_FILE: str = "/etc/fstab"
+    GRUB_DIR: str = "/boot/grub"
+    GRUB_CFG_FILE: str = "/boot/grub/grub.cfg"
+    CUSTOM_CFG_FILE: str = "/boot/grub/custom.cfg"
+    DEFAULT_GRUB_FILE: str = "/etc/default/grub"
 
 
-@dataclass(frozen=True)
+@dataclass
 class CBootControlConfig(_BaseConfig):
     """
     NOTE: only for tegraid:0x19, roscube-x platform(jetson-xavier-agx series)
@@ -56,16 +56,16 @@ class CBootControlConfig(_BaseConfig):
 
     BOOTLOADER: str = "cboot"
     CHIP_ID_MODEL_MAP: dict = field(default_factory=lambda: {0x19: "rqx_580"}.copy())
-    EXTLINUX_FILE: Path = "/boot/extlinux/extlinux.conf"
-    SLOT_IN_USE_FILE: Path = "/boot/ota-status/slot_in_use"
-    OTA_STATUS_DIR: Path = "/boot/ota-status"
-    KERNEL: Path = "/boot/Image"
-    KERNEL_SIG: Path = "/boot/Image.sig"
-    INITRD: Path = "/boot/initrd"
-    INITRD_IMG_LINK: Path = "/boot/initrd.img"
-    FDT: Path = "/boot/tegra194-rqx-580.dtb"
-    FDT_HDR40: Path = "/boot/tegra194-rqx-580-hdr40.dtbo"
-    SEPERATE_BOOT_MOUNT_POINT: Path = Path("/mnt/standby_boot")
+    EXTLINUX_FILE: str = "/boot/extlinux/extlinux.conf"
+    SLOT_IN_USE_FILE: str = "/boot/ota-status/slot_in_use"
+    OTA_STATUS_DIR: str = "/boot/ota-status"
+    KERNEL: str = "/boot/Image"
+    KERNEL_SIG: str = "/boot/Image.sig"
+    INITRD: str = "/boot/initrd"
+    INITRD_IMG_LINK: str = "/boot/initrd.img"
+    FDT: str = "/boot/tegra194-rqx-580.dtb"
+    FDT_HDR40: str = "/boot/tegra194-rqx-580-hdr40.dtbo"
+    SEPERATE_BOOT_MOUNT_POINT: str = "/mnt/standby_boot"
     EXTRA_CMDLINE: str = (
         "console=ttyTCU0,115200n8 console=tty0 fbcon=map:0 net.ifnames=0"
     )

--- a/app/configs.py
+++ b/app/configs.py
@@ -1,14 +1,14 @@
-import dataclasses
 import platform
+from dataclasses import dataclass, field
 from pathlib import Path
 from logging import INFO
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclass(frozen=True)
 class _BaseConfig:
     DEFAULT_LOG_LEVEL: int = (INFO,)
     LOG_LEVEL_TABLE: dict = (
-        dataclasses.field(
+        field(
             default_factory=lambda: {
                 "ecu_info": INFO,
                 "grub_control": INFO,
@@ -36,7 +36,7 @@ class _BaseConfig:
     MOUNT_POINT: Path = Path("/mnt/standby")
 
 
-@dataclasses.dataclass
+@dataclass(frozen=True)
 class GrubControlConfig(_BaseConfig):
     """
     x86-64 platform, using grub
@@ -50,14 +50,14 @@ class GrubControlConfig(_BaseConfig):
     DEFAULT_GRUB_FILE: Path = (Path("/etc/default/grub"),)
 
 
-@dataclasses.dataclass
+@dataclass(frozen=True)
 class CBootControlConfig(_BaseConfig):
     """
     NOTE: only for tegraid:0x19, roscube-x platform(jetson-xavier-agx series)
     """
 
     BOOTLOADER: str = "cboot"
-    CHIP_ID_MODEL_MAP: dict = dataclasses.field(
+    CHIP_ID_MODEL_MAP: dict = field(
         default_factory=lambda: {0x19: "rqx_580"}.copy()
     )
     EXTLINUX_FILE: Path = ("/boot/extlinux/extlinux.conf",)

--- a/app/configs.py
+++ b/app/configs.py
@@ -2,6 +2,7 @@ import platform
 from dataclasses import dataclass, field
 from logging import INFO
 
+
 # fmt: off
 @dataclass
 class _BaseConfig:
@@ -19,7 +20,7 @@ class _BaseConfig:
             "ota_client_stub": INFO,
             "ota_metadata": INFO,
             "ota_status": INFO,
-        }.copy()
+        }
     )
     BOOT_DIR: str = "/boot"
     ECU_INFO_FILE: str = "/boot/ota/ecu_info.yaml"
@@ -55,7 +56,7 @@ class CBootControlConfig(_BaseConfig):
     """
 
     BOOTLOADER: str = "cboot"
-    CHIP_ID_MODEL_MAP: dict = field(default_factory=lambda: {0x19: "rqx_580"}.copy())
+    CHIP_ID_MODEL_MAP: dict = field(default_factory=lambda: {0x19: "rqx_580"})
     EXTLINUX_FILE: str = "/boot/extlinux/extlinux.conf"
     SLOT_IN_USE_FILE: str = "/boot/ota-status/slot_in_use"
     OTA_STATUS_DIR: str = "/boot/ota-status"

--- a/app/configs.py
+++ b/app/configs.py
@@ -25,7 +25,7 @@ class _BaseConfig:
     ECU_INFO_FILE: str = "/boot/ota/ecu_info.yaml"
     PASSWD_FILE: str = "/etc/passwd"
     GROUP_FILE: str = "/etc/group"
-    BOOT_OTA_PARTITION_FILE: str = str("ota-partition")
+    BOOT_OTA_PARTITION_FILE: str = "ota-partition"
     OTA_STATUS_FNAME: str = "status"
     OTA_VERSION_FNAME: str = "version"
     LOG_FORMAT: str = (
@@ -65,7 +65,7 @@ class CBootControlConfig(_BaseConfig):
     INITRD_IMG_LINK: str = "/boot/initrd.img"
     FDT: str = "/boot/tegra194-rqx-580.dtb"
     FDT_HDR40: str = "/boot/tegra194-rqx-580-hdr40.dtbo"
-    SEPERATE_BOOT_MOUNT_POINT: str = "/mnt/standby_boot"
+    SEPARATE_BOOT_MOUNT_POINT: str = "/mnt/standby_boot"
     EXTRA_CMDLINE: str = (
         "console=ttyTCU0,115200n8 console=tty0 fbcon=map:0 net.ifnames=0"
     )

--- a/app/configs.py
+++ b/app/configs.py
@@ -97,17 +97,19 @@ class CBootControlConfig(_BaseConfig):
     def __init__(self):
         super().__init__()
 
-        self.extlinux_file = self.BOOT_DIR / "extlinux/extlinux.conf"
-
         self._properties_map.update(
             {
-                "EXTLINUX_FILE": self.extlinux_file,
+                "EXTLINUX_FILE": self.BOOT_DIR / "extlinux/extlinux.conf",
                 "SLOT_IN_USE_FILE": self.BOOT_DIR / "ota-status/slot_in_use",
                 "OTA_STATUS_DIR": self.BOOT_DIR / "ota-status",
-                "LINUX": self.BOOT_DIR / "Image",
+                "KERNEL": self.BOOT_DIR / "Image",
+                "KERNEL_SIG": self.BOOT_DIR / "Image.sig",
                 "INITRD": self.BOOT_DIR / "initrd",
+                "INITRD_IMG_LINK": self.BOOT_DIR / "initrd.img",
                 "FDT": self.BOOT_DIR / "tegra194-rqx-580.dtb",
+                "FDT_HDR40": self.BOOT_DIR / "tegra194-rqx-580-hdr40.dtbo",
                 "EXTRA_CMDLINE": "console=ttyTCU0,115200n8 console=tty0 fbcon=map:0 net.ifnames=0",
+                "SEPERATE_BOOT_MOUNT_POINT": Path("/mnt/standby_boot")
             }
         )
 

--- a/app/extlinux_control.py
+++ b/app/extlinux_control.py
@@ -5,7 +5,6 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Tuple
 
 import log_util
 from configs import config as cfg
@@ -13,7 +12,7 @@ from ota_error import OtaErrorUnrecoverable
 from ota_status import OtaStatus
 from ota_client_interface import BootControlInterface
 
-assert cfg.PLATFORM == "cboot"
+assert cfg.BOOTLOADER == "cboot"
 
 logger = log_util.get_logger(
     __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)

--- a/app/extlinux_control.py
+++ b/app/extlinux_control.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import log_util
 from configs import config as cfg
-from ota_error import OtaErrorUnrecoverable
+from ota_error import OtaErrorRecoverable, OtaErrorUnrecoverable
 from ota_status import OtaStatus
 from ota_client_interface import BootControlInterface
 
@@ -152,7 +152,7 @@ class Nvbootctrl:
     # p1->slot0, p2->slot1
     PARTID_SLOTID_MAP = {"1": "0", "2": "1"}
     # slot0->p1, slot1->p2
-    SLOTID_PARTID_MAP = {"0": "1", "1": "2"}
+    SLOTID_PARTID_MAP = {v: k for k, v in PARTID_SLOTID_MAP.items()}
 
     # nvbootctrl
     @staticmethod
@@ -615,71 +615,34 @@ class CBootControlMixin(BootControlInterface):
         )
         return _nvboot_res and _ota_status_res and _is_slot_in_use
 
-    def _populate_extlinux_cfg_to_separate_bootdev(self):
-        if not self._boot_control.is_external_rootfs_enabled():
-            return
-
-        src: Path = self._mount_point / Path(cfg.EXTLINUX_FILE).relative_to("/")
-        target_dir: Path = (
-            self._standby_boot_mount_point
-            / Path(cfg.EXTLINUX_FILE).relative_to("/").parent
-        )
-
-        # ensure target dir's present
-        target_dir.mkdir(parents=True, exist_ok=True)
-
-        if src.is_file():
-            shutil.copy(str(src), target_dir)
-        else:
-            raise OtaErrorUnrecoverable(
-                "extlinux.cfg on boot partition and/or standby slot not found"
-            )
-
     def _populate_boot_folder_to_separate_bootdev(self):
         if not self._boot_control.is_external_rootfs_enabled():
             return
 
-        # copy the /boot folder from standby slot to boot dev unconditionally
-        tmp_dir = self._standby_boot_mount_point / ".tmp_boot"
+        src_dir = self._mount_point / "boot"
         dst_dir = self._standby_boot_mount_point / "boot"
-        dst_dir.mkdir(parents=True, exist_ok=True)  # ensure dst
-        # prepare temporary files
-        if tmp_dir.is_dir():  # cleanup previous temp
-            shutil.rmtree(str(tmp_dir), ignore_errors=True)
 
-        shutil.copytree(
-            str(self._mount_point / "boot"), tmp_dir, symlinks=True, dirs_exist_ok=True
-        )
+        # first list unneeded files in the dst_dir
+        src_dir_files_set = {str(f.relative_to(src_dir)) for f in src_dir.glob("**/*")}
+        dst_dir_files_set = {str(f.relative_to(dst_dir)) for f in dst_dir.glob("**/*")}
+        unneeded_files_set = dst_dir_files_set - src_dir_files_set
 
-        src_files = tmp_dir.glob("**/*")
-        dst_files = {str(f.relative_to(dst_dir)) for f in dst_dir.glob("**/*")}
+        # copy the /boot folder from standby slot to boot dev unconditionally
+        _cmd = f"cp -rdp {src_dir} {dst_dir}"
+        try:
+            _subprocess_call(_cmd, raise_exception=True)
+        except Exception as e:
+            raise OtaErrorRecoverable(
+                f"failed to update /boot on standby bootdev: {e!r}"
+            )
 
-        # move files from tmp to dst
-        # Path.replace is atomic operation on Unix platform, within the same partition
-        for f in src_files:
-            f_relative = f.relative_to(tmp_dir)
-
-            dst = dst_dir / f_relative
-            if f.is_dir():
-                dst.mkdir(parents=True, exist_ok=True)
-            else:
-                f.parent.mkdir(parents=True, exist_ok=True)
-                f.rename(dst)
-
-            fn = str(f_relative)
-            if fn in dst_files:
-                dst_files.remove(fn)
-
-        # cleanup old files in the dst
-        for f in dst_files:
+        # cleanup unused files in the dst_dir
+        for f in unneeded_files_set:
             f = dst_dir / f
             if f.is_dir():
                 shutil.rmtree(str(f), ignore_errors=True)
             else:
                 f.unlink(missing_ok=True)
-
-        # cleanup temporary
-        shutil.rmtree(tmp_dir)
 
     def init_slot_in_use_file(self):
         """
@@ -787,7 +750,6 @@ class CBootControlMixin(BootControlInterface):
                 "rootfs on external storage: updating the /boot folder in standby bootdev..."
             )
             self._populate_boot_folder_to_separate_bootdev()
-            self._populate_extlinux_cfg_to_separate_bootdev()
 
         logger.debug("switching boot...")
         self._boot_control.switch_boot_standby()

--- a/app/grub_control.py
+++ b/app/grub_control.py
@@ -11,7 +11,7 @@ import log_util
 from configs import config as cfg
 from ota_error import OtaErrorUnrecoverable
 
-assert cfg.PLATFORM == "grub"
+assert cfg.BOOTLOADER == "grub"
 
 logger = log_util.get_logger(
     __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)

--- a/app/grub_control.py
+++ b/app/grub_control.py
@@ -81,10 +81,10 @@ class GrubControl:
     DEFAULT_GRUB_FILE = cfg.DEFAULT_GRUB_FILE  # Path("/etc/default/grub")
 
     def __init__(self):
-        self._grub_cfg_file = GrubControl.GRUB_CFG_FILE
-        self._custom_cfg_file = GrubControl.CUSTOM_CFG_FILE
-        self._fstab_file = GrubControl.FSTAB_FILE
-        self._default_grub_file = GrubControl.DEFAULT_GRUB_FILE
+        self._grub_cfg_file = Path(GrubControl.GRUB_CFG_FILE)
+        self._custom_cfg_file = Path(GrubControl.CUSTOM_CFG_FILE)
+        self._fstab_file = Path(GrubControl.FSTAB_FILE)
+        self._default_grub_file = Path(GrubControl.DEFAULT_GRUB_FILE)
 
     def create_custom_cfg_and_reboot(
         self, standby_device, vmlinuz_file, initrd_img_file

--- a/app/grub_ota_partition.py
+++ b/app/grub_ota_partition.py
@@ -33,8 +33,8 @@ class OtaPartition:
     def __init__(self):
         self._active_root_device_cache = None
         self._standby_root_device_cache = None
-        self._boot_dir = OtaPartition.BOOT_DIR
-        self._boot_ota_partition_file = OtaPartition.BOOT_OTA_PARTITION_FILE
+        self._boot_dir = Path(OtaPartition.BOOT_DIR)
+        self._boot_ota_partition_file = Path(OtaPartition.BOOT_OTA_PARTITION_FILE)
 
     def get_active_boot_device(self):
         """

--- a/app/grub_ota_partition.py
+++ b/app/grub_ota_partition.py
@@ -13,7 +13,7 @@ from grub_control import GrubControl
 from ota_error import OtaErrorUnrecoverable
 import log_util
 
-assert cfg.PLATFORM == "grub"
+assert cfg.BOOTLOADER == "grub"
 
 logger = log_util.get_logger(
     __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -800,7 +800,7 @@ def gen_ota_client_class(platform: str):
 
                 # standby slot
                 self._standby_ota_status_dir: Path = (
-                    self._mount_point / self._ota_status_dir.relative_to(Path("/"))
+                    self._mount_point / self._ota_status_dir.relative_to("/")
                 )
                 self._standby_ota_status_file = (
                     self._standby_ota_status_dir / cfg.OTA_STATUS_FNAME
@@ -808,12 +808,12 @@ def gen_ota_client_class(platform: str):
                 self._standby_ota_version_file = (
                     self._standby_ota_status_dir / cfg.OTA_VERSION_FNAME
                 )
-                self._standby_extlinux_cfg = (
-                    self._mount_point / cfg.EXTLINUX_FILE.relative_to("/")
-                )
                 self._standby_slot_in_use_file = (
-                    self._mount_point / self._slot_in_use_file.relative_to(Path("/"))
+                    self._mount_point / self._slot_in_use_file.relative_to("/")
                 )
+
+                # standby bootdev
+                self._standby_boot_mount_point = cfg.SEPERATE_BOOT_MOUNT_POINT
 
                 self._boot_control: CBootControl = CBootControl()
                 self._ota_status: OtaStatus = self.initialize_ota_status()

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -274,9 +274,9 @@ class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
         self._failure_reason = ""
         self._update_phase = OtaClientUpdatePhase.INITIAL
 
-        self._mount_point = cfg.MOUNT_POINT
-        self._passwd_file = cfg.PASSWD_FILE
-        self._group_file = cfg.GROUP_FILE
+        self._mount_point = Path(cfg.MOUNT_POINT)
+        self._passwd_file = Path(cfg.PASSWD_FILE)
+        self._group_file = Path(cfg.GROUP_FILE)
 
         # statistics
         self._statistics = OtaClientStatistics()
@@ -766,8 +766,8 @@ class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
         self.boot_ctrl_post_rollback()
 
 
-def gen_ota_client_class(platform: str):
-    if platform == "grub":
+def gen_ota_client_class(bootloader: str):
+    if bootloader == "grub":
 
         from grub_ota_partition import GrubControlMixin, OtaPartitionFile
 
@@ -780,7 +780,7 @@ def gen_ota_client_class(platform: str):
 
                 logger.debug(f"ota status: {self._ota_status.name}")
 
-    elif platform == "cboot":
+    elif bootloader == "cboot":
 
         from extlinux_control import CBootControl, CBootControlMixin
 
@@ -789,14 +789,14 @@ def gen_ota_client_class(platform: str):
                 super().__init__()
 
                 # current slot
-                self._ota_status_dir: Path = cfg.OTA_STATUS_DIR
+                self._ota_status_dir: Path = Path(cfg.OTA_STATUS_DIR)
                 self._ota_status_file: Path = (
                     self._ota_status_dir / cfg.OTA_STATUS_FNAME
                 )
                 self._ota_version_file: Path = (
                     self._ota_status_dir / cfg.OTA_VERSION_FNAME
                 )
-                self._slot_in_use_file: Path = cfg.SLOT_IN_USE_FILE
+                self._slot_in_use_file: Path = Path(cfg.SLOT_IN_USE_FILE)
 
                 # standby slot
                 self._standby_ota_status_dir: Path = (
@@ -813,7 +813,7 @@ def gen_ota_client_class(platform: str):
                 )
 
                 # standby bootdev
-                self._standby_boot_mount_point = cfg.SEPERATE_BOOT_MOUNT_POINT
+                self._standby_boot_mount_point = Path(cfg.SEPERATE_BOOT_MOUNT_POINT)
 
                 self._boot_control: CBootControl = CBootControl()
                 self._ota_status: OtaStatus = self.initialize_ota_status()
@@ -825,10 +825,10 @@ def gen_ota_client_class(platform: str):
 
 
 def _ota_client_class():
-    platform = cfg.PLATFORM
-    logger.debug(f"ota_client is running with {platform}")
+    bootloader = cfg.BOOTLOADER
+    logger.debug(f"ota_client is running with {bootloader=}")
 
-    return gen_ota_client_class(platform)
+    return gen_ota_client_class(bootloader)
 
 
 OtaClient = _ota_client_class()

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -813,7 +813,7 @@ def gen_ota_client_class(bootloader: str):
                 )
 
                 # standby bootdev
-                self._standby_boot_mount_point = Path(cfg.SEPERATE_BOOT_MOUNT_POINT)
+                self._standby_boot_mount_point = Path(cfg.SEPARATE_BOOT_MOUNT_POINT)
 
                 self._boot_control: CBootControl = CBootControl()
                 self._ota_status: OtaStatus = self.initialize_ota_status()


### PR DESCRIPTION
# Introduction
Supporting nvme boot with ota-client, along with improvement over extlinux_control module and configs module
1. ota-client now supports 2 kinds of boot-from-nvme-storage mechanism:
    1.1: rootfs on nvme storage(tested, working as expected)
    1.2: native boot from nvme storage(not tested, but extlinux_control module should support it)
2. ota-client can automatically detect the present of rootfs on external storage, and also backward support boot with internal storage if the ROSCUBE-X runs on internal storage
3. refactor to the configs module, use built-in dataclasses to compose Config class
4. other minor changes and cleanup

# Details
The ota-client support 2 kinds of boot-from-nvme-storage mechanism as follow: 
1. When detects the present of external nvme storage, ota-client will first update the partition on nvme storage, and ensure the extlinux.cfg and kernel/initrd files in nvme partition's /boot folder, ensuring the mechanism 1.2.
2. And then the ota-client will also sync the /boot folder to the corresponding emmc partition, which ensuring the mechanism 1.1.