### PR TITLE
Resolve ota-proxy performance bottleneck.

### DIFF
--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -71,12 +71,9 @@ class OtaProxyWrapper:
         import uvicorn
         from ota_proxy import App
 
-        # 20220413: Temporarily disable cache on ota-proxy
-        # to reduce performance bottleneck before the fix comes.
-        # Now ota_proxy will become a pure proxy server without cache
         uvicorn.run(
             App(
-                cache_enabled=False,
+                cache_enabled=enable_cache,
                 upper_proxy=proxy_cfg.upper_ota_proxy,
                 enable_https=proxy_cfg.gateway,
                 init_cache=init_cache,

--- a/ota_proxy/config.py
+++ b/ota_proxy/config.py
@@ -56,7 +56,6 @@ class ColField:
 class Config:
     BASE_DIR: str = "/ota-cache"
     CHUNK_SIZE: int = 4 * 1024 * 1024  # 4MB
-    REMOTE_CHUNK_SIZE: int = 1 * 1024 * 1024  # 1MB
     DISK_USE_LIMIT_SOTF_P = 60  # in p%
     DISK_USE_LIMIT_HARD_P = 70  # in p%
     DISK_USE_PULL_INTERVAL = 2  # in seconds

--- a/ota_proxy/db.py
+++ b/ota_proxy/db.py
@@ -166,6 +166,9 @@ class DBProxy:
         # 1 thread is enough according to small scale test
         self._db_executor = ThreadPoolExecutor(max_workers=1, initializer=_initializer)
 
+    def close(self):
+        self._db_executor.shutdown(wait=True)
+
     def __getattr__(self, key: str):
         """Passthrough method call by dot operator to threadpool."""
 

--- a/ota_proxy/db.py
+++ b/ota_proxy/db.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from dataclasses import make_dataclass
 from pathlib import Path
 from threading import Lock
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Generator, List, Tuple
 
 from .config import config as cfg
 
@@ -58,53 +58,58 @@ class OTACacheDB:
         + ", ".join([f"{k} {v.col_def}" for k, v in cfg.COLUMNS.items()])
         + ")"
     )
+    ROW_SHAPE = ",".join(["?"] * CacheMeta.shape())
 
     def __init__(self, db_file: str, init=False):
         logger.debug("init database...")
         self._db_file = db_file
-        self._wlock = Lock()
-        self._closed = False
-
         self._connect_db(init)
 
     @contextmanager
     def _general_query(self, query: str, query_param: List[Any], /, *, init=False):
-        if not init and self._closed:
-            raise sqlite3.OperationalError("connect is closed")
-
-        _query_method = query.strip().split(" ")[0]
-
         cur = self._con.cursor()
         _query_handler = cur.execute
-        if _query_method in {"INSERT", "DELETE"}:
-            _query_handler = cur.executemany
-
-        _query_handler(query, query_param)
 
         try:
+            _query_method = query.strip().split(" ")[0]
+            if _query_method in {"INSERT", "DELETE"}:
+                _query_handler = cur.executemany
+
+            _query_handler(query, query_param)
+            if _query_method in {"INSERT", "DELETE"}:
+                self._con.commit()
             yield cur
+        except sqlite3.Error as e:
+            # if any exception happens, rollback the latest transaction
+            self._con.rollback()
+            logger.debug(f"db {query=} error: {e!r}")
         finally:
             cur.close()
 
-    def close(self):
-        logger.debug("closing db...")
-        if not self._closed:
-            self._con.close()
-            self._closed = True
-
     def _init_table(self):
         logger.debug("init sqlite database...")
-        with self._general_query(self.INIT_DB, (), init=True):
+        _cur = self._con.cursor()
+        try:
+            _cur.execute(self.INIT_DB, ())
             self._con.commit()
+        except sqlite3.Error as e:
+            logger.error(f"init table failed: {e!r}")
+            raise
+        finally:
+            _cur.close()
 
     def _connect_db(self, init: bool):
         if init:
             Path(self._db_file).unlink(missing_ok=True)
 
-        self._con = sqlite3.connect(self._db_file, check_same_thread=False)
+        self._con = sqlite3.connect(
+            self._db_file,
+            check_same_thread=True,  # one thread per connection in the threadpool
+            isolation_level=None,  # enable autocommit mode
+        )
         self._con.row_factory = sqlite3.Row
 
-        # check if the table exists
+        # check if the table exists/check whether the db file is valid
         with self._general_query(
             "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
             (self.TABLE_NAME,),
@@ -113,28 +118,26 @@ class OTACacheDB:
             if cur.fetchone() is None:
                 self._init_table()
 
+            # enable WAL mode
+            self._con.execute("PRAGMA journal_mode=WAL;")
+
     def remove_url_by_hash(self, *hash: str):
         hash = [(h,) for h in hash]
-        with self._wlock, self._general_query(
-            f"DELETE FROM {self.TABLE_NAME} WHERE hash=?", hash
-        ):
-            self._con.commit()
+        with self._general_query(f"DELETE FROM {self.TABLE_NAME} WHERE hash=?", hash):
+            pass
 
     def remove_urls(self, *urls: str):
         urls = [(u,) for u in urls]
-        with self._wlock, self._general_query(
-            f"DELETE FROM {self.TABLE_NAME} WHERE url=?", urls
-        ):
-            self._con.commit()
+        with self._general_query(f"DELETE FROM {self.TABLE_NAME} WHERE url=?", urls):
+            pass
 
     def insert_urls(self, *cache_meta: CacheMeta):
         rows = [m.to_tuple() for m in cache_meta]
-        _row_shape = ",".join(["?"] * CacheMeta.shape())
-        with self._wlock, self._general_query(
-            f"INSERT OR REPLACE INTO {self.TABLE_NAME} VALUES ({_row_shape})",
+        with self._general_query(
+            f"INSERT OR REPLACE INTO {self.TABLE_NAME} VALUES ({self.ROW_SHAPE})",
             rows,
         ):
-            self._con.commit()
+            pass
 
     def lookup_url(self, url: str) -> CacheMeta:
         with self._general_query(
@@ -142,7 +145,7 @@ class OTACacheDB:
         ) as cur:
             return CacheMeta.row_to_meta(cur.fetchone())
 
-    def lookup_all(self) -> CacheMeta:
+    def lookup_all(self) -> Generator[CacheMeta, None, None]:
         with self._general_query(f"SELECT * FROM {self.TABLE_NAME}", ()) as cur:
             for row in cur.fetchall():
                 yield CacheMeta.row_to_meta(row)

--- a/ota_proxy/ota_cache.py
+++ b/ota_proxy/ota_cache.py
@@ -249,11 +249,11 @@ class OTAFile:
         Backoff retry is applied here to allow delays of data chunks arrived in the queue.
 
         This method should be called when the OTAFile instance is created.
-        A callback method should be register when the caching task is dispatched.
-        Check OTACache.retrieve_file for callback registeration details.
+        A callback method should be assigned when this method is called.
 
-        Returns:
-            The OTAFile instance itself for cache entry registeration on callback.
+        Args:
+            callback Callable[[OTAFile,], None]:
+                a callback function to do post-caching jobs
         """
         if not self._store_cache or not self._storage_below_hard_limit:
             # call callback function even we don't cache anything
@@ -458,7 +458,6 @@ class OTACache:
         self._scrub_cache_event = scrub_cache_event
 
         self._chunk_size = cfg.CHUNK_SIZE
-        self._remote_chunk_size = cfg.REMOTE_CHUNK_SIZE
         self._base_dir = Path(cfg.BASE_DIR)
         self._closed = False
         self._cache_enabled = cache_enabled
@@ -757,9 +756,7 @@ class OTACache:
                     ),
                 )
 
-                async for data in response.content.iter_chunked(
-                    self._remote_chunk_size
-                ):
+                async for data, _ in response.content.iter_chunks():
                     yield data
 
         # start the fp

--- a/ota_proxy/ota_cache.py
+++ b/ota_proxy/ota_cache.py
@@ -858,10 +858,8 @@ class OTACache:
                 )
 
                 # dispatch the background cache writing to executor
-                loop = asyncio.get_running_loop()
-                fut = loop.run_in_executor(
-                    self._executor,
-                    partial(res.background_write_cache, self._register_cache_callback),
+                self._executor.submit(
+                    res.background_write_cache, self._register_cache_callback
                 )
                 return res
 

--- a/ota_proxy/ota_cache.py
+++ b/ota_proxy/ota_cache.py
@@ -505,7 +505,8 @@ class OTACache:
             # dispatch a background task to pulling the disk usage info
             self._executor.submit(self._background_check_free_space)
 
-            self._db = db.OTACacheDB(cfg.DB_FILE)
+            # NOTE: type hint proxy class as its target class
+            self._db: db.OTACacheDB = db.DBProxy(cfg.DB_FILE)
 
             if upper_proxy:
                 # if upper proxy presented, we must disable https

--- a/ota_proxy/ota_cache.py
+++ b/ota_proxy/ota_cache.py
@@ -335,7 +335,7 @@ class OTAFile:
                 # to caching thread
                 if self._store_cache:
                     if not self._cache_aborted.is_set():
-                        await self._queue.put_nowait(chunk)
+                        self._queue.put_nowait(chunk)
 
                 # to uvicorn thread
                 yield chunk


### PR DESCRIPTION
# Introduction
This PR tries to resolve the bottleneck of ota-proxy performance caused by inefficient db operation implementation.

# Changes
1. remove lock in OTACacheDB class, use sqlite3’s own lock mechanism instead
2. enable WAL mode and autocommit
3. serialize requests by dispatch all db requests to a dedicated threadpool
4. refactor some parts of ota-cache module
5. minor changes:
5.1 ditch the usage of `janus.queue` as it is not so necessary in our implementation
5.2 using the std queue
5.3 decrease the backoff timeout of queue.get to 1ms

# Result on small scale test
with ota-image of 1.9G, containing 73543 files
before: 490+s
after: 150+s

# Result on VM test
1. number of download errors significantly lower now(less than 10 per 100,000 requests)
2. memory usage of ota-proxy also stable now(a potential memory leak is fixed)
3. (BUG) it seems that there are some bugs in cache renews logics when space soft limit is reached, will be addressed in a new PR in the future.

# TODO
- [x] small scale test 
- [x] test on VM(standalone)