### PR TITLE
add condition where filesize is None

### DIFF
--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -43,7 +43,7 @@ def file_sha256(filename: Path) -> str:
 
 
 def verify_file(filename: Path, filehash: str, filesize) -> bool:
-    if filename.stat().st_size != filesize:
+    if filesize and filename.stat().st_size != filesize:
         return False
     return file_sha256(filename) == filehash
 


### PR DESCRIPTION
# What is this PR?
This PR fixes the issue that ota-client downloads all files from the server w/o copying from active bank if file size attribute is not set.