### PR TITLE
fix http log robustness

### DIFF
--- a/aws-iot-log-server/app/aws_iot_logger.py
+++ b/aws-iot-log-server/app/aws_iot_logger.py
@@ -116,12 +116,12 @@ class AwsIotLogger:
                     self._sequence_tokens[log_stream_name] = None
             raise
         except Exception:
+            # put log and just ignore
             logger.exception(
                 "put_log_events failure: "
                 f"log_group_name={self._log_group_name}, "
                 f"log_stream_name={log_stream_name}"
             )
-            raise
 
     def put_message(self, log_stream_suffix: str, message: LogMessage):
         data = {log_stream_suffix: message}


### PR DESCRIPTION
# What is this PR?
This PR makes it possible to send logs even if the order of launching the http proxy server and ota-client is different.
The previous implementation dropped ota-client log at the beginning.

# test
This PR is confirmed by OTA image with https://github.com/tier4/autoware_ecu_system_setup/pull/154