### PR TITLE
fix: use cp -T not to create {nvme}/boot/boot directory

### DIFF
--- a/app/extlinux_control.py
+++ b/app/extlinux_control.py
@@ -461,7 +461,7 @@ class CBootControlMixin(BootControlInterface):
         unneeded_files_set = dst_dir_files_set - src_dir_files_set
 
         # copy the /boot folder from standby slot to boot dev unconditionally
-        _cmd = f"cp -rdp {src_dir} {dst_dir}"
+        _cmd = f"cp -rdpT {src_dir} {dst_dir}"
         try:
             _subprocess_call(_cmd, raise_exception=True)
         except Exception as e:


### PR DESCRIPTION
# About this PR.
Current implementation copies {standby nvme}/boot to {standby emmc}/boot and {standby emmc}/boot/boot is created as a result.
This PR added -T option not to create boot directory under {standby emmc}/boot.


# issue
https://tier4.atlassian.net/browse/T4PB-16833