### PR TITLE
Fix test files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     container_name: ota-client
     volumes:
       - ./app:/ota-client/app:ro
+      - ./ota_proxy:/ota-client/ota_proxy:ro
       - ./tests:/ota-client/tests:ro
       - ./aws-iot-log-server:/ota-client/aws-iot-log-server:ro
     depends_on:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,11 @@
 import pytest
 import sys
-import os
 
+from pathlib import Path
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="session")
 def pythonpath():
-    sys.path.append(
-        os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + "/../app/")
+    _base_dir = Path(__file__).absolute().parent.parent
+    sys.path.extend(
+        [str(_base_dir), str(_base_dir / "app")]
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,8 @@ import sys
 
 from pathlib import Path
 
+
 @pytest.fixture(autouse=True, scope="session")
 def pythonpath():
     _base_dir = Path(__file__).absolute().parent.parent
-    sys.path.extend(
-        [str(_base_dir), str(_base_dir / "app")]
-    )
+    sys.path.extend([str(_base_dir), str(_base_dir / "app")])

--- a/tests/test_ota_client_service.py
+++ b/tests/test_ota_client_service.py
@@ -4,9 +4,11 @@ import grpc
 import json
 from unittest.mock import ANY
 
+from pytest_mock import MockerFixture
+
 
 @pytest.fixture
-def start_service_with_ota_client_mock(mocker):
+def start_service_with_ota_client_mock(mocker: MockerFixture):
     from ota_client_service import (
         OtaClientServiceV2,
         service_start,
@@ -20,6 +22,7 @@ def start_service_with_ota_client_mock(mocker):
     mocker.patch("ota_client_stub.OtaClient", return_value=ota_client_mock)
 
     ota_client_stub = OtaClientStub()
+    mocker.patch.object(ota_client_stub, "_ensure_subecu_status")
 
     ota_client_service_v2 = OtaClientServiceV2(ota_client_stub)
 


### PR DESCRIPTION
# Introduction
This PR fix some issues in the test files to let pytest finish the test properly.

# Changes
1. add ota_proxy module to the test environment
2. conftest.py: minor fix on path adding
3. test_ota_client_service.py: mock `_ensure_subecu_status`