### PR TITLE
ota_client: create_regular_files refactor

### DIFF
--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -9,12 +9,7 @@ import tempfile
 import threading
 import time
 import weakref
-from concurrent.futures import (
-    FIRST_EXCEPTION,
-    ThreadPoolExecutor,
-    Future,
-    wait as concurrent_futures_wait,
-)
+from concurrent.futures import ThreadPoolExecutor, Future
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum, unique
@@ -24,7 +19,7 @@ from json.decoder import JSONDecodeError
 from pathlib import Path
 from queue import Queue
 from threading import Event, Lock
-from typing import Any, Dict, List, Tuple, TypeVar, Union
+from typing import Any, Dict, List, Tuple, Union
 from urllib.parse import quote_from_bytes, urlparse, urljoin
 
 from ota_client_interface import OtaClientInterface
@@ -576,7 +571,7 @@ class _CreateRegularStatsCollector:
         _cur_time = time.time()
         while True:
             if self.abort_event.is_set():
-                logger.error(f"abort event is set, collector exits")
+                logger.error("abort event is set, collector exits")
                 break
 
             if self._store.get_processed_num() < total_num:

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -957,7 +957,7 @@ class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
         with tempfile.TemporaryDirectory(prefix=__name__) as d:
             file_name = Path(d) / list_info["file"]
             # NOTE: do not use cache when fetching symlink list
-            self._downloader(
+            self._downloader.download(
                 list_info["file"],
                 file_name,
                 list_info["hash"],
@@ -991,11 +991,9 @@ class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
             # create a bounded downloader that pre-loads some options
             boot_standby_path = self.get_standby_boot_partition_path()
             _downloader = partial(
-                self._downloader,
+                self._downloader.download,
                 url_base=url_rootfsdir,
                 cookies=cookies,
-                standby_path=standby_path,
-                boot_standby_path=boot_standby_path,
             )
 
             self._create_regular_files(

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -1134,6 +1134,10 @@ class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
         downloader,
     ) -> _RegularStats:
         # thread_time for multithreading function
+        # NOTE: for multithreading implementation,
+        # when a thread is sleeping, the GIL will be released
+        # and other thread will take the place to execute,
+        # so we use time.thread_time here.
         begin_time = time.thread_time()
 
         processed = _RegularStats()

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -685,7 +685,7 @@ class _HardlinkRegister:
 
 
 class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
-    MAX_CONCURRENT_DOWNLOAD_TASKS = 16384
+    MAX_CONCURRENT_DOWNLOAD_TASKS = 2048
     MAX_DOWNLOAD_WORKERS = 7
     COLLECT_INTERVAL = 1  # sec
 

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -649,6 +649,7 @@ class _HardlinkTracker:
 
     def writer_on_failed(self):
         self._failed.set()
+        self._ref_holder.clear()
 
     def subscribe(self) -> Path:
         # wait for writer
@@ -1177,14 +1178,15 @@ class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
                     )
                     processed.op = "download"
 
-                    if is_hardlink and _is_writer:
-                        # writer indicates that the first copy of hardlink is ready
-                        _hardlink_tracker.writer_done()
+                if is_hardlink and _is_writer:
+                    # writer indicates that the first copy of hardlink is ready
+                    _hardlink_tracker.writer_done()
             except Exception:
                 # signal all subscribers to abort
                 if is_hardlink and _is_writer:
                     _hardlink_tracker.writer_on_failed()
-                    raise
+
+                raise
 
         processed.size = dst.stat().st_size
 

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -207,6 +207,11 @@ class Downloader:
         if not headers:
             headers = dict()
 
+        # specially deal with empty file
+        if digest == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855":
+            dst.write_bytes(b"")
+            return 0
+
         try:
             error_count = 0
             response = self._session.get(

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -1,20 +1,29 @@
 import dataclasses
-import tempfile
+import json
+import os
+import queue
+import re
 import requests
 import shutil
-import re
-import os
+import tempfile
+import threading
 import time
-import json
-from typing import Any, Dict, Tuple, Union
+import weakref
+from concurrent.futures import (
+    ThreadPoolExecutor,
+    Future,
+    wait as concurrent_futures_wait,
+)
 from contextlib import contextmanager
-from hashlib import sha256
-from pathlib import Path
-from json.decoder import JSONDecodeError
-from multiprocessing import Pool, Manager
-from threading import Event, Lock
-from functools import partial
+from dataclasses import dataclass
 from enum import Enum, unique
+from functools import partial
+from hashlib import sha256
+from json.decoder import JSONDecodeError
+from pathlib import Path
+from queue import Queue
+from threading import Event, Lock
+from typing import Any, Dict, List, Tuple, TypeVar, Union
 from urllib.parse import quote_from_bytes, urlparse, urljoin
 
 from ota_client_interface import OtaClientInterface


### PR DESCRIPTION
# Introduction
This PR refactor the implementation of create_regular_files.
Previous implementation has the following problem:
1. large max memory usage
2. complicated implementation and sync logic
3. multiprocessing on I/O mainly tasks

# Changes
1. schedule and dispatch create_regular_file in thread-pool
2. new implementation for hardlink file handling
3. callback based stats collecting and processing
4. use `time.thread_time` to track the download time cost
5. special handling for empty file on `Downloader`(create file directly without request remote)
6. other minor updates

# TODO
- [x] local test
- [x] standalone vm test