### PR TITLE
Bug fix-20220513

### DIFF
--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -220,6 +220,10 @@ class OtaClientStub:
                 main_ecu = response.ecu.add()
                 main_ecu.ecu_id = entry.ecu_id
                 main_ecu.result = v2.FAILURE
+        # NOTE(20220513): is it illegal that ecu itself is not requested to update
+        # but its subecus do, but currently we just log errors for it
+        else:
+            logger.warning("entries in update request doesn't include this ecu")
 
         # wait for all sub ecu acknowledge ota update requests
         if len(tasks):  # if we have sub ecu to update

--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -104,7 +104,8 @@ class OtaProxyWrapper:
                 )
 
                 return self._server_p.pid
-        # sliently return if the server already started
+            else:
+                logger.warning(f"try to launch ota-proxy again")
 
     def wait_on_ota_cache(self, timeout: float = None):
         self._scrub_cache_event.wait(timeout=timeout)

--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -84,7 +84,7 @@ class OtaProxyWrapper:
             log_level="error",
             lifespan="on",
             workers=1,
-            limit_concurrency=64,
+            limit_concurrency=256,
         )
 
     def start(self, enable_cache=False, init_cache=True) -> int:

--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -105,7 +105,7 @@ class OtaProxyWrapper:
 
                 return self._server_p.pid
             else:
-                logger.warning(f"try to launch ota-proxy again")
+                logger.warning("try to launch ota-proxy again")
 
     def wait_on_ota_cache(self, timeout: float = None):
         self._scrub_cache_event.wait(timeout=timeout)

--- a/ota_proxy/config.py
+++ b/ota_proxy/config.py
@@ -84,7 +84,9 @@ class Config:
 
     # DB configuration/setup
     # ota-cache table
-    TABLE_NAME: str = "ota_cache"
+    # NOTE: use table name to keep track of table scheme version
+    TABLE_DEFINITION_VERSION = "v2"
+    TABLE_NAME: str = f"ota_cache_{TABLE_DEFINITION_VERSION}"
     COLUMNS: dict = field(
         default_factory=lambda: {
             "url": ColField(str, "TEXT UNIQUE NOT NULL PRIMARY KEY"),

--- a/ota_proxy/config.py
+++ b/ota_proxy/config.py
@@ -57,8 +57,8 @@ class ColField:
 class Config:
     BASE_DIR: str = "/ota-cache"
     CHUNK_SIZE: int = 4 * 1024 * 1024  # 4MB
-    DISK_USE_LIMIT_SOFT_P = 60  # in p%
-    DISK_USE_LIMIT_HARD_P = 70  # in p%
+    DISK_USE_LIMIT_SOFT_P = 70  # in p%
+    DISK_USE_LIMIT_HARD_P = 80  # in p%
     DISK_USE_PULL_INTERVAL = 2  # in seconds
     # value is the largest numbers of files that
     # might need to be deleted for the bucket to hold a new entry

--- a/ota_proxy/config.py
+++ b/ota_proxy/config.py
@@ -99,10 +99,8 @@ class Config:
         }
     )
 
-    OTA_CACHE_IDX: List[str] = field(
-        default_factory=lambda: [
-            "CREATE INDEX bucket_last_access_idx ON ota_cache(bucket, last_access)",
-        ]
+    BUCKET_LAST_ACCESS_IDX: str = (
+        f"CREATE INDEX bucket_last_access_idx ON {TABLE_NAME}(bucket, last_access)"
     )
 
 

--- a/ota_proxy/db.py
+++ b/ota_proxy/db.py
@@ -58,7 +58,9 @@ class OTACacheDB:
         + ", ".join([f"{k} {v.col_def}" for k, v in cfg.COLUMNS.items()])
         + ")"
     )
-    OTA_CACHE_IDX: List[str] = cfg.OTA_CACHE_IDX
+    OTA_CACHE_IDX: List[str] = [
+        cfg.BUCKET_LAST_ACCESS_IDX,
+    ]
     ROW_SHAPE = ",".join(["?"] * CacheMeta.shape())
 
     def __init__(self, db_file: str, init=False):

--- a/ota_proxy/ota_cache.py
+++ b/ota_proxy/ota_cache.py
@@ -551,8 +551,12 @@ class OTACache:
                 # scrub the cache folder
                 _scrub_cache = OTACacheScrubHelper()
                 _scrub_cache()
-                if scrub_cache_event:
-                    scrub_cache_event.set()
+
+            # set scrub_cache_event after init/scrub cache
+            # TODO: passthrough the exception to the ota_client process
+            # if the init/scrub failed
+            if scrub_cache_event:
+                scrub_cache_event.set()
 
             # dispatch a background task to pulling the disk usage info
             self._executor.submit(self._background_check_free_space)
@@ -569,6 +573,9 @@ class OTACache:
 
         else:
             self._cache_enabled = False
+            # event cache is not set, still remember to set the scrub_cache_event!!!
+            if scrub_cache_event:
+                scrub_cache_event.set()
 
     def close(self):
         """Shutdowns OTACache instance.

--- a/ota_proxy/ota_cache.py
+++ b/ota_proxy/ota_cache.py
@@ -950,40 +950,47 @@ class OTACache:
 
         # case 2: no valid cache entry presented, try to cache the requested file
         if no_cache_available:
-            logger.debug(f"try to download and cache {url=}")
+            logger.debug(f"no cache entry for {url=}")
 
-            # case 2.1: download and cache new file
-            _tracker, is_writer = await self._on_going_caching.get_tracker(url)
-            if is_writer:
-                _remote_fp, meta = await self._open_fp_by_requests(
-                    url, cookies, extra_headers, _tracker
-                )
-
-                ota_file = OTAFile(
-                    _remote_fp,
-                    meta,
-                    below_hard_limit_event=self._storage_below_hard_limit_event,
-                )
-
-                # NOTE: bind the tracker to the callback function
-                self._executor.submit(
-                    ota_file.background_write_cache,
-                    _tracker,
-                    self._register_cache_callback,
-                )
-
-                fp = ota_file.get_chunks()
+            # case 2.1: reache storage hardlimit, directly download file without caching it
+            if not self._storage_below_hard_limit_event.is_set():
+                fp, meta = await self._open_fp_by_requests(url, cookies, extra_headers)
                 return fp, meta
 
-            # case 2.2: respond by cache streaming
+            # case 2.2: normal caching
             else:
-                # if this tracker is failed, drop it
-                if _tracker._is_failed:
-                    raise ValueError(f"cache corrupted on {_tracker.fn}, abort")
+                # case 2.2.1: download and cache new file
+                _tracker, is_writer = await self._on_going_caching.get_tracker(url)
+                if is_writer:
+                    _remote_fp, meta = await self._open_fp_by_requests(
+                        url, cookies, extra_headers, _tracker
+                    )
 
-                logger.debug(f"enable cache streaming for {url=}")
-                fp = await self._open_fp_by_cache_streaming(_tracker)
-                return fp, _tracker.meta
+                    ota_file = OTAFile(
+                        _remote_fp,
+                        meta,
+                        below_hard_limit_event=self._storage_below_hard_limit_event,
+                    )
+
+                    # NOTE: bind the tracker to the callback function
+                    self._executor.submit(
+                        ota_file.background_write_cache,
+                        _tracker,
+                        self._register_cache_callback,
+                    )
+
+                    fp = ota_file.get_chunks()
+                    return fp, meta
+
+                # case 2.2.2: respond by cache streaming
+                else:
+                    # if this tracker is failed, drop it
+                    if _tracker._is_failed:
+                        raise ValueError(f"cache corrupted on {_tracker.fn}, abort")
+
+                    logger.debug(f"enable cache streaming for {url=}")
+                    fp = await self._open_fp_by_cache_streaming(_tracker)
+                    return fp, _tracker.meta
 
         # case 3: cache is available and valid, use cache
         else:

--- a/ota_proxy/server_app.py
+++ b/ota_proxy/server_app.py
@@ -151,7 +151,6 @@ class App:
         # pass cookies and other headers needed for proxy into the ota_cache module
         cookies_dict: Dict[str, str] = dict()
         extra_headers: Dict[str, str] = dict()
-
         # currently we only need cookie and/or authorization header
         # also parse OTA-File-Cache-Control header
         ota_cache_control_policies = set()
@@ -170,10 +169,12 @@ class App:
                     # also preserved the raw headers value string
                     extra_headers[OTAFileCacheControl.header.value] = header[1].decode()
                 except KeyError:
-                    logger.debug(
-                        f"{url=}: "
-                        f"ignore bad OTA-File-Cache-Control headers: {header[1]}"
+                    await self._respond_with_error(
+                        HTTPStatus.BAD_REQUEST,
+                        f"bad OTA-File-Cache-Control headers: {header[1]}",
+                        send,
                     )
+                    return
 
         respond_started = False
         try:

--- a/ota_proxy/server_app.py
+++ b/ota_proxy/server_app.py
@@ -151,6 +151,7 @@ class App:
         # pass cookies and other headers needed for proxy into the ota_cache module
         cookies_dict: Dict[str, str] = dict()
         extra_headers: Dict[str, str] = dict()
+
         # currently we only need cookie and/or authorization header
         # also parse OTA-File-Cache-Control header
         ota_cache_control_policies = set()
@@ -169,12 +170,10 @@ class App:
                     # also preserved the raw headers value string
                     extra_headers[OTAFileCacheControl.header.value] = header[1].decode()
                 except KeyError:
-                    await self._respond_with_error(
-                        HTTPStatus.BAD_REQUEST,
-                        f"bad OTA-File-Cache-Control headers: {header[1]}",
-                        send,
+                    logger.debug(
+                        f"{url=}: "
+                        f"ignore bad OTA-File-Cache-Control headers: {header[1]}"
                     )
-                    return
 
         respond_started = False
         try:


### PR DESCRIPTION
# Introduction
This PR fix bugs found on the 20220513 benchmark test.

# Bugs and fix
1. when space hardlimit reached, ota-update will failed
    cause: when reached hardlimit, cache will be disable, failing the cache stream
    solution: disable cache stream when storage reach hardlimit
2. ota-client will hang if apply ota-update when status==SUCCESS
    cause: scrub_cache_event is not set under status==SUCCESS or cache_init=True but ota_client_service always wait for the event
    solution: set scrub_cache_event in all needed situation
3. ota-client will fail if the ota-proxy database scheme changed
    solution: database scheme version is recorded now and reflected in the database table name

# Other changes
1. ota_proxy.uvicorn: concurrency limit raises up to 256
2. disk usage limit raises from 60:70 to 70:80
3. ~~unknown OTA-File-Cache-Control headers will be ignored instead of failing the request~~
5. database scheme now has version control, and version is embedded in the table_name