### PR TITLE
Implement ota_http_proxy server

### DIFF
--- a/ota_proxy/__init__.py
+++ b/ota_proxy/__init__.py
@@ -1,0 +1,3 @@
+from .server_app import App
+
+__all__ = server_app.__all__

--- a/ota_proxy/config.py
+++ b/ota_proxy/config.py
@@ -4,19 +4,19 @@ from dataclasses import dataclass
 @dataclass
 class Config:
     BASE_DIR: str = "/ota-cache"
-    CHUNK_SIZE: int = 2097_152  # in bytes
+    CHUNK_SIZE: int = 4 * 1024 * 1024  # 4MB
     DISK_USE_LIMIT_P = 70  # in p%
     DISK_USE_PULL_INTERVAL = 2  # in seconds
     BUCKET_FILE_SIZE_LIST = (
         0,
-        10_240,  # 10KiB
-        102_400,  # 100KiB
-        512_000,  # 500KiB
-        1_048_576,  # 1MiB
-        5_242_880,  # 5MiB
-        10_485_760,  # 10MiB
-        104_857_600,  # 100MiB
-        1_048_576_000,  # 1GiB
+        10 * 1024,  # 10KiB
+        100 * 1024,  # 100KiB
+        500 * 1024,  # 500KiB
+        1 * 1024 * 1024,  # 1MiB
+        5 * 1024 * 1024,  # 5MiB
+        10 * 1024 * 1024,  # 10MiB
+        100 * 1024 * 1024,  # 100MiB
+        1 * 1024 * 1024 * 1024,  # 1GiB
     )  # Bytes
     DB_FILE = f"{BASE_DIR}/cache_db"
 

--- a/ota_proxy/config.py
+++ b/ota_proxy/config.py
@@ -20,4 +20,5 @@ class Config:
     )  # Bytes
     DB_FILE = f"{BASE_DIR}/cache_db"
 
+
 config = Config()

--- a/ota_proxy/config.py
+++ b/ota_proxy/config.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Config:
+    BASE_DIR: str = "/ota-cache"
+    CHUNK_SIZE: int = 2097_152  # in bytes
+    DISK_USE_LIMIT_P = 70  # in p%
+    DISK_USE_PULL_INTERVAL = 2  # in seconds
+    BUCKET_FILE_SIZE_LIST = (
+        0,
+        10_240,  # 10KiB
+        102_400,  # 100KiB
+        512_000,  # 500KiB
+        1_048_576,  # 1MiB
+        5_242_880,  # 5MiB
+        10_485_760,  # 10MiB
+        104_857_600,  # 100MiB
+        1_048_576_000,  # 1GiB
+    )  # Bytes
+    DB_FILE = f"{BASE_DIR}/cache_db"
+
+config = Config()

--- a/ota_proxy/db.py
+++ b/ota_proxy/db.py
@@ -1,0 +1,139 @@
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Lock
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CacheMeta:
+    url: str
+    hash: str
+    size: int
+    content_type: str
+    content_encoding: str
+
+    def to_tuple(self) -> tuple:
+        return (
+            self.url,
+            self.hash,
+            self.size,
+            self.content_type,
+            self.content_encoding,
+        )
+
+
+class OTACacheDB:
+    TABLE_NAME: str = "ota_cache"
+    COLUMNS: dict = {
+        "url": 0,
+        "hash": 1,
+        "size": 2,
+        "content_type": 3,
+        "content_encoding": 4,
+    }
+
+    def __init__(self, db_file: str, init: bool = False):
+        logger.debug("init database...")
+        self._db_file = db_file
+        self._wlock = Lock()
+        self._closed = False
+
+        self._connect_db(init)
+
+    def close(self):
+        logger.debug("closing db...")
+        if not self._closed:
+            self._con.close()
+            self._closed = True
+
+    def _init_table(self):
+        logger.debug("init sqlite database...")
+        cur = self._con.cursor()
+
+        # create the table
+        cur.execute(
+            f"""CREATE TABLE {self.TABLE_NAME}(
+                    url text UNIQUE PRIMARY KEY, 
+                    hash text NOT NULL, 
+                    size real NOT NULL,
+                    content_type text, 
+                    content_encoding text)"""
+        )
+
+        self._con.commit()
+        cur.close()
+
+    def _connect_db(self, init: bool):
+        if init:
+            Path(self._db_file).unlink(missing_ok=True)
+            self._con = sqlite3.connect(self._db_file, check_same_thread=False)
+            self._init_table()
+        else:
+            self._con = sqlite3.connect(self._db_file, check_same_thread=False)
+
+        # check if the table exists
+        cur = self._con.cursor()
+        cur.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (self.TABLE_NAME,),
+        )
+        if cur.fetchone() is None:
+            self._init_table()
+
+    def remove_url_by_hash(self, *hash: str):
+        if self._closed:
+            raise sqlite3.OperationalError("connect is closed")
+
+        with self._wlock:
+            cur = self._con.cursor()
+            cur.executemany(f"DELETE FROM {self.TABLE_NAME} WHERE hash=?", hash)
+
+            self._con.commit()
+            cur.close()
+        return
+
+    def remove_urls(self, *urls):
+        if self._closed:
+            raise sqlite3.OperationalError("connect is closed")
+
+        with self._wlock:
+            cur = self._con.cursor()
+            cur.executemany(f"DELETE FROM {self.TABLE_NAME} WHERE url=?", urls)
+
+            self._con.commit()
+            cur.close()
+
+    def insert_urls(self, *cache_meta: CacheMeta):
+        if self._closed:
+            raise sqlite3.OperationalError("connect is closed")
+
+        rows = [m.to_tuple() for m in cache_meta]
+        with self._wlock:
+            cur = self._con.cursor()
+            cur.executemany(f"INSERT INTO {self.TABLE_NAME} VALUES (?,?,?,?,?)", rows)
+
+            self._con.commit()
+            cur.close()
+
+    def lookup_url(self, url: str) -> CacheMeta:
+        if self._closed:
+            raise sqlite3.OperationalError("connect is closed")
+
+        cur = self._con.cursor()
+        cur.execute(f"SELECT * FROM {self.TABLE_NAME} WHERE url=?", (url,))
+        row = cur.fetchone()
+        if not row:
+            return
+
+        res = CacheMeta(
+            url=row[self.COLUMNS["url"]],
+            hash=row[self.COLUMNS["hash"]],
+            size=row[self.COLUMNS["size"]],
+            content_type=row[self.COLUMNS["content_type"]],
+            content_encoding=row[self.COLUMNS["content_encoding"]],
+        )
+        return res

--- a/ota_proxy/db.py
+++ b/ota_proxy/db.py
@@ -114,7 +114,9 @@ class OTACacheDB:
         rows = [m.to_tuple() for m in cache_meta]
         with self._wlock:
             cur = self._con.cursor()
-            cur.executemany(f"INSERT INTO {self.TABLE_NAME} VALUES (?,?,?,?,?)", rows)
+            cur.executemany(
+                f"INSERT OR REPLACE INTO {self.TABLE_NAME} VALUES (?,?,?,?,?)", rows
+            )
 
             self._con.commit()
             cur.close()

--- a/ota_proxy/ota_cache.py
+++ b/ota_proxy/ota_cache.py
@@ -1,0 +1,480 @@
+import asyncio
+import requests
+import subprocess
+import shlex
+import shutil
+import time
+from collections import OrderedDict
+from concurrent.futures import ThreadPoolExecutor
+from queue import Queue
+from hashlib import sha256
+from threading import Lock, Event
+from typing import Dict
+from pathlib import Path
+
+from . import db
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _subprocess_check_output(cmd: str, *, raise_exception=False) -> str:
+    try:
+        return (
+            subprocess.check_output(shlex.split(cmd), stderr=subprocess.DEVNULL)
+            .decode()
+            .strip()
+        )
+    except subprocess.CalledProcessError:
+        if raise_exception:
+            raise
+        return ""
+
+
+class _Bucket(OrderedDict):
+    def __init__(self, size: int, cache_dir: str):
+        super().__init__()
+        self._lock = Lock()
+        self._base = cache_dir
+        self.size = size
+
+    def add_entry(self, key):
+        """
+        newly added item will be added to the last(right)
+        this method can also be used to warm up an entry
+        """
+        self[key] = None
+        self.move_to_end(key)
+
+    warm_up_entry = add_entry
+
+    def popleft(self) -> str:
+        try:
+            res, _ = self.popitem(last=False)
+            return res
+        except KeyError:
+            return
+
+    def reserve_space(self, size: int) -> list:
+        enough_space = False
+        with self._lock:
+            hash_list, files_list = [], []
+            space_available = None
+            for h in self:
+                if space_available >= size:
+                    break
+                else:
+                    f: Path = Path(self._base) / h
+                    if f.is_file():
+                        # TODO: deal with dangling cache?
+                        space_available += f.stat().st_size
+                        hash_list.append(h)
+                        files_list.append(f)
+
+            if space_available >= size:
+                enough_space = True
+                # we can reserve enough space from current bucket
+                for h in hash_list:
+                    del self[h]
+
+        if enough_space:
+            for f in files_list:
+                f.unlink(missing_ok=True)
+            return hash_list
+
+        return
+
+
+class OTAFile:
+    CHUNK_SIZE = 2097_152  # in bytes, 2MB
+
+    def __init__(
+        self,
+        url: str,
+        base_path: str,
+        session: requests.Session,
+        meta: db.CacheMeta = None,
+        store_cache: bool = False,
+        enable_https: bool = False,
+        free_space_event: Event = None,
+    ):
+        logger.debug(f"new OTAFile request: {url}")
+        self.base_path = base_path
+        self._session = session
+        self._cached = False
+        self._store_cache = store_cache
+        self._free_space_event = free_space_event
+
+        # cache entry meta
+        self.url = url
+        self.hash = None
+        self.content_type = None
+        self.content_encoding = None
+        self.size = 0
+
+        # data fp that we used in iterator
+        self._fp = None
+        self._dst_fp = None  # cache entry dst if store_cache
+        self._response = None
+
+        # life cycle
+        self._finished = False
+        self.cached_success = False
+
+        if meta:  # cache entry presented
+            self.hash: str = meta.hash
+            self.fpath = Path(self.base_path) / self.hash
+
+            if self.fpath.is_file():
+                # check if it is a dangling cache
+                # NOTE: we are currently not dealing with dangling entry yet
+                self.content_type = meta.content_type
+                self.content_encoding = meta.content_encoding
+                self.size = meta.size
+                self._cached = True
+                self._fp = open(self.fpath, "rb")
+
+        if not self._cached:
+            self._queue = Queue()
+
+            # open the remote connection
+            _url = url
+            if enable_https:
+                _url = url.replace("http", "https")
+
+            self._response = self._session.get(_url, stream=True)
+            self.content_type = self._response.headers.get(
+                "Content-Type", "application/octet-stream"
+            )
+            self.content_encoding = self._response.headers.get("Content-Encoding", "")
+            self._fp = self._response.raw
+
+    def background_write_cache(self, callback):
+        if not self._store_cache or not self._free_space_event:
+            return
+
+        try:
+            logger.debug(f"start to cache for {self.url}...")
+            self._hash_f = sha256()
+            tmp_fpath = Path(self.base_path) / str(time.time()).replace(".", "")
+            self.temp_fpath = tmp_fpath
+            self._dst_fp = open(tmp_fpath, "wb")
+
+            while not self._finished or not self._queue.empty():
+                if not self._free_space_event.is_set():
+                    # if the free space is not enough duing caching
+                    # abort the caching
+                    logger.error(
+                        f"not enough free space during caching url={self.url}, abort"
+                    )
+                    break
+
+                try:
+                    data = self._queue.get(timeout=360)
+                except Exception:
+                    logger.error(f"timeout caching for {self.url}, abort")
+                    break
+                self._hash_f.update(data)
+                self.size += self._dst_fp.write(data)
+
+            self._dst_fp.close()
+            if self._finished and self.size > 0:  # not caching 0 size file
+                # rename the file to the hash value
+                self.hash = self._hash_f.hexdigest()[:16]
+                self.temp_fpath.rename(Path(self.base_path) / self.hash)
+                self.cached_success = True
+                logger.debug(f"successfully cache {self.url}")
+            # NOTE: if queue is empty but self._finished is not set
+            # an unfinished caching might happen
+        finally:
+            # execute the callback function
+            callback(self)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> bytes:
+        if self._finished:
+            raise ValueError("file is closed")
+
+        chunk = self._fp.read(self.CHUNK_SIZE)
+        if len(chunk) == 0:  # stream finished
+            self._finished = True
+            # finish the background cache writing
+            if self._store_cache:
+                self._queue.put(b"")
+
+            # cleanup
+            self._fp.close()
+            if self._response is not None:
+                self._response.close()
+
+            raise StopAsyncIteration
+        else:
+            # stream the contents to background caching task non-blockingly
+            if self._store_cache:
+                self._queue.put_nowait(chunk)
+
+            return chunk
+
+
+class OTACache:
+    CACHE_DIR = "/ota-cache"
+    DB_FILE = f"{CACHE_DIR}/cache_db"
+    DISK_USE_LIMIT_P = 70  # in p%
+    DISK_USE_PULL_INTERVAL = 2  # in seconds
+    BUCKET_FILE_SIZE_LIST = (
+        0,
+        10_240,  # 10KiB
+        102_400,  # 100KiB
+        512_000,  # 500KiB
+        1_048_576,  # 1MiB
+        5_242_880,  # 5MiB
+        10_485_760,  # 10MiB
+        104_857_600,  # 100MiB
+        1_048_576_000,  # 1GiB
+    )  # Bytes
+
+    def __init__(
+        self,
+        cache_enabled: bool,
+        init: bool,
+        upper_proxy: str = None,
+        enable_https: bool = False,
+    ):
+        logger.debug(f"init ota cache({cache_enabled=}, {init=}, {upper_proxy=})")
+
+        self._closed = False
+        self._cache_enabled = cache_enabled
+        self._enable_https = enable_https
+        self._executor = ThreadPoolExecutor()
+
+        self._enough_free_space_event = Event()
+
+        if cache_enabled:
+            self._cache_enabled = True
+
+            # prepare cache dire
+            if init:
+                shutil.rmtree(self.CACHE_DIR, ignore_errors=True)
+            Path(self.CACHE_DIR).mkdir(exist_ok=True, parents=True)
+
+            # dispatch a background task to pulling the disk usage info
+            self._executor.submit(self._background_check_free_space)
+
+            self._db = db.OTACacheDB(self.DB_FILE)
+            # NOTE: requests doesn't decompress the contents,
+            # we cache the contents as its original form, and send
+            # to the client
+            self._session = requests.Session()
+            if upper_proxy:
+                # override the proxy setting if we configure one
+                proxies = {"http": upper_proxy, "https": ""}
+                self._session.proxies.update(proxies)
+                # if upper proxy presented, we must disable https
+                self._enable_https = False
+
+            self._init_buckets()
+        else:
+            self._cache_enabled = False
+
+    def close(self, cleanup: bool = False):
+        logger.debug(f"shutdown ota-cache({cleanup=})...")
+        if self._cache_enabled and not self._closed:
+            self._closed = True
+            self._executor.shutdown(wait=True)
+            self._db.close()
+
+            if cleanup:
+                shutil.rmtree(self.CACHE_DIR, ignore_errors=True)
+        logger.info("shutdown ota-cache completed")
+
+    def _background_check_free_space(self) -> bool:
+        while not self._closed:
+            try:
+                cmd = f"df --output=pcent {self.CACHE_DIR}"
+                current_used_p = _subprocess_check_output(cmd, raise_exception=True)
+
+                # expected output:
+                # 0: Use%
+                # 1: 33%
+                current_used_p = int(current_used_p.splitlines()[-1].strip(" %"))
+                if current_used_p < self.DISK_USE_LIMIT_P:
+                    self._enough_free_space_event.set()
+                else:
+                    self._enough_free_space_event.clear()
+            except Exception:
+                self._enough_free_space_event.clear()
+
+            time.sleep(self.DISK_USE_PULL_INTERVAL)
+
+    def _init_buckets(self):
+        self._buckets: Dict[_Bucket] = dict()  # dict[file_size_target]_Bucket
+
+        for s in self.BUCKET_FILE_SIZE_LIST:
+            self._buckets[s] = _Bucket(size=s, cache_dir=self.CACHE_DIR)
+
+    def _register_cache_callback(self, f: OTAFile):
+        """
+        the callback for finishing up caching
+
+        NOTE:
+        1. if the free space is used up duing caching,
+        the caching will terminate immediately.
+        2. if the free space is used up after cache writing finished,
+        we will first try reserving free space, if fails,
+        then we delete the already cached file.
+        """
+        if f.cached_success and self._ensure_free_space(f.size):
+            logger.debug(f"commit cache for {f.url}...")
+            bs = self._find_target_bucket_size(f.size)
+            self._buckets[bs].add_entry(f.hash)
+
+            # register to the database
+            cache_meta = db.CacheMeta(
+                url=f.url,
+                hash=f.hash,
+                size=f.size,
+                content_type=f.content_type,
+                content_encoding=f.content_encoding,
+            )
+            self._db.insert_urls(cache_meta)
+        else:
+            # try to cleanup the dangling cache file
+            Path(f.temp_fpath).unlink(missing_ok=True)
+
+    def _find_target_bucket_size(self, file_size: int) -> int:
+        if file_size < 0:
+            raise ValueError(f"invalid file size {file_size}")
+
+        s, e = 0, len(self.BUCKET_FILE_SIZE_LIST) - 1
+        target_size = None
+
+        if file_size >= self.BUCKET_FILE_SIZE_LIST[-1]:
+            target_size = self.BUCKET_FILE_SIZE_LIST[-1]
+        else:
+            idx = None
+            while True:
+                if abs(e - s) <= 1:
+                    idx = s
+                    break
+
+                if file_size <= self.BUCKET_FILE_SIZE_LIST[(s + e) // 2]:
+                    e = (s + e) // 2
+                elif file_size > self.BUCKET_FILE_SIZE_LIST[(s + e) // 2]:
+                    s = (s + e) // 2
+            target_size = self.BUCKET_FILE_SIZE_LIST[idx]
+
+        return target_size
+
+    def _ensure_free_space(self, size: int) -> bool:
+        if not self._enough_free_space_event.is_set():  # no enough free space
+            bs = self._find_target_bucket_size(size)
+            bucket: _Bucket = self._buckets[bs]
+
+            # first check the current bucket
+            hash_list = bucket.reserve_space(size)
+            if hash_list:
+                self._db.remove_url_by_hash(*hash_list)
+                return True
+
+            else:  # if current bucket is not enough, check higher bucket
+                entry_to_clear = None
+                for bs in self.BUCKET_FILE_SIZE_LIST[
+                    self.BUCKET_FILE_SIZE_LIST.index(bs) + 1 :
+                ]:
+                    bucket = self._buckets[bs]
+                    entry_to_clear = bucket.popleft()
+
+                if entry_to_clear:
+                    # get one entry from the target bucket
+                    # and then delete it
+
+                    f: Path = Path(self.CACHE_DIR) / entry_to_clear
+                    f.unlink(missing_ok=True)
+                    self._db.remove_url_by_hash(entry_to_clear)
+
+                    return True
+
+        else:  # there is already enough space
+            return True
+
+        return False
+
+    def _promote_cache_entry(self, cache_meta: db.CacheMeta):
+        bs = self._find_target_bucket_size(cache_meta.size)
+        bucket: _Bucket = self._buckets[bs]
+        bucket.warm_up_entry(cache_meta.hash)
+
+    # exposed API
+    async def retrieve_file(self, url: str) -> OTAFile:
+        logger.debug(f"try to retrieve file from {url=}")
+        if self._closed:
+            raise ValueError("ota cache pool is closed")
+
+        res = None
+        if not self._cache_enabled:
+            # case 1: not using cache, directly download file
+            res = OTAFile(
+                url=url,
+                base_path=None,
+                session=self._session,
+                store_cache=False,
+                enable_https=self._enable_https,
+            )
+        else:
+            no_cache_available = True
+
+            cache_meta = self._db.lookup_url(url)
+            if cache_meta:  # cache hit
+                logger.debug(f"cache hit for {url=}\n, {cache_meta=}")
+                path = Path(self.CACHE_DIR) / cache_meta.hash
+                if not path.is_file():
+                    # invalid cache entry found in the db, cleanup it
+                    logger.error(f"dangling cache entry found: \n{cache_meta=}")
+                    self._db.remove_urls(url)
+                    no_cache_available = True
+                else:
+                    no_cache_available = False
+            else:
+                no_cache_available = True
+
+            # check whether we should use cache, not use cache,
+            # or download and cache the new file
+            if no_cache_available:
+                # case 2: download and cache new file
+                # try to ensure space for new cache
+                logger.debug(f"try to download and cache {url=}")
+                res = OTAFile(
+                    url=url,
+                    base_path=self.CACHE_DIR,
+                    session=self._session,
+                    store_cache=True,
+                    enable_https=self._enable_https,
+                    free_space_event=self._enough_free_space_event,
+                )
+
+                # dispatch the background cache writing to executor
+                loop = asyncio.get_running_loop()
+                loop.run_in_executor(
+                    self._executor,
+                    res.background_write_cache,
+                    self._register_cache_callback,
+                )
+            else:
+                # case 3: use cache
+                # warm up the cache
+                logger.debug(f"use cache for {url=}")
+                self._promote_cache_entry(cache_meta)
+                # use cache
+                res = OTAFile(
+                    url=url,
+                    base_path=self.CACHE_DIR,
+                    session=self._session,
+                    meta=cache_meta,
+                    enable_https=self._enable_https,
+                    free_space_event=self._enough_free_space_event,
+                )
+
+        return res

--- a/ota_proxy/ota_cache.py
+++ b/ota_proxy/ota_cache.py
@@ -188,7 +188,10 @@ class OTAFile:
                 self._queue.put_nowait(b"")
 
             # cleanup
-            self._fp.close()
+            if not self._remote:
+                self._fp.close()
+            else:
+                self._fp.release()
 
             raise StopAsyncIteration
         else:

--- a/ota_proxy/ota_cache.py
+++ b/ota_proxy/ota_cache.py
@@ -190,7 +190,6 @@ class OTAFile:
 
 
 class OTACache:
-    
     def __init__(
         self,
         cache_enabled: bool,

--- a/ota_proxy/server_app.py
+++ b/ota_proxy/server_app.py
@@ -85,13 +85,12 @@ class App:
 
         # parse response
         # NOTE: currently only record content_type and content_encoding
-        content_type = f.content_type
-        content_encoding = f.content_encoding
+        meta = f.meta
         headers = []
-        if content_type:
-            headers.append([b"Content-Type", content_type.encode()])
-        if content_encoding:
-            headers.append([b"Content-Encoding", content_encoding.encode()])
+        if meta.content_type:
+            headers.append([b"Content-Type", meta.content_type.encode()])
+        if meta.content_encoding:
+            headers.append([b"Content-Encoding", meta.content_encoding.encode()])
 
         # prepare the response to the client
         await self._init_response(HTTPStatus.OK, headers, send)

--- a/ota_proxy/server_app.py
+++ b/ota_proxy/server_app.py
@@ -1,0 +1,146 @@
+from http import HTTPStatus
+from threading import Lock
+
+from . import ota_cache
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# only expose app
+__all__ = "App"
+
+
+class App:
+    def __init__(
+        self, cache_enabled=False, upper_proxy: str = None, enable_https: bool = False
+    ):
+        self.cache_enabled = cache_enabled
+        self.upper_proxy = upper_proxy
+        self.enable_https = enable_https
+        self.started = False
+
+        self._lock = Lock()
+
+    def start(self):
+        if self._lock.acquire(blocking=False):
+            if not self.started:
+                logger.info("start ota http proxy app...")
+                self.started = True
+                self._ota_cache = ota_cache.OTACache(
+                    upper_proxy=self.upper_proxy,
+                    cache_enabled=self.cache_enabled,
+                    init=True,
+                    enable_https=self.enable_https,
+                )
+            self._lock.release()
+
+    def stop(self):
+        if self._lock.acquire(blocking=False):
+            if self.started:
+                logger.info("stopping ota http proxy app...")
+                self._ota_cache.close()
+                logger.info("shutdown server completed")
+            self._lock.release()
+
+    async def _respond_with_error(self, status: HTTPStatus, msg: str, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status,
+                "headers": [
+                    [b"content-type", b"text/html;charset=UTF-8"],
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": msg.encode("utf8")})
+
+    async def _send_chunk(self, data: bytes, more: bool, send):
+        if more:
+            await send({"type": "http.response.body", "body": data, "more_body": True})
+        else:
+            await send({"type": "http.response.body", "body": b""})
+
+    async def _init_response(self, status: HTTPStatus, headers: dict, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status,
+                "headers": headers,
+            }
+        )
+
+    async def _pull_data_and_send(self, url: str, send):
+        f: ota_cache.OTAFile = await self._ota_cache.retrieve_file(url)
+
+        # for any reason the response is not OK,
+        # report to the client as 500
+        if f is None:
+            msg = f"proxy server failed to handle request {url=}"
+            await self._respond_with_error(HTTPStatus.INTERNAL_SERVER_ERROR, msg, send)
+
+            # terminate the request processing
+            logger.error(f"failed to handle request {url=}")
+            return
+
+        # parse response
+        # NOTE: currently only record content_type and content_encoding
+        content_type = f.content_type
+        content_encoding = f.content_encoding
+        headers = []
+        if content_type:
+            headers.append([b"Content-Type", content_type.encode()])
+        if content_encoding:
+            headers.append([b"Content-Encoding", content_encoding.encode()])
+
+        # prepare the response to the client
+        await self._init_response(HTTPStatus.OK, headers, send)
+
+        # stream the response to the client
+        async for chunk in f:
+            await self._send_chunk(chunk, True, send)
+        # finish the streaming by send a 0 len payload
+        await self._send_chunk(b"", False, send)
+
+    async def app(self, scope, send):
+        """
+        the real entry for the server app
+        """
+        from urllib.parse import urlparse
+
+        assert scope["type"] == "http"
+        # check method, currently only support GET method
+        if scope["method"] != "GET":
+            msg = "ONLY SUPPORT GET METHOD."
+            await self._respond_with_error(HTTPStatus.BAD_REQUEST, msg, send)
+            return
+
+        # get the url from the request
+        url = scope["path"]
+        _url = urlparse(url)
+        if not _url.scheme or not _url.path:
+            msg = f"INVALID URL {url}."
+            await self._respond_with_error(HTTPStatus.BAD_REQUEST, msg, send)
+            return
+
+        logger.debug(f"receive request for {url=}")
+        await self._pull_data_and_send(url, send)
+
+    async def __call__(self, scope, receive, send):
+        """
+        the entrance of the asgi app
+        """
+        if scope["type"] == "lifespan":
+            # handling lifespan protocol
+            while True:
+                message = await receive()
+                if message["type"] == "lifespan.startup":
+                    self.start()
+                    await send({"type": "lifespan.startup.complete"})
+                elif message["type"] == "lifespan.shutdown":
+                    self.stop()
+                    await send({"type": "lifespan.shutdown.complete"})
+                    return
+        else:
+            # real app entry
+            await self.app(scope, send)


### PR DESCRIPTION
## Introduction
This PR implements a cache-enabled standalone http proxy server dedicated for streaming OTA updates to subECUs.
This ota_proxy server runs as an independent proxy server. It will cache the OTA files request by URL, and stream the files to the subECUs.

## NOTE
1. https is not supported between mainECU and subECUs as we enable cached.
2. https is supported when mainECU fetch files from the internet.
3. currently the server will stop caching if the disk which cache_dir on usage reach 70%.