### PR TITLE
Integrate ota_proxy into ota_client

### DIFF
--- a/app/configs.py
+++ b/app/configs.py
@@ -2,9 +2,10 @@ import platform
 from dataclasses import dataclass, field
 from logging import INFO
 
+from typing import Tuple
 
 # fmt: off
-@dataclass
+@dataclass(frozen=True)
 class OtaClientServerConfig:
     SERVER_PORT: str = "50051"
     PRE_UPDATE_TIMEOUT: float = 300  # 5mins
@@ -14,6 +15,9 @@ class OtaClientServerConfig:
     LOCAL_OTA_UPDATE_TIMEOUT: float = 3600  # 1h
     QUERYING_SUBECU_STATUS_TIMEOUT: float = 120  # 2mins
     LOOP_QUERYING_SUBECU_STATUS_INTERVAL: float = 10
+
+    # proxy server
+    OTA_PROXY_SERVER_ADDR: Tuple[str, int] = ("0.0.0.0", 8000)
 
 
 @dataclass

--- a/app/configs.py
+++ b/app/configs.py
@@ -17,7 +17,7 @@ class OtaClientServerConfig:
     LOOP_QUERYING_SUBECU_STATUS_INTERVAL: float = 10
 
     # proxy server
-    OTA_PROXY_SERVER_ADDR: Tuple[str, int] = ("0.0.0.0", 8000)
+    OTA_PROXY_SERVER_ADDR: Tuple[str, int] = ("0.0.0.0", 8082)
 
 
 @dataclass

--- a/app/configs.py
+++ b/app/configs.py
@@ -36,6 +36,7 @@ class _BaseConfig:
     )
     BOOT_DIR: str = "/boot"
     ECU_INFO_FILE: str = "/boot/ota/ecu_info.yaml"
+    PROXY_INFO_FILE: str = "/boot/ota/proxy_info.yaml"
     PASSWD_FILE: str = "/etc/passwd"
     GROUP_FILE: str = "/etc/group"
     BOOT_OTA_PARTITION_FILE: str = "ota-partition"

--- a/app/ecu_info.py
+++ b/app/ecu_info.py
@@ -29,10 +29,10 @@ class EcuInfo:
     def get_ecu_ip_addr(self):
         return self._ecu_info.get("ip_addr", "localhost")
 
-    def _load_ecu_info(self, path):
+    def _load_ecu_info(self, path: str):
         try:
             with open(path) as f:
-                ecu_info = yaml.load(f, Loader=yaml.SafeLoader)
+                ecu_info = yaml.safe_load(f)
         except Exception:
             return EcuInfo.DEFAULT_ECU_INFO
         return ecu_info

--- a/app/main.py
+++ b/app/main.py
@@ -20,12 +20,6 @@ logger = log_util.get_logger(
 
 VERSION_FILE = Path(__file__).parent.parent / "version.txt"
 
-def _path_load():
-    import sys
-    from pathlib import Path
-
-    project_base = Path(__file__).absolute().parent.parent
-    sys.path.append(str(project_base))
 
 def main():
     logger.info("started")
@@ -63,5 +57,4 @@ def main():
 
 
 if __name__ == "__main__":
-    _path_load()
     main()

--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,12 @@ logger = log_util.get_logger(
 
 VERSION_FILE = Path(__file__).parent.parent / "version.txt"
 
+def _path_load():
+    import sys
+    from pathlib import Path
+
+    project_base = Path(__file__).absolute().parent.parent
+    sys.path.append(str(project_base))
 
 def main():
     logger.info("started")
@@ -57,4 +63,5 @@ def main():
 
 
 if __name__ == "__main__":
+    _path_load()
     main()

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -331,9 +331,9 @@ class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
     ):
         logger.debug("[update] entering...")
 
-        # use local proxy for ota update if enabled
-        if proxy_cfg.enable_local_ota_proxy:
-            self._download.configure_proxy(proxy_cfg.get_proxy_for_local_ota())
+        proxy = proxy_cfg.get_proxy_for_local_ota()
+        if proxy:
+            self._download.configure_proxy(proxy)
 
         try:
             cookies = json.loads(cookies_json)

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -65,6 +65,10 @@ class Downloader:
         session.proxies.update(proxies)
 
         # init retry mechanism
+        # NOTE: for urllib3 version below 2.0, we have to change Retry class' DEFAULT_BACKOFF_MAX,
+        # to configure the backoff max, set the value to the instance will not work as increment() method
+        # will create a new instance of Retry on every try without inherit the change to instance's DEFAULT_BACKOFF_MAX
+        Retry.DEFAULT_BACKOFF_MAX = 10
         retry_strategy = Retry(
             total=self.RETRY_COUNT,
             raise_on_status=True,
@@ -73,7 +77,6 @@ class Downloader:
             status_forcelist={413, 429, 500, 502, 503, 504},
             allowed_methods=["GET"],
         )
-        retry_strategy.DEFAULT_BACKOFF_MAX = 10
         adapter = HTTPAdapter(max_retries=retry_strategy)
         session.mount("https://", adapter)
         session.mount("http://", adapter)

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -68,11 +68,12 @@ class Downloader:
         retry_strategy = Retry(
             total=self.RETRY_COUNT,
             raise_on_status=True,
-            backoff_factor=0.1,
+            backoff_factor=1,
             # retry on common server side errors and non-critical client side errors
             status_forcelist={413, 429, 500, 502, 503, 504},
             allowed_methods=["GET"],
         )
+        retry_strategy.DEFAULT_BACKOFF_MAX = 10
         adapter = HTTPAdapter(max_retries=retry_strategy)
         session.mount("https://", adapter)
         session.mount("http://", adapter)

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -51,7 +51,7 @@ def verify_file(filename: Path, filehash: str, filesize) -> bool:
     return file_sha256(filename) == filehash
 
 class Downloader:
-    CHUNK_SIZE = 4 * 1024 * 1024 # 4MiB
+    CHUNK_SIZE = 2 * 1024 * 1024 # 2MiB
     RETRY_COUNT = 5
 
     def __init__(self, *, proxies: dict):

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -85,11 +85,6 @@ class Downloader:
         quoted_path = quote(url)
         return urljoin(url_base, quoted_path)
 
-    def load_cookies_for_session(self, cookies: dict):
-        from requests.cookies import cookiejar_from_dict
-
-        self._session.cookies = cookiejar_from_dict(cookies)
-
     def __call__(
         self, url_base: str, path: str, dst: Path, digest: str, cookies: dict
     ) -> int:

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -48,8 +48,9 @@ def verify_file(filename: Path, filehash: str, filesize) -> bool:
         return False
     return file_sha256(filename) == filehash
 
+
 class Downloader:
-    CHUNK_SIZE = 2 * 1024 * 1024 # 2MiB
+    CHUNK_SIZE = 2 * 1024 * 1024  # 2MiB
     RETRY_COUNT = 5
 
     def __init__(self, *, proxy: str):
@@ -60,7 +61,7 @@ class Downloader:
         session = requests.Session()
 
         # configure proxy
-        proxies={'http': proxy, 'https': ''}
+        proxies = {"http": proxy, "https": ""}
         session.proxies.update(proxies)
 
         # init retry mechanism
@@ -70,7 +71,7 @@ class Downloader:
             backoff_factor=0.1,
             # retry on common server side errors and non-critical client side errors
             status_forcelist={413, 429, 500, 502, 503, 504},
-            allowed_methods=["GET"]
+            allowed_methods=["GET"],
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         session.mount("https://", adapter)
@@ -80,15 +81,18 @@ class Downloader:
         self._session = session
 
     @staticmethod
-    def _regulate_url(url: str, url_base: str) -> str:        
+    def _regulate_url(url: str, url_base: str) -> str:
         quoted_path = quote(url)
         return urljoin(url_base, quoted_path)
 
     def load_cookies_for_session(self, cookies: dict):
         from requests.cookies import cookiejar_from_dict
+
         self._session.cookies = cookiejar_from_dict(cookies)
 
-    def __call__(self, url_base: str, path: str, dst: Path, digest: str, cookies: dict) -> int:
+    def __call__(
+        self, url_base: str, path: str, dst: Path, digest: str, cookies: dict
+    ) -> int:
         url = self._regulate_url(path, url_base)
 
         error_count = 0
@@ -118,7 +122,7 @@ class Downloader:
 
         # prepare hash
         hash_f = sha256()
-        with open(dst, 'wb') as f:
+        with open(dst, "wb") as f:
             for data in response.iter_content(chunk_size=self.CHUNK_SIZE):
                 hash_f.update(data)
                 f.write(data)
@@ -126,8 +130,8 @@ class Downloader:
         calc_digest = hash_f.hexdigest()
         if digest and calc_digest != digest:
             raise OtaErrorRecoverable(
-            f"hash error: act={calc_digest}, exp={digest}, {url=}"
-        )
+                f"hash error: act={calc_digest}, exp={digest}, {url=}"
+            )
 
         return error_count
 

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -6,7 +6,7 @@ import re
 import os
 import time
 import json
-from typing import Any
+from typing import Any, Dict
 from contextlib import contextmanager
 from hashlib import sha256
 from pathlib import Path
@@ -95,7 +95,7 @@ class Downloader:
         return urljoin(url_base, quoted_path)
 
     def __call__(
-        self, url_base: str, path: str, dst: Path, digest: str, cookies: dict
+        self, url_base: str, path: str, dst: Path, digest: str, cookies: Dict[str, str]
     ) -> int:
         url = self._regulate_url(path, url_base)
 
@@ -546,7 +546,7 @@ class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
             metadata.verify(open(file_name).read())
             logger.info("done")
 
-    def _process_metadata(self, url_base, cookies):
+    def _process_metadata(self, url_base, cookies: Dict[str, str]):
         with tempfile.TemporaryDirectory(prefix=__name__) as d:
             file_name = Path(d) / "metadata.jwt"
             self._download(url_base, "metadata.jwt", file_name, None, cookies=cookies)

--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -56,7 +56,7 @@ class OtaProxyWrapper:
 
         app = App(
             cache_enabled=enable_cache, 
-            upper_proxy=proxy_cfg.upper_proxy,
+            upper_proxy=proxy_cfg.upper_ota_proxy,
             enable_https=proxy_cfg.gateway)
         uvicorn.run(app, host=proxy_cfg.host, port=proxy_cfg.port, lifespan="on")
 

--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -21,6 +21,14 @@ logger = log_util.get_logger(
     __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)
 )
 
+def _path_load():
+    import sys
+    from pathlib import Path
+
+    project_base = Path(__file__).absolute().parent.parent
+    sys.path.append(str(project_base))
+
+_path_load()
 
 def _statusprogress_msg_from_dict(input: dict) -> v2.StatusProgress:
     """

--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -71,7 +71,13 @@ class OtaProxyWrapper:
             upper_proxy=proxy_cfg.upper_ota_proxy,
             enable_https=proxy_cfg.gateway,
         )
-        uvicorn.run(app, host=proxy_cfg.host, port=proxy_cfg.port, lifespan="on")
+        uvicorn.run(
+            app,
+            host=proxy_cfg.host,
+            port=proxy_cfg.port,
+            log_level="error",
+            lifespan="on",
+        )
 
     def start(self, enable_cache=False):
         with self._lock:

--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -21,6 +21,7 @@ logger = log_util.get_logger(
     __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)
 )
 
+
 def _path_load():
     import sys
     from pathlib import Path
@@ -28,7 +29,9 @@ def _path_load():
     project_base = Path(__file__).absolute().parent.parent
     sys.path.append(str(project_base))
 
+
 _path_load()
+
 
 def _statusprogress_msg_from_dict(input: dict) -> v2.StatusProgress:
     """
@@ -73,9 +76,11 @@ class OtaProxyWrapper:
     def start(self, enable_cache=False):
         with self._lock:
             if self._closed:
-                self._server_p = Process(target=self._start_server, args=(enable_cache,))
+                self._server_p = Process(
+                    target=self._start_server, args=(enable_cache,)
+                )
                 self._server_p.start()
-                
+
                 self._closed = False
                 logger.info(
                     f"ota proxy server started(pid={self._server_p.pid}, {enable_cache=})"

--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -43,21 +43,22 @@ def _statusprogress_msg_from_dict(input: dict) -> v2.StatusProgress:
 
     return res
 
-class OtaProxyWrapper:
 
+class OtaProxyWrapper:
     def __init__(self):
         self._lock = Lock()
         self._closed = True
         self._server_p: Process = None
-    
+
     def _start_server(self, enable_cache):
         import uvicorn
-        from ..ota_proxy import App
+        from ota_proxy import App
 
         app = App(
-            cache_enabled=enable_cache, 
+            cache_enabled=enable_cache,
             upper_proxy=proxy_cfg.upper_ota_proxy,
-            enable_https=proxy_cfg.gateway)
+            enable_https=proxy_cfg.gateway,
+        )
         uvicorn.run(app, host=proxy_cfg.host, port=proxy_cfg.port, lifespan="on")
 
     def start(self, enable_cache=False):
@@ -68,7 +69,7 @@ class OtaProxyWrapper:
                 logger.info(
                     f"ota proxy server started(pid={self._server_p.pid}, {enable_cache=})"
                     f"{proxy_cfg}"
-                    )
+                )
             else:
                 raise Exception("server already started")
 
@@ -78,7 +79,7 @@ class OtaProxyWrapper:
                 # send SIGTERM to the server process
                 self._server_p.terminate()
                 self._closed = True
-                logger.info(f"ota proxy server closed")
+                logger.info("ota proxy server closed")
 
 
 class OtaClientStub:

--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -50,7 +50,8 @@ class OtaProxyWrapper:
         self._closed = True
         self._server_p: Process = None
 
-    def _start_server(self, enable_cache):
+    @staticmethod
+    def _start_server(enable_cache):
         import uvicorn
         from ota_proxy import App
 
@@ -64,7 +65,9 @@ class OtaProxyWrapper:
     def start(self, enable_cache=False):
         with self._lock:
             if self._closed:
-                self._start_server(enable_cache)
+                self._server_p = Process(target=self._start_server, args=(enable_cache,))
+                self._server_p.start()
+                
                 self._closed = False
                 logger.info(
                     f"ota proxy server started(pid={self._server_p.pid}, {enable_cache=})"

--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -300,9 +300,6 @@ class OtaClientStub:
             )
             # all subECUs are updated, now the ota_client can reboot
             logger.info("all subECUs are updated ready, set post_update_event")
-            # close ota proxy server since all child subECUs are updated
-            if proxy_cfg.enable_local_ota_proxy:
-                self._ota_proxy.stop()
             # signal the local updator to do post-update
             post_update_event.set()
 
@@ -316,6 +313,10 @@ class OtaClientStub:
                 logger.error(f"ota update failed: {e!r}")
             elif isinstance(e, TimeoutError):
                 logger.error(f"timeout local ota update {update_request=}")
+        finally:
+            # always close the local proxy server
+            if proxy_cfg.enable_local_ota_proxy:
+                self._ota_proxy.stop()
 
     async def _get_subecu_status(
         self,

--- a/app/proxy_info.py
+++ b/app/proxy_info.py
@@ -14,13 +14,14 @@ proxy_info.yaml:
 gateway: bool
 enable_ota_proxy: bool
 upper_ota_proxy: str
-generic_proxy: str
 local_server: Tuple[str, int]
 """
 
+# if no proxy_info.yaml presented,
+# we should treat the ecu as main ecu,
+# and enable ota_proxy without upper proxy
 DEFUALT_PROXY_INFO = """
-gateway: false
-enable_ota_proxy: false
+enable_ota_proxy: true
 """
 
 
@@ -34,7 +35,6 @@ class ProxyInfo:
 
         self.enable_local_ota_proxy: bool = proxy_info.get("enable_ota_proxy", False)
         self.upper_ota_proxy: str = proxy_info.get("upper_ota_proxy")
-        self.generic_proxy: str = proxy_info.get("generic_proxy")
 
         if self.enable_local_ota_proxy:
             self.gateway: bool = proxy_info.get("gateway", False)
@@ -47,17 +47,8 @@ class ProxyInfo:
         elif self.upper_ota_proxy:
             # else we directly use the upper proxy
             return self.upper_ota_proxy
-        elif self.generic_proxy:
-            # else we try to use the generic proxy
-            return self.generic_proxy
         else:
             # default not using proxy
-            return ""
-
-    def get_generic_proxy(self) -> str:
-        if self.generic_proxy:
-            return self.generic_proxy
-        else:
             return ""
 
 

--- a/app/proxy_info.py
+++ b/app/proxy_info.py
@@ -1,4 +1,5 @@
 import yaml
+from pathlib import Path
 
 from configs import config as cfg
 import log_util
@@ -17,11 +18,19 @@ generic_proxy: str
 local_server: Tuple[str, int]
 """
 
+DEFUALT_PROXY_INFO = """
+gateway: false
+enable_ota_proxy: false
+"""
+
 class ProxyInfo:
 
     def __init__(self, proxy_info_file: str=cfg.PROXY_INFO_FILE):
-        with open(proxy_info_file, 'r') as f:
-            proxy_info: dict = yaml.safe_load(f)
+        proxy_info_file_path = Path(proxy_info_file)
+        if proxy_info_file_path.is_file():
+            proxy_info: dict = yaml.safe_load(proxy_info_file_path.read_text())
+        else:
+            proxy_info: dict = yaml.safe_load(DEFUALT_PROXY_INFO)
 
         self.enable_local_ota_proxy: bool = proxy_info.get("enable_ota_proxy", False)
         self.upper_ota_proxy: str = proxy_info.get("upper_ota_proxy")
@@ -43,9 +52,12 @@ class ProxyInfo:
             return self.generic_proxy
         else:
             # default not using proxy
-            return
+            return ""
 
     def get_generic_proxy(self) -> str:
-        return self.generic_proxy
+        if self.generic_proxy:
+            return self.generic_proxy
+        else:
+            return ""
 
 proxy_cfg = ProxyInfo()

--- a/app/proxy_info.py
+++ b/app/proxy_info.py
@@ -1,0 +1,45 @@
+import yaml
+
+from configs import config as cfg
+import log_util
+
+logger = log_util.get_logger(
+    __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)
+)
+
+"""
+proxy_info.yaml:
+# version 1
+gateway: <1|0>
+enable_ota_proxy: <1|0>
+upper_proxy: ""
+host: ""
+port: ""
+"""
+
+class ProxyInfo:
+
+    def __init__(self, proxy_info_file: str=cfg.PROXY_INFO_FILE):
+        with open(proxy_info_file, 'r') as f:
+            proxy_info = yaml.safe_load(f)
+
+        self.enable_local_ota_proxy: bool = proxy_info.get("enable_ota_proxy", 0) ==  1
+        self.upper_proxy: str = proxy_info.get("upper_proxy")
+
+        if self.enable_local_ota_proxy:
+            self.gateway: bool = proxy_info.get("gateway", 0) == 1
+            self.host: str = proxy_info.get("host", "0.0.0.0")
+            self.port: int = proxy_info.get("port", 8000)
+    
+    def get_proxy_for_local_ota(self) -> str:
+        if self.enable_local_ota_proxy:
+            # if local proxy is enabled, local ota client also uses it
+            return f"http://{self.host}:{self.port}"
+        elif self.upper_proxy:
+            # else we directly use the upper proxy
+            return self.upper_proxy
+        else:
+            # else we do not use any proxy
+            return
+
+proxy_cfg = ProxyInfo()

--- a/app/proxy_info.py
+++ b/app/proxy_info.py
@@ -10,36 +10,42 @@ logger = log_util.get_logger(
 """
 proxy_info.yaml:
 # version 1
-gateway: <1|0>
-enable_ota_proxy: <1|0>
-upper_proxy: ""
-host: ""
-port: ""
+gateway: bool
+enable_ota_proxy: bool
+upper_ota_proxy: str
+generic_proxy: str
+local_server: Tuple[str, int]
 """
 
 class ProxyInfo:
 
     def __init__(self, proxy_info_file: str=cfg.PROXY_INFO_FILE):
         with open(proxy_info_file, 'r') as f:
-            proxy_info = yaml.safe_load(f)
+            proxy_info: dict = yaml.safe_load(f)
 
-        self.enable_local_ota_proxy: bool = proxy_info.get("enable_ota_proxy", 0) ==  1
-        self.upper_proxy: str = proxy_info.get("upper_proxy")
+        self.enable_local_ota_proxy: bool = proxy_info.get("enable_ota_proxy", False)
+        self.upper_ota_proxy: str = proxy_info.get("upper_ota_proxy")
+        self.generic_proxy: str = proxy_info.get("generic_proxy")
 
         if self.enable_local_ota_proxy:
-            self.gateway: bool = proxy_info.get("gateway", 0) == 1
-            self.host: str = proxy_info.get("host", "0.0.0.0")
-            self.port: int = proxy_info.get("port", 8000)
+            self.gateway: bool = proxy_info.get("gateway", False)
+            self.host, self.port = proxy_info.get("local_server", ("0.0.0.0", 8000))
     
     def get_proxy_for_local_ota(self) -> str:
         if self.enable_local_ota_proxy:
             # if local proxy is enabled, local ota client also uses it
             return f"http://{self.host}:{self.port}"
-        elif self.upper_proxy:
+        elif self.upper_ota_proxy:
             # else we directly use the upper proxy
-            return self.upper_proxy
+            return self.upper_ota_proxy
+        elif self.generic_proxy:
+            # else we try to use the generic proxy
+            return self.generic_proxy
         else:
-            # else we do not use any proxy
+            # default not using proxy
             return
+
+    def get_generic_proxy(self) -> str:
+        return self.generic_proxy
 
 proxy_cfg = ProxyInfo()

--- a/app/proxy_info.py
+++ b/app/proxy_info.py
@@ -39,7 +39,9 @@ class ProxyInfo:
 
         if self.enable_local_ota_proxy:
             self.gateway: bool = proxy_info.get("gateway", False)
-            self.host, self.port = proxy_info.get("local_server", server_cfg.OTA_PROXY_SERVER_ADDR)
+            self.host, self.port = proxy_info.get(
+                "local_server", server_cfg.OTA_PROXY_SERVER_ADDR
+            )
 
     def get_proxy_for_local_ota(self) -> str:
         if self.enable_local_ota_proxy:

--- a/app/proxy_info.py
+++ b/app/proxy_info.py
@@ -23,9 +23,9 @@ gateway: false
 enable_ota_proxy: false
 """
 
-class ProxyInfo:
 
-    def __init__(self, proxy_info_file: str=cfg.PROXY_INFO_FILE):
+class ProxyInfo:
+    def __init__(self, proxy_info_file: str = cfg.PROXY_INFO_FILE):
         proxy_info_file_path = Path(proxy_info_file)
         if proxy_info_file_path.is_file():
             proxy_info: dict = yaml.safe_load(proxy_info_file_path.read_text())
@@ -39,7 +39,7 @@ class ProxyInfo:
         if self.enable_local_ota_proxy:
             self.gateway: bool = proxy_info.get("gateway", False)
             self.host, self.port = proxy_info.get("local_server", ("0.0.0.0", 8000))
-    
+
     def get_proxy_for_local_ota(self) -> str:
         if self.enable_local_ota_proxy:
             # if local proxy is enabled, local ota client also uses it
@@ -59,5 +59,6 @@ class ProxyInfo:
             return self.generic_proxy
         else:
             return ""
+
 
 proxy_cfg = ProxyInfo()

--- a/app/proxy_info.py
+++ b/app/proxy_info.py
@@ -2,6 +2,7 @@ import yaml
 from pathlib import Path
 
 from configs import config as cfg
+from configs import server_cfg
 import log_util
 
 logger = log_util.get_logger(
@@ -38,7 +39,7 @@ class ProxyInfo:
 
         if self.enable_local_ota_proxy:
             self.gateway: bool = proxy_info.get("gateway", False)
-            self.host, self.port = proxy_info.get("local_server", ("0.0.0.0", 8000))
+            self.host, self.port = proxy_info.get("local_server", server_cfg.OTA_PROXY_SERVER_ADDR)
 
     def get_proxy_for_local_ota(self) -> str:
         if self.enable_local_ota_proxy:

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -11,3 +11,5 @@ botocore==1.20.112
 boto3==1.17.112
 retrying==1.3.3
 uvicorn>=0.16.0
+urllib3>=1.26.8
+aiohttp>=3.8.1

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -10,3 +10,4 @@ pytz==2021.1
 botocore==1.20.112
 boto3==1.17.112
 retrying==1.3.3
+uvicorn>=0.16.0

--- a/ota_proxy/config.py
+++ b/ota_proxy/config.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass
 class Config:
     BASE_DIR: str = "/ota-cache"
     CHUNK_SIZE: int = 4 * 1024 * 1024  # 4MB
-    DISK_USE_LIMIT_P = 70  # in p%
+    DISK_USE_LIMIT_SOTF_P = 60  # in p%
+    DISK_USE_LIMIT_HARD_P = 70  # in p%
     DISK_USE_PULL_INTERVAL = 2  # in seconds
     BUCKET_FILE_SIZE_LIST = (
         0,

--- a/ota_proxy/config.py
+++ b/ota_proxy/config.py
@@ -1,3 +1,4 @@
+from logging import INFO
 from dataclasses import dataclass
 
 
@@ -20,6 +21,8 @@ class Config:
         1 * 1024 * 1024 * 1024,  # 1GiB
     )  # Bytes
     DB_FILE = f"{BASE_DIR}/cache_db"
+
+    LOG_LEVEL = INFO
 
 
 config = Config()

--- a/ota_proxy/db.py
+++ b/ota_proxy/db.py
@@ -5,7 +5,10 @@ from threading import Lock
 
 import logging
 
+from .config import config as cfg
+
 logger = logging.getLogger(__name__)
+logger.setLevel(cfg.LOG_LEVEL)
 
 
 @dataclass

--- a/ota_proxy/ota_cache.py
+++ b/ota_proxy/ota_cache.py
@@ -13,14 +13,13 @@ from typing import Dict, Union, Tuple, BinaryIO
 from pathlib import Path
 from os import urandom
 
-from ota_metadata import OtaMetadata
-
 from . import db
 from .config import config as cfg
 
 import logging
 
 logger = logging.getLogger(__name__)
+logger.setLevel(cfg.LOG_LEVEL)
 
 
 def _subprocess_check_output(cmd: str, *, raise_exception=False) -> str:

--- a/ota_proxy/ota_cache.py
+++ b/ota_proxy/ota_cache.py
@@ -242,7 +242,7 @@ class OTACache:
                 # if upper proxy presented, we must disable https
                 self._upper_proxy = upper_proxy
                 self._enable_https = False
-            
+
             # NOTE: we configure aiohttp to not decompress the contents,
             # we cache the contents as its original form, and send
             # to the client with proper headers to indicate the client to
@@ -426,8 +426,8 @@ class OTACache:
             url = raw_url.replace("http", "https")
 
         response = await self._session.get(
-            url, proxy=self._upper_proxy,
-            cookies=cookies, headers=extra_headers)
+            url, proxy=self._upper_proxy, cookies=cookies, headers=extra_headers
+        )
 
         # assembling output cachemeta
         # NOTE: output cachemeta doesn't have hash and size set yet

--- a/ota_proxy/ota_cache.py
+++ b/ota_proxy/ota_cache.py
@@ -237,12 +237,12 @@ class OTACache:
             # to the client
             if upper_proxy:
                 self._session = aiohttp.ClientSession(
-                    auto_decompress=False, proxy=upper_proxy
+                    auto_decompress=False, proxy=upper_proxy, raise_for_status=True
                 )
                 # if upper proxy presented, we must disable https
                 self._enable_https = False
             else:
-                self._session = aiohttp.ClientSession(auto_decompress=False)
+                self._session = aiohttp.ClientSession(auto_decompress=False, raise_for_status=True)
 
             self._init_buckets()
         else:
@@ -387,8 +387,6 @@ class OTACache:
             url = raw_url.replace("http", "https")
 
         response = await self._session.get(url, cookies=cookies, headers=extra_headers)
-        if response.status != HTTPStatus.OK:
-            return
 
         # assembling output cachemeta
         # NOTE: output cachemeta doesn't have hash and size set yet

--- a/ota_proxy/ota_cache.py
+++ b/ota_proxy/ota_cache.py
@@ -9,9 +9,8 @@ from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
 from hashlib import sha256
-from http import HTTPStatus
 from threading import Lock, Event
-from typing import Dict, Tuple, Union, List
+from typing import Dict, Union
 from pathlib import Path
 from os import urandom
 
@@ -242,7 +241,9 @@ class OTACache:
                 # if upper proxy presented, we must disable https
                 self._enable_https = False
             else:
-                self._session = aiohttp.ClientSession(auto_decompress=False, raise_for_status=True)
+                self._session = aiohttp.ClientSession(
+                    auto_decompress=False, raise_for_status=True
+                )
 
             self._init_buckets()
         else:
@@ -404,7 +405,8 @@ class OTACache:
 
     # exposed API
     async def retrieve_file(
-        self, url: str, cookies: Dict[str, str], extra_headers: Dict[str, str]) -> OTAFile:
+        self, url: str, cookies: Dict[str, str], extra_headers: Dict[str, str]
+    ) -> OTAFile:
         if self._closed:
             raise ValueError("ota cache pool is closed")
 

--- a/ota_proxy/server_app.py
+++ b/ota_proxy/server_app.py
@@ -51,10 +51,10 @@ class App:
         """
         parse raw cookies bytes into dict
         """
-        cookie_pairs: List[str] = cookies_bytes.decode().split(';')
+        cookie_pairs: List[str] = cookies_bytes.decode().split(";")
         res = dict()
         for p in cookie_pairs:
-            k, v = p.strip().split('=')
+            k, v = p.strip().split("=")
             res[k] = v
 
         return res
@@ -91,10 +91,10 @@ class App:
         cookies_dict: Dict[str, str] = dict()
         extra_headers: Dict[str, str] = dict()
         # currently we only need cookie and/or authorization header
-        for header in scope['headers']:
-            if header[0] == b'cookie':
+        for header in scope["headers"]:
+            if header[0] == b"cookie":
                 cookies_dict = self.parse_raw_cookies(header[1])
-            elif header[0] == b'authorization':
+            elif header[0] == b"authorization":
                 extra_headers["Authorization"] = header[1].decode()
 
         f: ota_cache.OTAFile = None
@@ -105,18 +105,20 @@ class App:
             return
         except aiohttp.ClientConnectionError:
             await self._respond_with_error(
-                HTTPStatus.INTERNAL_SERVER_ERROR, 
-                "failed to connect to remote server", send)
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                "failed to connect to remote server",
+                send,
+            )
             return
         except aiohttp.ClientError as e:
             await self._respond_with_error(
-                HTTPStatus.INTERNAL_SERVER_ERROR, 
-                f"client error: {e!r}", send)
+                HTTPStatus.INTERNAL_SERVER_ERROR, f"client error: {e!r}", send
+            )
             return
         except Exception as e:
             await self._respond_with_error(
-                HTTPStatus.INTERNAL_SERVER_ERROR, 
-                f"{e!r}", send)
+                HTTPStatus.INTERNAL_SERVER_ERROR, f"{e!r}", send
+            )
             return
 
         # parse response
@@ -139,8 +141,10 @@ class App:
             await self._send_chunk(b"", False, send)
         else:
             await self._respond_with_error(
-                HTTPStatus.INTERNAL_SERVER_ERROR, 
-                f"failed to retrieve file for {url=}", send)
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                f"failed to retrieve file for {url=}",
+                send,
+            )
 
     async def app(self, scope, send):
         """

--- a/ota_proxy/server_app.py
+++ b/ota_proxy/server_app.py
@@ -5,10 +5,12 @@ from typing import Dict, List
 import aiohttp
 
 from . import ota_cache
+from .config import config as cfg
 
 import logging
 
 logger = logging.getLogger(__name__)
+logger.setLevel(cfg.LOG_LEVEL)
 
 # only expose app
 __all__ = "App"


### PR DESCRIPTION
# Introduction
This PR integrates the ota_proxy server into the ota_client.

# Details
1. introduce proxy_info.yaml, this configuration file configures proxy settings for ota_client, including ota_proxy and generic proxy
2. integrate ota_proxy into ota_client, ota_proxy server will be launched on ota_update only, and being closed after ota update finished
3. refactor `ota_client._downloader` into `Downloader`
    a. use `session(connection pool)` to handle all requests
    b. use `Retry` from urllib3 with `requests.HTTPAdapter` to implement better retry mechanism

# TODO

- [x] e2e test with ota_proxy enabled

# Ticket
https://tier4.atlassian.net/browse/T4PUB-644
https://tier4.atlassian.net/browse/T4PUB-644
https://tier4.atlassian.net/browse/T4PB-11208