### PR TITLE
Fix large memory use caused by the use of multiprocessing.imap_unordered.

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,7 @@ pytest-mock==3.6.1
 pytest-cov==2.12.1
 pytest-custom-exit-code==0.3.0
 pytest-datadir==1.3.1
-black==21.6b0
+black==22.3.0
 grpcio-tools==1.40.0
 pyflakes==2.4.0
 requests-mock==1.9.3


### PR DESCRIPTION
### Supersede #117

# Introduction
Previously, I introduce `multiprocessing.imap_unordered` to accelerate the `RegularInf` parsing.
But after small scale tests with `memory profiling` and `timeit`, I found that comparing to the time it saves(around 10seconds), it consume 200MB~ extra memory, which is not so efficient.
This PR dips the use of `multiprocessing.imap_unordered`, and also reduce some memory footprint for `RegularInf` class.

# Test and result
For one mainecu and one subecu environment, the memory usage on the mainecu drops from `867M~` to `664M~`.