### PR TITLE
use py38

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -28,8 +28,6 @@ def main():
         version = open(version_file).read()
         logger.info(version)
 
-
-if __name__ == "__main__":
     if cfg is None:
         sys.exit("unsupported platform, abort")
 

--- a/systemd/otaclient.service
+++ b/systemd/otaclient.service
@@ -7,7 +7,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 /opt/ota/client/app/main.py
+ExecStart=/usr/bin/python3.8 /opt/ota/client/app/main.py
 Restart=always
 
 [Install]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,17 +3,17 @@ import pytest
 
 @pytest.fixture
 def patch(mocker):
+    import random
     from ota_client import OtaClient
-    from ecu_info import EcuInfo
     from ota_client_call import OtaClientCall
     from ota_client_service import OtaClientServiceV2
 
     mocker.patch.object(OtaClient, "__init__", return_value=None)
-    mocker.patch.object(EcuInfo, "__init__", return_value=None)
     mocker.patch.object(OtaClientCall, "__init__", return_value=None)
     mocker.patch.object(OtaClientServiceV2, "__init__", return_value=None)
     mocker.patch("main.service_start", return_value=None)
     mocker.patch("main.service_wait_for_termination", return_value=None)
+    mocker.patch("main.os.getpid", lambda: random.getrandbits(64))
 
 
 def test_main(patch, mocker):
@@ -30,7 +30,7 @@ def test_main_with_version(patch, mocker, tmp_path, caplog):
     mocker.patch("main.VERSION_FILE", version)
 
     main()
-    assert len(caplog.records) == 2
+    assert caplog.records[0].msg == "started"
     assert (
         caplog.records[1].msg == "d3b6bdb | 2021-10-27 09:36:48 +0900 | Initial commit"
     )


### PR DESCRIPTION
# What is this PR?
This PR specifies python3.8 specific version to support roscube-x. Default python3 for roscube-x is python3.6.

# issue
https://tier4.atlassian.net/browse/T4PB-14182