### PR TITLE
Temporary fix for ota-proxy performance.

### DIFF
--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -71,9 +71,12 @@ class OtaProxyWrapper:
         import uvicorn
         from ota_proxy import App
 
+        # 20220413: Temporarily disable cache on ota-proxy
+        # to reduce performance bottleneck before the fix comes.
+        # Now ota_proxy will become a pure proxy server without cache
         uvicorn.run(
             App(
-                cache_enabled=enable_cache,
+                cache_enabled=False,
                 upper_proxy=proxy_cfg.upper_ota_proxy,
                 enable_https=proxy_cfg.gateway,
                 init_cache=init_cache,


### PR DESCRIPTION
# Introduction
Ota-update is much slower(5x times) with ota-proxy than without ota-proxy.
According to the investigation, the bottleneck is the cache entry committing into sqlite db in ota-proxy's cache implemenation.
This PR provide a first-aid fix to avoid this issue by disable the ota-proxy's cache mechanims, make ota-proxy a pure proxy server.

# Changes
1. cache mechanism is disabled for ota-proxy.
2. fix an issue of ota-cache module initializing.