### PR TITLE
New way to limit resource usage for ota-client during ota-update.

### DIFF
--- a/app/configs.py
+++ b/app/configs.py
@@ -95,9 +95,13 @@ class _BaseConfig:
     )
     MOUNT_POINT: str = "/mnt/standby"
 
-    # ota-update download setting
+    # ota-client behavior setting
+    CHUNK_SIZE: int = 1 * 1024 * 1024  # 1MB
+    DOWNLOAD_RETRY: int = 5
+    DOWNLOAD_BACKOFF_MAX: int = 10 # seconds
     MAX_CONCURRENT_DOWNLOAD: int = 16
     MAX_CONCURRENT_TASKS: int = 128
+    STATS_COLLECT_INTERVAL: int = 1 # second
 
 
 @dataclass

--- a/app/configs.py
+++ b/app/configs.py
@@ -95,6 +95,10 @@ class _BaseConfig:
     )
     MOUNT_POINT: str = "/mnt/standby"
 
+    # ota-update download setting
+    MAX_CONCURRENT_DOWNLOAD: int = 16
+    MAX_CONCURRENT_TASKS: int = 128
+
 
 @dataclass
 class GrubControlConfig(_BaseConfig):

--- a/app/configs.py
+++ b/app/configs.py
@@ -99,8 +99,8 @@ class _BaseConfig:
     CHUNK_SIZE: int = 1 * 1024 * 1024  # 1MB
     DOWNLOAD_RETRY: int = 5
     DOWNLOAD_BACKOFF_MAX: int = 10 # seconds
-    MAX_CONCURRENT_DOWNLOAD: int = 16
-    MAX_CONCURRENT_TASKS: int = 128
+    MAX_CONCURRENT_DOWNLOAD: int = 8
+    MAX_CONCURRENT_TASKS: int = 1024
     STATS_COLLECT_INTERVAL: int = 1 # second
 
 

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -1190,13 +1190,12 @@ class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
                 else:
                     # limit the concurrent downloading tasks
                     with download_limiter:
-                        if True:
-                            processed.errors = downloader(
-                                reginf.path,
-                                dst,
-                                reginf.sha256hash,
-                            )
-                            processed.op = "download"
+                        processed.errors = downloader(
+                            reginf.path,
+                            dst,
+                            reginf.sha256hash,
+                        )
+                        processed.op = "download"
 
                 # when first copy is ready(by copy or download),
                 # inform the subscriber

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -11,7 +11,7 @@ import time
 import weakref
 from concurrent.futures import ThreadPoolExecutor, Future
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum, unique
 from functools import partial
 from hashlib import sha256
@@ -19,7 +19,7 @@ from json.decoder import JSONDecodeError
 from pathlib import Path
 from queue import Queue
 from threading import Event, Lock
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import Any, Callable, ClassVar, Dict, List, Tuple, Union
 from urllib.parse import quote_from_bytes, urlparse, urljoin
 
 from ota_client_interface import OtaClientInterface
@@ -114,11 +114,11 @@ def _retry(retry, backoff_factor, backoff_max, func):
 
 
 class Downloader:
-    CHUNK_SIZE = 1 * 1024 * 1024  # 1MB
-    RETRY_COUNT = 5
+    CHUNK_SIZE = cfg.CHUNK_SIZE
+    RETRY_COUNT = cfg.DOWNLOAD_RETRY
     BACKOFF_FACTOR = 1
     OUTER_BACKOFF_FACTOR = 0.01
-    BACKOFF_MAX = 10
+    BACKOFF_MAX = cfg.DOWNLOAD_BACKOFF_MAX
     MAX_CONCURRENT_DOWNLOAD = cfg.MAX_CONCURRENT_DOWNLOAD
 
     def __init__(self):
@@ -697,7 +697,7 @@ class _HardlinkRegister:
 class _BaseOtaClient(OtaStatusControlMixin, OtaClientInterface):
     MAX_CONCURRENT_DOWNLOAD = cfg.MAX_CONCURRENT_DOWNLOAD
     MAX_CONCURRENT_TASKS = cfg.MAX_CONCURRENT_TASKS
-    COLLECT_INTERVAL = 1  # sec
+    COLLECT_INTERVAL = cfg.STATS_COLLECT_INTERVAL  # sec
 
     def __init__(self):
         self._lock = Lock()  # NOTE: can't be referenced from pool.apply_async target.

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -19,7 +19,7 @@ from json.decoder import JSONDecodeError
 from pathlib import Path
 from queue import Queue
 from threading import Event, Lock
-from typing import Any, Callable, ClassVar, Dict, List, Tuple, Union
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple, Union
 from urllib.parse import quote_from_bytes, urlparse, urljoin
 
 from ota_client_interface import OtaClientInterface
@@ -319,7 +319,7 @@ class RegularInf:
     gid: int
     nlink: int
     sha256hash: str
-    size: int
+    size: Optional[int]
     _path: Path
 
     _reginf_pa: ClassVar[re.Pattern] = re.compile(
@@ -398,32 +398,24 @@ class OtaClientStatistics:
         self._slot = _OtaClientStatisticsStorage()
 
     def get_snapshot(self):
-        """
-        return a copy of statistics storage
-        """
+        """Return a copy of statistics storage."""
         return self._slot.copy()
 
     def get_processed_num(self) -> int:
         return self._slot.regular_files_processed
 
     def set(self, attr: str, value):
-        """
-        set a single attr in the slot
-        """
+        """Set a single attr in the slot."""
         with self._lock:
             setattr(self._slot, attr, value)
 
     def clear(self):
-        """
-        clear the storage slot and reset to empty
-        """
+        """Clear the storage slot and reset to empty."""
         self._slot = _OtaClientStatisticsStorage()
 
     @contextmanager
     def acquire_staging_storage(self):
-        """
-        acquire a staging storage for updating the slot atomically and thread-safely
-        """
+        """Acquire a staging storage for updating the slot atomically and thread-safely."""
         try:
             self._lock.acquire()
             staging_slot: _OtaClientStatisticsStorage = self._slot.copy()


### PR DESCRIPTION
# Introduction
Previously, we directly cap the `max_workers` of threadpool to `7` for all operations(copy, link, download).
That is not so flexible and not so compatible to different machine. This PR changes the limitation mechanism from capping `max_workers` of threadpool, to using `Semaphore` to limit the total number concurrent tasks(copy, link, download), and apply another Semaphore to specially limit the on-going downloading tasks.

# Changes
1. Apply semaphore(set to 128 currently) to all operations(copy, link, download).
2. Apply semaphore(set to 16 currently) to download operation.
3. Above settings and some other settings are configured at `configs.py`.
4. Use dataclass for all Inf class.

# TODO
- [x] regression test on VM.