### PR TITLE
Support new RegularInf scheme and cleanup Inf related classes.

### DIFF
--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -2,7 +2,6 @@ import dataclasses
 import json
 import os
 import queue
-import re
 import requests
 import shutil
 import tempfile
@@ -11,7 +10,7 @@ import time
 import weakref
 from concurrent.futures import ThreadPoolExecutor, Future
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum, unique
 from functools import partial
 from hashlib import sha256
@@ -19,11 +18,17 @@ from json.decoder import JSONDecodeError
 from pathlib import Path
 from queue import Queue
 from threading import Event, Lock
-from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Tuple, Union
 from urllib.parse import quote_from_bytes, urlparse, urljoin
 
 from ota_client_interface import OtaClientInterface
-from ota_metadata import OtaMetadata
+from ota_metadata import (
+    OtaMetadata,
+    RegularInf,
+    DirectoryInf,
+    SymbolicLinkInf,
+    PersistentInf,
+)
 from ota_status import OtaStatus, OtaStatusControlMixin
 from ota_error import OtaErrorUnrecoverable, OtaErrorRecoverable, OtaErrorBusy
 from copy_tree import CopyTree
@@ -240,108 +245,6 @@ class Downloader:
             raise _ExceptionWrapper(url) from e
 
         return error_count
-
-
-def de_escape(s: str) -> str:
-    return s.replace(r"'\''", r"'")
-
-
-@dataclass
-class _BaseInf:
-    mode: int
-    uid: int
-    gid: int
-    _left: str = field(init=False, compare=False, repr=False)
-
-    _base_pattern: ClassVar[re.Pattern] = re.compile(
-        r"(?P<mode>\d+),(?P<uid>\d+),(?P<gid>\d+),(?P<left_over>.*)"
-    )
-
-    def __init__(self, info: str):
-        match_res: re.Match = self._base_pattern.match(info.strip())
-        assert match_res is not None, f"match base_inf failed: {info}"
-
-        self.mode = int(match_res.group("mode"), 8)
-        self.uid = int(match_res.group("uid"))
-        self.gid = int(match_res.group("gid"))
-        self._left: str = match_res.group("left_over")
-
-
-@dataclass
-class DirectoryInf(_BaseInf):
-    """Directory file information class."""
-
-    path: Path
-
-    def __init__(self, info):
-        super().__init__(info)
-        self.path = Path(de_escape(self._left[1:-1]))
-
-        del self._left
-
-
-@dataclass
-class SymbolicLinkInf(_BaseInf):
-    """Symbolik link information class."""
-
-    slink: Path
-    srcpath: Path
-
-    _pattern: ClassVar[re.Pattern] = re.compile(
-        r"'(?P<link>.+)((?<!\')',')(?P<target>.+)'"
-    )
-
-    def __init__(self, info):
-        super().__init__(info)
-        res = self._pattern.match(self._left)
-        assert res is not None, f"match symlink failed: {info}"
-
-        self.slink = Path(de_escape(res.group("link")))
-        self.srcpath = Path(de_escape(res.group("target")))
-
-        del self._left
-
-
-@dataclass
-class PersistentInf:
-    """Persistent file information class."""
-
-    path: Path
-
-    def __init__(self, info: str):
-        self.path = Path(de_escape(info[1:-1]))
-
-
-@dataclass
-class RegularInf:
-    mode: int
-    uid: int
-    gid: int
-    nlink: int
-    sha256hash: str
-    size: Optional[int]
-    _path: Path
-
-    _reginf_pa: ClassVar[re.Pattern] = re.compile(
-        r"(?P<mode>\d+),(?P<uid>\d+),(?P<gid>\d+),(?P<nlink>\d+),(?P<hash>\w+),'(?P<path>.+)'(,(?P<size>\d+))?"
-    )
-
-    def __init__(self, _input: str):
-        _ma = self._reginf_pa.match(_input)
-        assert _ma is not None, f"matching reg_inf failed for {_input}"
-
-        self.mode = int(_ma.group("mode"), 8)
-        self.uid = int(_ma.group("uid"))
-        self.gid = int(_ma.group("gid"))
-        self.nlink = int(_ma.group("nlink"))
-        self.sha256hash = _ma.group("hash")
-        self._path = de_escape(_ma.group("path"))
-        _size = _ma.group("size")
-        self.size = int(_size) if _size is not None else None
-
-    @property
-    def path(self) -> Path:
-        return Path(self._path)
 
 
 @unique


### PR DESCRIPTION
# Introduction
1. This PR introduce the support for new new RegularInf scheme that supports distinguishing hardlink group.
The new format for RegularInf is defined as follow:
```python3
# add support for distinguishing hardlink group
format: mode,uid,gid,link number,sha256sum,'path/to/file'[,size[,inode]]
example: 0644,1000,1000,1,0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef,'path/to/file',1234,12345678

NOTE: size and inode sections are both optional, if inode exists, size must exist.
```
2. relocate Inf related classes to `ota_metadata.py`.
3. introduce tests files for Inf related classes.
4. update hardlink tracker to support hardlink group.