### PR TITLE
add support sub-ecu logger

### DIFF
--- a/app/aws_gglog/boto3_session.py
+++ b/app/aws_gglog/boto3_session.py
@@ -4,8 +4,6 @@ import botocore.credentials
 import botocore.session
 import boto3
 import logging
-import os
-import sys
 import datetime
 from pytz import utc
 

--- a/app/aws_gglog/boto3_session.py
+++ b/app/aws_gglog/boto3_session.py
@@ -9,9 +9,6 @@ import sys
 import datetime
 from pytz import utc
 
-sys.path.append(os.path.dirname(__file__))
-from greengrass_config import GreengrassConfig
-
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 _sh = logging.StreamHandler()
@@ -21,15 +18,11 @@ logger.addHandler(_sh)
 class Boto3Session:
     def __init__(
         self,
-        greengrass_config: str,
+        config: dict,
         credential_provider_endpoint: str,
         role_alias: str,
-        config: dict,
     ):
-        if greengrass_config:
-            cfg = GreengrassConfig.parse_config(greengrass_config)
-        else:
-            cfg = config
+        cfg = config
 
         self._ca_cert = cfg.get("ca_cert")
         self._cert = cfg.get("cert")

--- a/app/aws_gglog/greengrass_config.py
+++ b/app/aws_gglog/greengrass_config.py
@@ -1,0 +1,56 @@
+import logging
+import json
+import re
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+_sh = logging.StreamHandler()
+logger.addHandler(_sh)
+
+
+class GreengrassConfig:
+    @staticmethod
+    def parse_config(config) -> dict:
+        try:
+            with open(config) as f:
+                cfg = json.load(f)
+        except FileNotFoundError:
+            logger.exception(f"config file is not found: file={config}")
+            raise
+        except json.JSONDecodeError as e:
+            logger.exception(f"invalid json format: {e}")
+            raise
+
+        ca_path = cfg.get("crypto", {}).get("caPath")
+        private_key_path = (
+            cfg.get("crypto", {})
+            .get("principals", {})
+            .get("IoTCertificate", {})
+            .get("privateKeyPath")
+        )
+        certificate_path = (
+            cfg.get("crypto", {})
+            .get("principals", {})
+            .get("IoTCertificate", {})
+            .get("certificatePath")
+        )
+        thing_arn = cfg.get("coreThing", {}).get("thingArn")
+
+        strs = thing_arn.split(":", 6)
+        if len(strs) != 6:
+            logger.error(f"invalid thing arn: thing_arn={thing_arn}")
+            raise Exception(f"invalid thing arn: thing_arn={thing_arn}")
+
+        region = strs[3]
+        thing_name = strs[5]
+
+        def remove_prefix(s, prefix):
+            return re.sub(f"^{prefix}", "", s)
+
+        return {
+            "ca_cert": remove_prefix(ca_path, "file://"),
+            "private_key": remove_prefix(private_key_path, "file://"),
+            "cert": remove_prefix(certificate_path, "file://"),
+            "region": region,
+            "thing_name": remove_prefix(thing_name, "thing/"),
+        }

--- a/app/aws_gglog/logger.py
+++ b/app/aws_gglog/logger.py
@@ -2,6 +2,9 @@ import os
 import watchtower
 import logging
 import sys
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+from retrying import retry
 
 sys.path.append(os.path.dirname(__file__))
 from boto3_session import Boto3Session
@@ -37,21 +40,22 @@ class _BaseLogger:
         self._logger = logging.getLogger(name)
         # not pass log records to root logger
         self._logger.propagate = False
+        self._executor = ThreadPoolExecutor()
 
     def set_handlers(self, level, format: str, boto3_session_duration: int = 0):
         if self._logger.hasHandlers():
             # if handlers are already set, skip to set handlers
             return
 
-        formatter = logging.Formatter(
-            fmt=format,
-        )
+        formatter = logging.Formatter(fmt=format)
 
         # set stream handler
         self._set_stream_log_handler(formatter)
 
         # set cloudwatch log handler
-        self._set_cloudwatch_log_handler(formatter, boto3_session_duration)
+        self._set_cloudwatch_log_handler_with_executor(
+            formatter, boto3_session_duration
+        )
 
         self._logger.setLevel(level)
         self._logger.info("handlers are set to base logger")
@@ -61,50 +65,86 @@ class _BaseLogger:
         handler.setFormatter(formatter)
         self._logger.addHandler(handler)
 
+    @retry(wait_exponential_multiplier=1_000, wait_exponential_max=4_000)
     def _set_cloudwatch_log_handler(
-        self, formatter: logging.Formatter, boto3_session_duration: int
+        self,
+        formatter: logging.Formatter,
+        boto3_session_duration: int,
+        event: Event,
     ):
         try:
-            config = _BaseLogger._get_config()
+            config = _BaseLogger._get_config_from_environment()
             session = Boto3Session(
-                greengrass_config=config["AWS_GREENGRASS_CONFIG"],
+                greengrass_config=config.get("AWS_GREENGRASS_CONFIG"),
                 credential_provider_endpoint=config["AWS_CREDENTIAL_PROVIDER_ENDPOINT"],
                 role_alias=config["AWS_ROLE_ALIAS"],
+                config={
+                    "ca_cert": config.get("AWS_CA_CERT_FILE"),
+                    "private_key": config.get("AWS_PRIVATE_KEY_FILE"),
+                    "cert": config.get("AWS_CERT_FILE"),
+                    "region": config.get("AWS_REGION"),
+                    "thing_name": config.get("AWS_THING_NAME"),
+                },
             )
             boto3_session = session.get_session(session_duration=boto3_session_duration)
-            stream_name = self._get_stream_name(config["AWS_GREENGRASS_CONFIG"])
+            stream_name = self._get_stream_name(session._thing_name)
             handler = watchtower.CloudWatchLogHandler(
                 boto3_session=boto3_session,
                 log_group=config["AWS_CLOUDWATCH_LOG_GROUP"],
                 stream_name=stream_name,
                 create_log_group=True,
                 create_log_stream=True,
+                send_interval=4,
             )
             handler.setFormatter(formatter)
             self._logger.addHandler(handler)
-        except Exception as e:
-            self._logger.warning(f"failed to setup cloudwatch log handler: {e}")
+        except Exception:
+            self.logger.exception("failed to setup cloudwatch log handler")
+            self._logger.warning("failed to setup cloudwatch log handler")
+            raise
+        finally:
+            event.set()
+
+    def _set_cloudwatch_log_handler_with_executor(
+        self, formatter: logging.Formatter, boto3_session_duration: int
+    ):
+        event = Event()
+        self._executor.submit(
+            self._set_cloudwatch_log_handler, formatter, boto3_session_duration, event
+        )
+        event.wait()  # this makes sure _set_cloudwatch_log_handler has been started.
 
     @staticmethod
-    def _get_config() -> dict:
-        keys = (
-            "AWS_GREENGRASS_CONFIG",
+    def _get_config_from_environment() -> dict:
+        config = {}
+
+        keys_req = (
             "AWS_CREDENTIAL_PROVIDER_ENDPOINT",
             "AWS_ROLE_ALIAS",
             "AWS_CLOUDWATCH_LOG_GROUP",
         )
-        config = {}
-        for key in keys:
+        for key in keys_req:
             config[key] = os.environ.get(key)
             if not config[key]:
                 raise Exception(f"environment variable {key} is not set")
 
+        keys_opt = (
+            "AWS_GREENGRASS_CONFIG",
+            "AWS_CA_CERT_FILE",
+            "AWS_PRIVATE_KEY_FILE",
+            "AWS_CERT_FILE",
+            "AWS_REGION",
+            "AWS_THING_NAME",
+        )
+        for key in keys_opt:
+            value = os.environ.get(key)
+            if value:
+                config[key] = value
+
         return config
 
     @staticmethod
-    def _get_stream_name(boto3_config: str):
-        config = Boto3Session.parse_config(boto3_config)
-        thing_name = config.get("thing_name", "unknown")
+    def _get_stream_name(thing_name: str):
         fmt = "{strftime:%Y/%m/%d}"
         return f"{fmt}/{thing_name}"
 
@@ -133,20 +173,14 @@ if __name__ == "__main__":
     examples
     """
 
-    log1 = Logger(
-        "foo",
-        level=logging.INFO,
-        format="### %(asctime)s %(levelname)s]-%(filename)s:%(lineno)d,%(message)s",
-    ).get_logger()
+    format = "### %(asctime)s [%(levelname)s]-%(filename)s:%(lineno)d,%(message)s"
+    log1 = Logger("foo", level=logging.INFO, format=format).get_logger()
     log1.debug("hello,world")
     log1.info("hello,world")
     log1.warning("hello,world")
     log1.error("hello,world")
 
-    log2 = Logger(
-        "bar",
-        level=logging.DEBUG,
-    ).get_logger()
+    log2 = Logger("bar", level=logging.DEBUG).get_logger()
     log2.debug("hello,world")
     log2.info("hello,world")
     log2.warning("hello,world")

--- a/tests/aws_gglog/test_boto3_session.py
+++ b/tests/aws_gglog/test_boto3_session.py
@@ -5,17 +5,20 @@ class TestBoto3Session:
     def test__refresh_credentials(self, mocker, shared_datadir):
         import requests
         from aws_gglog.boto3_session import Boto3Session
+        from aws_gglog.greengrass_config import GreengrassConfig
 
         resp_mock = mocker.MagicMock()
         resp_mock.text = '{"credentials":{"accessKeyId":"123","secretAccessKey":"abc","sessionToken":"ABC","expiration":"2021-10-01T09:18:06Z"}}'
         requests.get = mocker.MagicMock(return_value=resp_mock)
         requests.raise_for_status = mocker.MagicMock()
 
+        session_config = GreengrassConfig.parse_config(
+            os.path.join(os.path.join(shared_datadir, "greengrass/config.json"))
+        )
         session = Boto3Session(
-            os.path.join(os.path.join(shared_datadir, "greengrass/config.json")),
+            session_config,
             "https://example.com",
             "example_role_alias",
-            {},
         )
         got_credential = session._refresh()
         want_credential = {

--- a/tests/aws_gglog/test_boto3_session.py
+++ b/tests/aws_gglog/test_boto3_session.py
@@ -1,38 +1,7 @@
 import os
-import pytest
 
 
 class TestBoto3Session:
-    def test_parse_config(self, shared_datadir):
-        from aws_gglog.boto3_session import Boto3Session
-
-        config = Boto3Session.parse_config(
-            os.path.join(shared_datadir, "greengrass/config.json")
-        )
-        assert config.get("ca_cert") == "/greengrass/certs/root.ca.pem"
-        assert config.get("private_key") == "/greengrass/certs/gg.private.key"
-        assert config.get("cert") == "/greengrass/certs/gg.cert.pem"
-        assert config.get("region") == "ap-northeast-1"
-        assert config.get("thing_name") == "foo-bar"
-
-    def test_parse_config_no_file(self):
-        from aws_gglog.boto3_session import Boto3Session
-
-        with pytest.raises(Exception) as e:
-            Boto3Session.parse_config("no_file")
-
-        assert str(e.value) == "[Errno 2] No such file or directory: 'no_file'"
-
-    def test_parse_config_invalid_thing_arn(self, shared_datadir):
-        from aws_gglog.boto3_session import Boto3Session
-
-        with pytest.raises(Exception) as e:
-            Boto3Session.parse_config(
-                os.path.join(shared_datadir, "greengrass/config_invalid_thingArn.json")
-            )
-
-        assert str(e.value) == "invalid thing arn: thing_arn=thing/foo-bar"
-
     def test__refresh_credentials(self, mocker, shared_datadir):
         import requests
         from aws_gglog.boto3_session import Boto3Session
@@ -46,6 +15,7 @@ class TestBoto3Session:
             os.path.join(os.path.join(shared_datadir, "greengrass/config.json")),
             "https://example.com",
             "example_role_alias",
+            {},
         )
         got_credential = session._refresh()
         want_credential = {

--- a/tests/aws_gglog/test_greengrass_config.py
+++ b/tests/aws_gglog/test_greengrass_config.py
@@ -1,0 +1,34 @@
+import os
+import pytest
+
+
+class TestGreengarssConfig:
+    def test_parse_config(self, shared_datadir):
+        from aws_gglog.greengrass_config import GreengrassConfig
+
+        config = GreengrassConfig.parse_config(
+            os.path.join(shared_datadir, "greengrass/config.json")
+        )
+        assert config.get("ca_cert") == "/greengrass/certs/root.ca.pem"
+        assert config.get("private_key") == "/greengrass/certs/gg.private.key"
+        assert config.get("cert") == "/greengrass/certs/gg.cert.pem"
+        assert config.get("region") == "ap-northeast-1"
+        assert config.get("thing_name") == "foo-bar"
+
+    def test_parse_config_no_file(self):
+        from aws_gglog.greengrass_config import GreengrassConfig
+
+        with pytest.raises(Exception) as e:
+            GreengrassConfig.parse_config("no_file")
+
+        assert str(e.value) == "[Errno 2] No such file or directory: 'no_file'"
+
+    def test_parse_config_invalid_thing_arn(self, shared_datadir):
+        from aws_gglog.greengrass_config import GreengrassConfig
+
+        with pytest.raises(Exception) as e:
+            GreengrassConfig.parse_config(
+                os.path.join(shared_datadir, "greengrass/config_invalid_thingArn.json")
+            )
+
+        assert str(e.value) == "invalid thing arn: thing_arn=thing/foo-bar"

--- a/tests/aws_gglog/test_logger.py
+++ b/tests/aws_gglog/test_logger.py
@@ -7,25 +7,55 @@ class Test_BaseLogger:
     def test__gen_log_stream_name(self, shared_datadir):
         from aws_gglog.logger import _BaseLogger
 
-        name = _BaseLogger._get_stream_name(
-            os.path.join(os.path.join(shared_datadir, "greengrass/config.json"))
-        )
+        name = _BaseLogger._get_stream_name("foo-bar")
         assert name == "{strftime:%Y/%m/%d}/foo-bar"
 
-    def test__get_config(self):
+    @pytest.mark.parametrize(
+        "keys, do_raise",
+        [
+            (
+                (
+                    "AWS_CREDENTIAL_PROVIDER_ENDPOINT",
+                    "AWS_ROLE_ALIAS",
+                    "AWS_CLOUDWATCH_LOG_GROUP",
+                ),
+                False,
+            ),
+            (
+                (
+                    "AWS_CREDENTIAL_PROVIDER_ENDPOINT",
+                    "AWS_ROLE_ALIAS",
+                    "AWS_CLOUDWATCH_LOG_GROUP",
+                    "AWS_GREENGRASS_CONFIG",
+                    "AWS_CA_CERT_FILE",
+                    "AWS_PRIVATE_KEY_FILE",
+                    "AWS_CERT_FILE",
+                    "AWS_REGION",
+                    "AWS_THING_NAME",
+                ),
+                False,
+            ),
+            (
+                (
+                    "AWS_ROLE_ALIAS",
+                    "AWS_CLOUDWATCH_LOG_GROUP",
+                ),
+                True,
+            ),
+        ],
+    )
+    def test__get_config_from_environment(self, mocker, keys, do_raise):
         from aws_gglog.logger import _BaseLogger
 
-        keys = (
-            "AWS_GREENGRASS_CONFIG",
-            "AWS_CREDENTIAL_PROVIDER_ENDPOINT",
-            "AWS_ROLE_ALIAS",
-            "AWS_CLOUDWATCH_LOG_GROUP",
-        )
         for key in keys:
-            os.environ[key] = f"{key.lower()}"
+            mocker.patch.dict(os.environ, {key: f"{key.lower()}"})
 
-        config = _BaseLogger._get_config()
-        assert config == {key: key.lower() for key in keys}
+        if do_raise:
+            with pytest.raises(Exception):
+                _BaseLogger._get_config_from_environment()
+        else:
+            config = _BaseLogger._get_config_from_environment()
+            assert config == {key: key.lower() for key in keys}
 
     def test_get_instance(self):
         from aws_gglog.logger import _BaseLogger
@@ -49,7 +79,7 @@ class Test_BaseLogger:
 
         mocker.patch("boto3_session.Boto3Session.get_session", return_value="session")
         mocker.patch(
-            "boto3_session.Boto3Session.parse_config",
+            "boto3_session.GreengrassConfig.parse_config",
             return_value={
                 "ca_cert": "/foo/bar/ca_cert.pem",
                 "private_key": "/foo/bar/private_key.pem",
@@ -60,10 +90,10 @@ class Test_BaseLogger:
         )
         watchtower.CloudWatchLogHandler = mocker.MagicMock()
 
-        os.environ["AWS_GREENGRASS_CONFIG"] = "/foo/bar/config.json"
-        os.environ["AWS_CREDENTIAL_PROVIDER_ENDPOINT"] = "foo.bar"
-        os.environ["AWS_ROLE_ALIAS"] = "foo-bar"
-        os.environ["AWS_CLOUDWATCH_LOG_GROUP"] = "foo/bar"
+        mocker.patch.dict(os.environ, {"AWS_GREENGRASS_CONFIG": "/foo/bar/config.json"})
+        mocker.patch.dict(os.environ, {"AWS_CREDENTIAL_PROVIDER_ENDPOINT": "foo.bar"})
+        mocker.patch.dict(os.environ, {"AWS_ROLE_ALIAS": "foo-bar"})
+        mocker.patch.dict(os.environ, {"AWS_CLOUDWATCH_LOG_GROUP": "foo/bar"})
 
         _BaseLogger._instance = None
         base_logger = _BaseLogger()
@@ -78,6 +108,7 @@ class Test_BaseLogger:
             stream_name="{strftime:%Y/%m/%d}/foo-bar",
             create_log_group=True,
             create_log_stream=True,
+            send_interval=4,
         )
 
     def test_create_instance_without_cloudwatch_handler(self, mocker):

--- a/tests/aws_gglog/test_logger.py
+++ b/tests/aws_gglog/test_logger.py
@@ -79,7 +79,7 @@ class Test_BaseLogger:
 
         mocker.patch("boto3_session.Boto3Session.get_session", return_value="session")
         mocker.patch(
-            "boto3_session.GreengrassConfig.parse_config",
+            "greengrass_config.GreengrassConfig.parse_config",
             return_value={
                 "ca_cert": "/foo/bar/ca_cert.pem",
                 "private_key": "/foo/bar/private_key.pem",


### PR DESCRIPTION
# What is this PR
This PR fixes two things:
1. `_set_cloudwatch_log_handler` is done in the thread and wait until getting a session in case of HTTP proxy is used and HTTP proxy server is not launched.
2. modify parameter to pass the certification config w/o greengrass config to support a non-greengrass environment.

# issue
https://tier4.atlassian.net/browse/T4PUB-705