### PR TITLE
Refinement on otastatus transition logic

### DIFF
--- a/app/boot_control/cboot.py
+++ b/app/boot_control/cboot.py
@@ -354,7 +354,7 @@ class CBootController(
 
         # FAILURE, INITIALIZED and ROLLBACK_FAILURE are remained as it
 
-        self.store_current_ota_status(_ota_status)
+        self._store_current_ota_status(_ota_status)
         logger.info(f"loaded ota_status: {_ota_status}")
         return _ota_status
 

--- a/app/boot_control/cboot.py
+++ b/app/boot_control/cboot.py
@@ -329,7 +329,15 @@ class CBootController(
 
     def _init_boot_control(self):
         """Init boot control and ota-status on start-up."""
+        # load ota_status str and slot_in_use
         _ota_status = self._load_current_ota_status()
+        _slot_in_use = self._load_current_slot_in_use()
+        if not (_ota_status and _slot_in_use):
+            logger.info("initializing boot control files...")
+            _ota_status = OTAStatusEnum.INITIALIZED
+            self._store_current_slot_in_use(Nvbootctrl.get_current_slot())
+            self._store_current_ota_status(OTAStatusEnum.INITIALIZED)
+
         if _ota_status in [OTAStatusEnum.UPDATING, OTAStatusEnum.ROLLBACKING]:
             if self._is_switching_boot():
                 # set the current slot(switched slot) as boot successful
@@ -341,11 +349,6 @@ class CBootController(
                     _ota_status = OTAStatusEnum.ROLLBACK_FAILURE
                 else:
                     _ota_status = OTAStatusEnum.FAILURE
-
-        if _ota_status not in [OTAStatusEnum.FAILURE, OTAStatusEnum.ROLLBACK_FAILURE]:
-            # store slot_in_use file
-            current_slot = Nvbootctrl.get_current_slot()
-            self._store_current_slot_in_use(current_slot)
         # status except UPDATING/ROLLBACKING remained as it
 
         self.ota_status = _ota_status

--- a/app/boot_control/cboot.py
+++ b/app/boot_control/cboot.py
@@ -29,6 +29,7 @@ from app.errors import (
     BootControlPlatformUnsupported,
     BootControlPostRollbackFailed,
     BootControlPostUpdateFailed,
+    BootControlPreRollbackFailed,
     BootControlPreUpdateFailed,
 )
 from app.ota_status import OTAStatusEnum
@@ -322,41 +323,34 @@ class CBootController(
         ).relative_to("/")
 
         # init ota-status
-        self.ota_status = self._init_boot_control()
+        self._init_boot_control()
 
     ###### private methods ######
 
-    def _init_boot_control(self) -> OTAStatusEnum:
+    def _init_boot_control(self):
         """Init boot control and ota-status on start-up."""
         _ota_status = self._load_current_ota_status()
-
-        if _ota_status == OTAStatusEnum.UPDATING:
-            _ota_status = self._finalize_update()
-        elif _ota_status == OTAStatusEnum.ROLLBACKING:
-            _ota_status = self._finalize_rollback()
-        elif _ota_status == OTAStatusEnum.SUCCESS:
-            # need to check whether it is negative SUCCESS
-            current_slot = Nvbootctrl.get_current_slot()
-            try:
-                slot_in_use = self._load_current_slot_in_use()
-                # cover the case that device reboot into unexpected slot
-                if current_slot != slot_in_use:
-                    logger.error(
-                        f"boot into old slot {current_slot}, "
-                        f"should boot into {slot_in_use}"
-                    )
+        if _ota_status in [OTAStatusEnum.UPDATING, OTAStatusEnum.ROLLBACKING]:
+            if self._is_switching_boot():
+                # set the current slot(switched slot) as boot successful
+                self._cboot_control.mark_current_slot_boot_successful()
+                # switch ota_status
+                _ota_status = OTAStatusEnum.SUCCESS
+            else:
+                if _ota_status == OTAStatusEnum.ROLLBACKING:
+                    _ota_status = OTAStatusEnum.ROLLBACK_FAILURE
+                else:
                     _ota_status = OTAStatusEnum.FAILURE
 
-            except FileNotFoundError:
-                # init slot_in_use file and ota_status file
-                self._store_current_slot_in_use(current_slot)
-                _ota_status = OTAStatusEnum.INITIALIZED
+        if _ota_status not in [OTAStatusEnum.FAILURE, OTAStatusEnum.ROLLBACK_FAILURE]:
+            # store slot_in_use file
+            current_slot = Nvbootctrl.get_current_slot()
+            self._store_current_slot_in_use(current_slot)
+        # status except UPDATING/ROLLBACKING remained as it
 
-        # FAILURE, INITIALIZED and ROLLBACK_FAILURE are remained as it
-
+        self.ota_status = _ota_status
         self._store_current_ota_status(_ota_status)
-        logger.info(f"loaded ota_status: {_ota_status}")
-        return _ota_status
+        logger.info(f"boot control init finished, ota_status is {_ota_status}")
 
     def _is_switching_boot(self) -> bool:
         # evidence 1: nvbootctrl status
@@ -382,19 +376,6 @@ class CBootController(
             f"slot_in_use: {_is_slot_in_use}"
         )
         return _nvboot_res and _ota_status and _is_slot_in_use
-
-    def _finalize_update(self) -> OTAStatusEnum:
-        logger.debug("entering finalizing stage...")
-        if self._is_switching_boot():
-            logger.debug("changes applied succeeded")
-            # set the current slot(switched slot) as boot successful
-            self._cboot_control.mark_current_slot_boot_successful()
-            return OTAStatusEnum.SUCCESS
-        else:
-            logger.error("changes applied failed")
-            return OTAStatusEnum.FAILURE
-
-    _finalize_rollback = _finalize_update
 
     def _populate_boot_folder_to_separate_bootdev(self):
         # mount the actual standby_boot_dev now
@@ -423,15 +404,19 @@ class CBootController(
                 logger.error(_failure_msg)
                 # no need to raise to the caller
 
-    def _on_operation_failure(self):
-        """Failure registering and cleanup at failure."""
-        self._store_standby_ota_status(OTAStatusEnum.FAILURE)
-        logger.warning("on failure try to unmounting standby slot...")
-        self._umount_all(ignore_error=True)
-
     ###### public methods ######
     # also includes methods from OTAStatusMixin, VersionControlMixin
     # load_version, get_ota_status
+
+    def on_operation_failure(self):
+        """Failure registering and cleanup at failure."""
+        self._store_current_ota_status(OTAStatusEnum.FAILURE)
+        # when standby slot is not created, otastatus is not needed to be set
+        if CMDHelperFuncs.is_target_mounted(self.standby_slot_mount_point):
+            self._store_standby_ota_status(OTAStatusEnum.FAILURE)
+
+        logger.warning("on failure try to unmounting standby slot...")
+        self._umount_all(ignore_error=True)
 
     def get_standby_slot_path(self) -> Path:
         return self.standby_slot_mount_point
@@ -445,6 +430,11 @@ class CBootController(
 
     def pre_update(self, version: str, *, standby_as_ref: bool, erase_standby=False):
         try:
+            # store current slot status
+            _target_slot = self._cboot_control.get_standby_slot()
+            self._store_current_ota_status(OTAStatusEnum.FAILURE)
+            self._store_current_slot_in_use(_target_slot)
+
             # setup updating
             self._cboot_control.set_standby_slot_unbootable()
             self._prepare_and_mount_standby(
@@ -456,25 +446,21 @@ class CBootController(
                 active_dev=self._cboot_control.get_current_rootfs_dev(),
                 standby_as_ref=standby_as_ref,
             )
+
+            ### re-populate /boot/ota-status folder
             # create the ota-status folder unconditionally
             _ota_status_dir = self.standby_slot_mount_point / Path(
                 cfg.OTA_STATUS_DIR
             ).relative_to("/")
             _ota_status_dir.mkdir(exist_ok=True, parents=True)
-
             # store status to standby slot
             self._store_standby_ota_status(OTAStatusEnum.UPDATING)
             self._store_standby_version(version)
-
-            _target_slot = self._cboot_control.get_standby_slot()
-            self._store_current_slot_in_use(_target_slot)
             self._store_standby_slot_in_use(_target_slot)
 
             logger.info("pre-update setting finished")
-
         except _BootControlError as e:
             logger.error(f"failed on pre_update: {e!r}")
-            self._on_operation_failure()
             raise BootControlPreUpdateFailed from e
 
     def post_update(self):
@@ -488,6 +474,9 @@ class CBootController(
                 dst=_extlinux_cfg, ref=_extlinux_cfg
             )
 
+            # NOTE: we didn't prepare /boot/ota here,
+            #       process_persistent does this for us
+
             if self._cboot_control.is_external_rootfs_enabled():
                 logger.info(
                     "rootfs on external storage detected: "
@@ -500,11 +489,23 @@ class CBootController(
             logger.info("post update finished, rebooting...")
             self._umount_all(ignore_error=True)
             self._cboot_control.reboot()
-
         except _BootControlError as e:
             logger.error(f"failed on post_update: {e!r}")
-            self._on_operation_failure()
             raise BootControlPostUpdateFailed from e
+
+    def pre_rollback(self):
+        try:
+            self._store_current_ota_status(OTAStatusEnum.FAILURE)
+            self._prepare_and_mount_standby(
+                self._cboot_control.get_standby_rootfs_dev(),
+                erase=False,
+            )
+            # store ROLLBACKING status to standby
+            self._store_standby_ota_status(OTAStatusEnum.ROLLBACKING)
+        except Exception as e:
+            logger.error(f"failed on pre_rollback: {e!r}")
+            # TODO: bootcontrol prerollback failure
+            raise BootControlPreRollbackFailed from e
 
     def post_rollback(self):
         try:
@@ -512,5 +513,4 @@ class CBootController(
             self._cboot_control.reboot()
         except _BootControlError as e:
             logger.error(f"failed on post_rollback: {e!r}")
-            self._on_operation_failure()
             raise BootControlPostRollbackFailed from e

--- a/app/boot_control/cboot.py
+++ b/app/boot_control/cboot.py
@@ -468,7 +468,6 @@ class CBootController(
             raise BootControlPreUpdateFailed from e
 
     def post_update(self):
-        # TODO: deal with unexpected reboot during post_update
         try:
             # update extlinux_cfg file
             _extlinux_cfg = self.standby_slot_mount_point / Path(
@@ -488,10 +487,9 @@ class CBootController(
                 )
                 self._populate_boot_folder_to_separate_bootdev()
 
-            self._cboot_control.switch_boot()
-
             logger.info("post update finished, rebooting...")
             self._umount_all(ignore_error=True)
+            self._cboot_control.switch_boot()
             CMDHelperFuncs.reboot()
         except _BootControlError as e:
             logger.error(f"failed on post_update: {e!r}")

--- a/app/boot_control/cboot.py
+++ b/app/boot_control/cboot.py
@@ -258,14 +258,6 @@ class _CBootControl:
         slot = self.current_slot
         return Nvbootctrl.is_slot_marked_successful(slot)
 
-    @classmethod
-    def reboot(cls):
-        try:
-            subprocess_call("reboot", raise_exception=True)
-        except CalledProcessError:
-            logger.exception("failed to reboot")
-            raise
-
     def update_extlinux_cfg(self, dst: Path, ref: Path):
         def _replace(ma: re.Match, repl: str):
             append_l: str = ma.group(0)
@@ -500,7 +492,7 @@ class CBootController(
 
             logger.info("post update finished, rebooting...")
             self._umount_all(ignore_error=True)
-            self._cboot_control.reboot()
+            CMDHelperFuncs.reboot()
         except _BootControlError as e:
             logger.error(f"failed on post_update: {e!r}")
             raise BootControlPostUpdateFailed from e
@@ -522,7 +514,7 @@ class CBootController(
     def post_rollback(self):
         try:
             self._cboot_control.switch_boot()
-            self._cboot_control.reboot()
+            CMDHelperFuncs.reboot()
         except _BootControlError as e:
             logger.error(f"failed on post_rollback: {e!r}")
             raise BootControlPostRollbackFailed from e

--- a/app/boot_control/common.py
+++ b/app/boot_control/common.py
@@ -370,9 +370,7 @@ class SlotInUseMixin:
         write_to_file_sync(self.standby_ota_status_dir / cfg.SLOT_IN_USE_FNAME, _slot)
 
     def _load_current_slot_in_use(self) -> str:
-        return read_from_file(
-            self.current_ota_status_dir / cfg.SLOT_IN_USE_FNAME, missing_ok=False
-        )
+        return read_from_file(self.current_ota_status_dir / cfg.SLOT_IN_USE_FNAME)
 
 
 class OTAStatusMixin:
@@ -390,20 +388,14 @@ class OTAStatusMixin:
             self.standby_ota_status_dir / cfg.OTA_STATUS_FNAME, _status.name
         )
 
-    def _load_current_ota_status(self) -> OTAStatusEnum:
-        _status = OTAStatusEnum.FAILURE  # for unexpected situation, default to FAILURE
-        try:
-            _status_str = read_from_file(
-                self.current_ota_status_dir / cfg.OTA_STATUS_FNAME
-            ).upper()
-            _status = OTAStatusEnum[_status_str]
-        except KeyError:
-            _status = OTAStatusEnum.INITIALIZED
-            write_to_file_sync(
-                self.current_ota_status_dir / cfg.OTA_STATUS_FNAME, _status.name
-            )
-        finally:
-            return _status
+    def _load_current_ota_status(self) -> Optional[OTAStatusEnum]:
+        if _status_str := read_from_file(
+            self.current_ota_status_dir / cfg.OTA_STATUS_FNAME
+        ).upper():
+            try:
+                return OTAStatusEnum[_status_str]
+            except KeyError:
+                pass  # invalid status string
 
     def get_ota_status(self) -> OTAStatusEnum:
         return self.ota_status

--- a/app/boot_control/common.py
+++ b/app/boot_control/common.py
@@ -380,7 +380,7 @@ class OTAStatusMixin:
     standby_ota_status_dir: Path
     ota_status: OTAStatusEnum
 
-    def store_current_ota_status(self, _status: OTAStatusEnum):
+    def _store_current_ota_status(self, _status: OTAStatusEnum):
         write_to_file_sync(
             self.current_ota_status_dir / cfg.OTA_STATUS_FNAME, _status.name
         )

--- a/app/boot_control/common.py
+++ b/app/boot_control/common.py
@@ -377,8 +377,11 @@ class SlotInUseMixin:
     def _store_standby_slot_in_use(self, _slot: str):
         write_to_file_sync(self.standby_ota_status_dir / cfg.SLOT_IN_USE_FNAME, _slot)
 
-    def _load_current_slot_in_use(self) -> str:
-        return read_from_file(self.current_ota_status_dir / cfg.SLOT_IN_USE_FNAME)
+    def _load_current_slot_in_use(self) -> Optional[str]:
+        if res := read_from_file(
+            self.current_ota_status_dir / cfg.SLOT_IN_USE_FNAME, default=""
+        ):
+            return res
 
 
 class OTAStatusMixin:
@@ -421,7 +424,9 @@ class VersionControlMixin:
 
     def load_version(self) -> str:
         _version = read_from_file(
-            self.current_ota_status_dir / cfg.OTA_VERSION_FNAME, missing_ok=True
+            self.current_ota_status_dir / cfg.OTA_VERSION_FNAME,
+            missing_ok=True,
+            default="",
         )
         if not _version:
             logger.warning("version file not found, return empty version string")

--- a/app/boot_control/common.py
+++ b/app/boot_control/common.py
@@ -357,6 +357,14 @@ class CMDHelperFuncs:
             # it will be mounted to /mnt/standby(rw), so we still mount it as bind,ro
             raise MountError("refroot is expected to be mounted")
 
+    @classmethod
+    def reboot(cls):
+        try:
+            subprocess_call("reboot", raise_exception=True)
+        except CalledProcessError:
+            logger.exception("failed to reboot")
+            raise
+
 
 ###### helper mixins ######
 class SlotInUseMixin:

--- a/app/boot_control/grub.py
+++ b/app/boot_control/grub.py
@@ -646,6 +646,10 @@ class GrubController(
             self._store_current_slot_in_use(self._boot_control.active_slot)
             self._store_current_ota_status(OTAStatusEnum.INITIALIZED)
 
+        # populate slot_in_use file if it doesn't exist
+        if not _slot_in_use:
+            self._store_current_slot_in_use(self._boot_control.active_slot)
+
         if _ota_status in [OTAStatusEnum.UPDATING, OTAStatusEnum.ROLLBACKING]:
             if self._is_switching_boot():
                 self._boot_control.finalize_update_switch_boot(

--- a/app/boot_control/grub.py
+++ b/app/boot_control/grub.py
@@ -650,7 +650,7 @@ class GrubController(
 
         # other ota_status will remain the same
         self.ota_status = _ota_status
-        self.store_current_ota_status(_ota_status)
+        self._store_current_ota_status(_ota_status)
         self._store_standby_ota_status(_ota_status)
         logger.info(f"boot control init finished, ota_status is {_ota_status}")
 
@@ -767,7 +767,7 @@ class GrubController(
     def on_operation_failure(self):
         """Failure registering and cleanup at failure."""
         self._store_standby_ota_status(OTAStatusEnum.FAILURE)
-        self.store_current_ota_status(OTAStatusEnum.FAILURE)
+        self._store_current_ota_status(OTAStatusEnum.FAILURE)
         logger.warning("on failure try to unmounting standby slot...")
         self._umount_all(ignore_error=True)
 
@@ -784,7 +784,7 @@ class GrubController(
     def pre_update(self, version: str, *, standby_as_ref: bool, erase_standby=False):
         try:
             # update ota_status files
-            self.store_current_ota_status(OTAStatusEnum.FAILURE)
+            self._store_current_ota_status(OTAStatusEnum.FAILURE)
             self._store_standby_ota_status(OTAStatusEnum.UPDATING)
             # update version file
             self._store_standby_version(version)

--- a/app/boot_control/grub.py
+++ b/app/boot_control/grub.py
@@ -630,7 +630,6 @@ class GrubController(
             self._init_boot_control()
         except Exception as e:
             logger.error(f"failed on init boot controller: {e!r}")
-            self.on_operation_failure()
             raise BootControlInitError from e
 
     def _init_boot_control(self):
@@ -809,7 +808,6 @@ class GrubController(
             self.cleanup_standby_ota_partition_folder()
         except Exception as e:
             logger.error(f"failed on pre_update: {e!r}")
-            self.on_operation_failure()
             raise BootControlPreUpdateFailed from e
 
     def post_update(self):
@@ -830,7 +828,6 @@ class GrubController(
             subprocess_call("reboot")
         except Exception as e:
             logger.error(f"failed on post_update: {e!r}")
-            self.on_operation_failure()
             raise BootControlPostUpdateFailed from e
 
     def post_rollback(self):
@@ -839,5 +836,4 @@ class GrubController(
             subprocess_call("reboot")
         except Exception as e:
             logger.error(f"failed on pre_rollback: {e!r}")
-            self.on_operation_failure()
             raise BootControlPostRollbackFailed from e

--- a/app/boot_control/grub.py
+++ b/app/boot_control/grub.py
@@ -848,7 +848,7 @@ class GrubController(
             self._umount_all(ignore_error=True)
 
             self._boot_control.grub_reboot_to_standby()
-            subprocess_call("reboot")
+            CMDHelperFuncs.reboot()
         except Exception as e:
             logger.error(f"failed on post_update: {e!r}")
             raise BootControlPostUpdateFailed from e
@@ -864,7 +864,7 @@ class GrubController(
     def post_rollback(self):
         try:
             self._boot_control.grub_reboot_to_standby()
-            subprocess_call("reboot")
+            CMDHelperFuncs.reboot()
         except Exception as e:
             logger.error(f"failed on pre_rollback: {e!r}")
             raise BootControlPostRollbackFailed from e

--- a/app/boot_control/interface.py
+++ b/app/boot_control/interface.py
@@ -39,3 +39,7 @@ class BootControllerProtocol(Protocol):
     @abstractmethod
     def store_current_ota_status(self, _status: OTAStatusEnum):
         ...
+
+    @abstractmethod
+    def on_operation_failure(self):
+        ...

--- a/app/boot_control/interface.py
+++ b/app/boot_control/interface.py
@@ -25,6 +25,10 @@ class BootControllerProtocol(Protocol):
         ...
 
     @abstractmethod
+    def pre_rollback(self):
+        ...
+
+    @abstractmethod
     def post_update(self):
         ...
 
@@ -35,10 +39,6 @@ class BootControllerProtocol(Protocol):
     @abstractmethod
     def load_version(self) -> str:
         """Read the version info from the current slot."""
-
-    @abstractmethod
-    def store_current_ota_status(self, _status: OTAStatusEnum):
-        ...
 
     @abstractmethod
     def on_operation_failure(self):

--- a/app/errors.py
+++ b/app/errors.py
@@ -117,7 +117,11 @@ class OTA_APIError(Exception):
 
 
 class OTAUpdateError(OTA_APIError):
-    api: OTAAPI = OTAAPI.Update
+    api = OTAAPI.Update
+
+
+class OTARollbackError(OTA_APIError):
+    api = OTAAPI.Rollback
 
 
 @unique

--- a/app/errors.py
+++ b/app/errors.py
@@ -148,6 +148,7 @@ class OTAErrorCode(Enum):
     E_BOOTCONTROL_POSTUPDATE_FAILED = 304
     E_BOOTCONTROL_POSTROLLBACK_FAILED = 305
     E_STANDBY_SLOT_SPACE_NOT_ENOUGH_ERROR = 306
+    E_BOOTCONTROL_PREROLLBACK_FAILED = 307
 
     def to_str(self) -> str:
         return f"{self.value:0>3}"
@@ -301,3 +302,9 @@ class StandbySlotSpaceNotEnoughError(OTAErrorUnRecoverable):
     module: OTAModules = OTAModules.StandbySlotCreater
     errcode: OTAErrorCode = OTAErrorCode.E_STANDBY_SLOT_SPACE_NOT_ENOUGH_ERROR
     desc: str = f"{_UNRECOVERABLE_DEFAULT_DESC}: standby slot has insufficient space to apply update, abort"
+
+
+class BootControlPreRollbackFailed(OTAErrorUnRecoverable):
+    module: OTAModules = OTAModules.BootController
+    errcode: OTAErrorCode = OTAErrorCode.E_BOOTCONTROL_PREROLLBACK_FAILED
+    desc: str = f"{_UNRECOVERABLE_DEFAULT_DESC}: pre_rollback process failed"

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -305,9 +305,9 @@ class OTAClient(OTAClientProtocol):
 
     def _rollback(self):
         # enter rollback
-        self.live_ota_status.set_ota_status(OTAStatusEnum.ROLLBACKING)
         self.failure_type = OTAFailureType.NO_FAILURE
         self.failure_reason = ""
+        self.boot_controller.pre_rollback()
 
         # leave rollback
         self.boot_controller.post_rollback()


### PR DESCRIPTION
## Introduction
This PR introduce refinement over otastatus transition logic.

## Motivation
otastatus should relate to the update/rollback operation, not relate to the slots' status.
A **SUCCESS** status only means the latest update/rollback operation is successful, 
meanwhile a **FAILURE** status only means a failed update/rollback attempt.

## Design of refinement
some basic rules are enforced as follow:
1. only the most recent successfully updated slot has the **SUCCESS** status, inactive slot always in **FAILURE** status, except for the case in 2.
2. **UPDATING/ROLLBACKING** are only set to standby slot that is receiving an update/rollback.
3. otaclient will only refer to current booted slot's otastatus file when launching itself.
4. slot switch will only happen at local update/rollback.

## Changes
1. implement new otastatus transition logic
2. fix/refinement on rollback implementation, define error types for it
3. refinement over cboot, grub controller according to 1
4. refinement on error handling for boot controller

## ticket
https://tier4.atlassian.net/browse/T4PB-19077