### PR TITLE
Bug fix and refinement over ota_client_stub

### DIFF
--- a/app/boot_control/grub.py
+++ b/app/boot_control/grub.py
@@ -28,6 +28,7 @@ from app.errors import (
     BootControlInitError,
     BootControlPostRollbackFailed,
     BootControlPostUpdateFailed,
+    BootControlPreRollbackFailed,
     BootControlPreUpdateFailed,
 )
 from app.ota_status import OTAStatusEnum
@@ -625,40 +626,60 @@ class GrubController(
                 os.mkdir(self.ref_slot_mount_point)
 
             # init boot control
-            _ota_status = self._load_current_ota_status()
-            if _ota_status == OTAStatusEnum.UPDATING:
-                _ota_status = self._finalize_update()
-            elif _ota_status == OTAStatusEnum.ROLLBACKING:
-                _ota_status = self._finalize_rollback()
-            # NOTE(20220714): pending the use of slot_in_use file for grub controller,
-            # re-introduce it in the future.
-            # negative SUCCESS detection is only available when slot_in_use file
-            # is presented.
-
-            # elif _ota_status == OTAStatusEnum.SUCCESS:
-            #     # need to check whether it is negative SUCCESS
-            #     current_slot = self._boot_control.active_slot
-            #     slot_in_use = self._load_current_slot_in_use()
-            #     # cover the case that device reboot into unexpected slot
-            #     if current_slot != slot_in_use:
-            #         logger.error(
-            #             f"boot into old slot {current_slot}, "
-            #             f"expect to boot into {slot_in_use}"
-            #         )
-            #         _ota_status = OTAStatusEnum.FAILURE
-            # SUCCESS, INITIALIZED, FAILURE and ROLLBACK_FAILURE are remained as it
-
-            # special treatment on initialized status
-            if _ota_status == OTAStatusEnum.INITIALIZED:
-                self._boot_control.init_active_ota_partition_file()
-                self._store_current_slot_in_use(self._boot_control.active_slot)
-
-            self.ota_status = _ota_status
-            self.store_current_ota_status(_ota_status)
-            logger.info(f"loaded ota_status: {_ota_status}")
+            #   1. load/process ota_status
+            #   2. finalize update/rollback or init boot files
+            self._init_boot_control()
         except Exception as e:
-            self.store_current_ota_status(OTAStatusEnum.FAILURE)
+            logger.error(f"failed on init boot controller: {e!r}")
             raise BootControlInitError from e
+
+    def _init_boot_control(self):
+        # load ota_status str and slot_in_use
+        _ota_status = self._load_current_ota_status()
+        _slot_in_use = self._load_current_slot_in_use()
+
+        # NOTE: for backward compatibility, only check otastatus file
+        if not _ota_status:
+            logger.info("initializing boot control files...")
+            _ota_status = OTAStatusEnum.INITIALIZED
+            self._boot_control.init_active_ota_partition_file()
+            self._store_current_slot_in_use(self._boot_control.active_slot)
+            self._store_current_ota_status(OTAStatusEnum.INITIALIZED)
+
+        # populate slot_in_use file if it doesn't exist
+        if not _slot_in_use:
+            self._store_current_slot_in_use(self._boot_control.active_slot)
+
+        if _ota_status in [OTAStatusEnum.UPDATING, OTAStatusEnum.ROLLBACKING]:
+            if self._is_switching_boot():
+                self._boot_control.finalize_update_switch_boot(
+                    abort_on_standby_missed=True
+                )
+                # switch ota_status
+                _ota_status = OTAStatusEnum.SUCCESS
+            else:
+                if _ota_status == OTAStatusEnum.ROLLBACKING:
+                    _ota_status = OTAStatusEnum.ROLLBACK_FAILURE
+                else:
+                    _ota_status = OTAStatusEnum.FAILURE
+        # other ota_status will remain the same
+
+        # detect failed reboot, but only print error logging
+        if (
+            _ota_status != OTAStatusEnum.INITIALIZED
+            and _slot_in_use
+            and _slot_in_use != self._boot_control.active_slot
+        ):
+            logger.error(
+                f"boot into old slot {self._boot_control.active_slot}, "
+                f"but slot_in_use indicates it should boot into {_slot_in_use}, "
+                "this might indicate a failed finalization at first reboot after update/rollback"
+            )
+
+        # apply ota_status to otaclient
+        self.ota_status = _ota_status
+        self._store_current_ota_status(_ota_status)
+        logger.info(f"boot control init finished, ota_status is {_ota_status}")
 
     def _is_switching_boot(self):
         # evidence 1: ota_status should be updating/rollbacking at the first reboot
@@ -767,15 +788,15 @@ class GrubController(
             else:
                 f.unlink(missing_ok=True)
 
-    def _on_operation_failure(self):
-        """Failure registering and cleanup at failure."""
-        self._store_standby_ota_status(OTAStatusEnum.FAILURE)
-        logger.warning("on failure try to unmounting standby slot...")
-        self._umount_all(ignore_error=True)
-
     ###### public methods ######
     # also includes methods from OTAStatusMixin, VersionControlMixin
     # load_version, get_ota_status
+    def on_operation_failure(self):
+        """Failure registering and cleanup at failure."""
+        self._store_standby_ota_status(OTAStatusEnum.FAILURE)
+        self._store_current_ota_status(OTAStatusEnum.FAILURE)
+        logger.warning("on failure try to unmounting standby slot...")
+        self._umount_all(ignore_error=True)
 
     def get_standby_slot_path(self) -> Path:
         return self.standby_slot_mount_point
@@ -789,6 +810,18 @@ class GrubController(
 
     def pre_update(self, version: str, *, standby_as_ref: bool, erase_standby=False):
         try:
+            # update ota_status files
+            self._store_current_ota_status(OTAStatusEnum.FAILURE)
+            self._store_standby_ota_status(OTAStatusEnum.UPDATING)
+            # update version file
+            self._store_standby_version(version)
+            # update slot_in_use file
+            # set slot_in_use to <standby_slot> to both slots
+            _target_slot = self._boot_control.standby_slot
+            self._store_current_slot_in_use(_target_slot)
+            self._store_standby_slot_in_use(_target_slot)
+
+            # enter pre-update
             self._prepare_and_mount_standby(
                 self._boot_control.standby_root_dev,
                 erase=erase_standby,
@@ -800,17 +833,8 @@ class GrubController(
             )
             # remove old files under standby ota_partition folder
             self.cleanup_standby_ota_partition_folder()
-
-            self._store_standby_ota_status(OTAStatusEnum.UPDATING)
-            self._store_standby_version(version)
-
-            # set slot_in_use to <standby_slot> to both slots
-            _target_slot = self._boot_control.standby_slot
-            self._store_current_slot_in_use(_target_slot)
-            self._store_standby_slot_in_use(_target_slot)
         except Exception as e:
             logger.error(f"failed on pre_update: {e!r}")
-            self._on_operation_failure()
             raise BootControlPreUpdateFailed from e
 
     def post_update(self):
@@ -828,17 +852,23 @@ class GrubController(
             self._umount_all(ignore_error=True)
 
             self._boot_control.grub_reboot_to_standby()
-            subprocess_call("reboot")
+            CMDHelperFuncs.reboot()
         except Exception as e:
             logger.error(f"failed on post_update: {e!r}")
-            self._on_operation_failure()
             raise BootControlPostUpdateFailed from e
+
+    def pre_rollback(self):
+        try:
+            self._store_current_ota_status(OTAStatusEnum.FAILURE)
+            self._store_standby_ota_status(OTAStatusEnum.ROLLBACKING)
+        except Exception as e:
+            logger.error(f"failed on pre_rollback: {e!r}")
+            raise BootControlPreRollbackFailed from e
 
     def post_rollback(self):
         try:
             self._boot_control.grub_reboot_to_standby()
-            subprocess_call("reboot")
+            CMDHelperFuncs.reboot()
         except Exception as e:
             logger.error(f"failed on pre_rollback: {e!r}")
-            self._on_operation_failure()
             raise BootControlPostRollbackFailed from e

--- a/app/boot_control/interface.py
+++ b/app/boot_control/interface.py
@@ -25,6 +25,10 @@ class BootControllerProtocol(Protocol):
         ...
 
     @abstractmethod
+    def pre_rollback(self):
+        ...
+
+    @abstractmethod
     def post_update(self):
         ...
 
@@ -37,5 +41,5 @@ class BootControllerProtocol(Protocol):
         """Read the version info from the current slot."""
 
     @abstractmethod
-    def store_current_ota_status(self, _status: OTAStatusEnum):
+    def on_operation_failure(self):
         ...

--- a/app/ecu_info.py
+++ b/app/ecu_info.py
@@ -30,7 +30,7 @@ class EcuInfo:
         return self._ecu_info.get("ip_addr", "localhost")
 
     def get_available_ecu_ids(self):
-        return self._ecu_info.get("available_ecu_ids", [])
+        return self._ecu_info.get("available_ecu_ids", [self.get_ecu_id()])
 
     def _load_ecu_info(self, path: str):
         try:

--- a/app/ecu_info.py
+++ b/app/ecu_info.py
@@ -30,7 +30,7 @@ class EcuInfo:
         return self._ecu_info.get("ip_addr", "localhost")
 
     def get_available_ecu_ids(self):
-        return self._ecu_info.get("available_ecu_ids", [self.get_ecu_id()])
+        return self._ecu_info.get("available_ecu_ids", [])
 
     def _load_ecu_info(self, path: str):
         try:

--- a/app/errors.py
+++ b/app/errors.py
@@ -117,7 +117,11 @@ class OTA_APIError(Exception):
 
 
 class OTAUpdateError(OTA_APIError):
-    api: OTAAPI = OTAAPI.Update
+    api = OTAAPI.Update
+
+
+class OTARollbackError(OTA_APIError):
+    api = OTAAPI.Rollback
 
 
 @unique
@@ -144,6 +148,7 @@ class OTAErrorCode(Enum):
     E_BOOTCONTROL_POSTUPDATE_FAILED = 304
     E_BOOTCONTROL_POSTROLLBACK_FAILED = 305
     E_STANDBY_SLOT_SPACE_NOT_ENOUGH_ERROR = 306
+    E_BOOTCONTROL_PREROLLBACK_FAILED = 307
 
     def to_str(self) -> str:
         return f"{self.value:0>3}"
@@ -297,3 +302,9 @@ class StandbySlotSpaceNotEnoughError(OTAErrorUnRecoverable):
     module: OTAModules = OTAModules.StandbySlotCreater
     errcode: OTAErrorCode = OTAErrorCode.E_STANDBY_SLOT_SPACE_NOT_ENOUGH_ERROR
     desc: str = f"{_UNRECOVERABLE_DEFAULT_DESC}: standby slot has insufficient space to apply update, abort"
+
+
+class BootControlPreRollbackFailed(OTAErrorUnRecoverable):
+    module: OTAModules = OTAModules.BootController
+    errcode: OTAErrorCode = OTAErrorCode.E_BOOTCONTROL_PREROLLBACK_FAILED
+    desc: str = f"{_UNRECOVERABLE_DEFAULT_DESC}: pre_rollback process failed"

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -354,9 +354,9 @@ class OTAClient(OTAClientProtocol):
 
     def status(self) -> v2.StatusResponseEcu:
         if self.live_ota_status.get_ota_status() == OTAStatusEnum.UPDATING:
-            _version, _update_progress = self.updater.update_progress()
+            _, _update_progress = self.updater.update_progress()
             _status = v2.Status(
-                version=_version,
+                version=self.current_version,
                 status=self.live_ota_status.get_ota_status().name,
                 progress=_update_progress,
             )

--- a/app/ota_client_call.py
+++ b/app/ota_client_call.py
@@ -71,3 +71,24 @@ class OtaClientCall:
             ecu.result = v2.RECOVERABLE  # treat unreachable ecu as recoverable
 
             return resp
+
+    async def rollback_call(
+        self,
+        ecu_id: str,
+        ecu_addr: str,
+        *,
+        request: v2.RollbackRequest,
+        timeout=None,
+    ) -> v2.RollbackResponse:
+        try:
+            return await asyncio.wait_for(
+                self.rollback(request, ecu_addr),  # type: ignore
+                timeout=timeout,
+            )
+        except (grpc.aio.AioRpcError, asyncio.TimeoutError):
+            resp = v2.RollbackResponse()
+            ecu = resp.ecu.add()
+            ecu.ecu_id = ecu_id
+            ecu.result = v2.RECOVERABLE  # treat unreachable ecu as recoverable
+
+            return resp

--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -484,9 +484,10 @@ class OtaClientStub:
                 # add to tracked ecu list
                 tracked_ecus_dict[_ecu_id] = _ecu_ip
                 coros.append(
-                    self._ota_client_call.status_call(
+                    self._ota_client_call.rollback_call(
                         _ecu_id,
                         _ecu_ip,
+                        request=request,
                         # TODO: should rollback timeout has its own value?
                         timeout=server_cfg.WAITING_SUBECU_ACK_UPDATE_REQ_TIMEOUT,
                     )

--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -571,7 +571,7 @@ class OtaClientStub:
                     my_ecu.result = v2.RECOVERABLE
 
                 # register the status to cache
-                self._cached_status = subecus_resp
+                self._cached_status = resp
 
         # respond with the cached status
         res = v2.StatusResponse()

--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -562,7 +562,7 @@ class OtaClientStub:
                     ecu = resp.ecu.add()
                     ecu.CopyFrom(ecu_status)
                 ## append my_ecu status
-                my_ecu = subecus_resp.ecu.add()
+                my_ecu = resp.ecu.add()
                 if my_ecu_status := self._ota_client.status():
                     my_ecu.CopyFrom(my_ecu_status)
                 else:

--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -549,6 +549,9 @@ class OtaClientStub:
                     )
                 subecu_resp: v2.StatusResponse
                 for subecu_resp in await asyncio.gather(*coros):
+                    if subecu_resp is None:
+                        continue
+
                     # gather the subecu and its child ecus status
                     for _ecu_resp in subecu_resp.ecu:  # type: ignore
                         _ecu = subecus_resp.ecu.add()

--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -367,7 +367,7 @@ class OtaClientStub:
     ) -> v2.StatusResponse:
         response = v2.StatusResponse()
 
-        coros: List[typing.Coroutine] = []
+        coros: List[Coroutine] = []
         for subecu_id, subecu_addr in ecus_addr_dict.items():
             coros.append(self._query_subecu_status_api(subecu_id, subecu_addr))
 
@@ -380,15 +380,16 @@ class OtaClientStub:
 
         return response
 
-    async def _local_update_tracker(self, fsm: OTAUpdateFSM):
+    async def _local_update_tracker(self, fsm: OTAUpdateFSM) -> bool:
         _loop = asyncio.get_running_loop()
         await _loop.run_in_executor(
             self._executor,
             fsm.stub_wait_for_local_update,
         )
 
-        if e := self._ota_client.get_last_failure():
-            raise e
+        if self._ota_client.get_last_failure():
+            return False
+        return True
 
     ###### API stub method #######
     def host_addr(self):

--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -282,7 +282,7 @@ class _SubECUTracker:
                 coros.append(self._query_ecu(subecu_addr))
 
             all_ecus_success, all_ecus_ready = True, True
-            for _ecustatus in asyncio.gather(*coros):
+            for _ecustatus in await asyncio.gather(*coros):
                 this_subecu_ready = True
                 if _ecustatus in (
                     self.ECUStatus.SUCCESS,
@@ -372,7 +372,7 @@ class OtaClientStub:
             coros.append(self._query_subecu_status_api(subecu_id, subecu_addr))
 
         subecu_resp: v2.StatusResponse
-        for subecu_resp in asyncio.gather(*coros):
+        for subecu_resp in await asyncio.gather(*coros):
             # gather the subecu and its child ecus status
             for _ecu_resp in subecu_resp.ecu:
                 _ecu = response.ecu.add()

--- a/app/ota_client_stub.py
+++ b/app/ota_client_stub.py
@@ -233,6 +233,9 @@ class OtaClientStub:
 
         self._ecu_info = EcuInfo()
         self.my_ecu_id = self._ecu_info.get_ecu_id()
+        self.subecus_dict: Dict[str, str] = {
+            e["ecu_id"]: e["ip_addr"] for e in self._ecu_info.get_secondary_ecus()
+        }
 
         # NOTE: explicitly specific which mechanism to use
         # for boot control and create standby slot

--- a/app/proto/__init__.py
+++ b/app/proto/__init__.py
@@ -36,5 +36,6 @@ del _import_proto, _import_from_file
 
 import otaclient_v2_pb2 as v2
 import otaclient_v2_pb2_grpc as v2_grpc
+from . import wrapper
 
-__all__ = ["v2", "v2_grpc"]
+__all__ = ["v2", "v2_grpc", "wrapper"]

--- a/app/proto/wrapper.py
+++ b/app/proto/wrapper.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import typing
+import otaclient_v2_pb2 as v2
+from enum import Enum
+from google.protobuf import message as _message
+from typing import (
+    Any,
+    ClassVar,
+    Generator,
+    Optional,
+    Protocol,
+    Tuple,
+    Type,
+    Union,
+)
+
+
+class _WrapperBase:
+    """Base for wrapper types."""
+
+    proto_class: ClassVar[Type[_message.Message]]
+
+    def __init__(self, *args, **kwargs):
+        self.data = self.proto_class(*args, **kwargs)
+
+
+_RollbackRequest = typing.cast(Type[v2.RollbackRequest], _WrapperBase)
+_RollbackRequestEcu = typing.cast(Type[v2.RollbackRequestEcu], _WrapperBase)
+_RollbackResponse = typing.cast(Type[v2.RollbackResponse], _WrapperBase)
+_RollbackResponseEcu = typing.cast(Type[v2.RollbackResponseEcu], _WrapperBase)
+_Status = typing.cast(Type[v2.Status], _WrapperBase)
+_StatusProgress = typing.cast(Type[v2.StatusProgress], _WrapperBase)
+_StatusRequest = typing.cast(Type[v2.StatusRequest], _WrapperBase)
+_StatusResponse = typing.cast(Type[v2.StatusResponse], _WrapperBase)
+_StatusResponseEcu = typing.cast(Type[v2.StatusResponseEcu], _WrapperBase)
+_UpdateRequest = typing.cast(Type[v2.UpdateRequest], _WrapperBase)
+_UpdateRequestEcu = typing.cast(Type[v2.UpdateRequestEcu], _WrapperBase)
+_UpdateResponse = typing.cast(Type[v2.UpdateResponse], _WrapperBase)
+_UpdateResponseEcu = typing.cast(Type[v2.UpdateRequestEcu], _WrapperBase)
+
+
+class MessageWrapperProtocol(Protocol):
+    """A proxy wrapper base that proxies all attrs from/to the
+    wrapped proto class instance."""
+
+    proto_class: ClassVar[Type[_message.Message]]
+    data: _message.Message
+
+    def __getattr__(self, __name: str) -> Any:
+        if __name in ["data", "proto_class"]:
+            return super().__getattribute__(__name)
+        return getattr(self.data, __name)
+
+    def __getitem__(self, __name: str) -> Any:
+        return getattr(self.data, __name)
+
+    def __setattr__(self, __name: str, __value: Any):
+        if __name in ["data", "proto_class"]:
+            super().__setattr__(__name, __value)
+        else:
+            setattr(self.data, __name, __value)
+
+    def __setitem__(self, __key: str, __value: Any):
+        setattr(self.data, __key, __value)
+
+    def __eq__(self, __o: object) -> bool:
+        if isinstance(__o, self.__class__):
+            return __o.data == self.data
+        return False
+
+    def export_pb(self):
+        res = self.proto_class()
+        res.CopyFrom(self.data)
+        return res
+
+    @classmethod
+    def _wrap(cls, _in: Optional[_message.Message] = None):
+        if _in is not None and not isinstance(_in, cls.proto_class):
+            raise TypeError(
+                f"wrong input type, expect={cls.proto_class}, in={_in.__class__}"
+            )
+
+        res = cls()
+        if _in is not None:
+            res.data = _in
+        return res
+
+    @classmethod
+    def wrap(cls, _in: _message.Message):
+        """Copy and wrap input message into a new wrapper instance."""
+        _new_data = cls.proto_class()
+        _new_data.CopyFrom(_in)
+        return cls._wrap(_new_data)
+
+    def rewrap(self, _in: _message.Message):
+        """Replace the underlaying wrapped data instance."""
+        self.data = _in
+
+    def unwrap(self):
+        return self.data
+
+
+class EnumWrapper(Enum):
+    def export_pb(self):
+        return self.value  # type: ignore
+
+    def __eq__(self, __o: object) -> bool:
+        """Support directly comparing with v2 Enum types."""
+        if isinstance(__o, self.__class__):
+            return super().__eq__(__o)
+        return self.value == __o
+
+
+# message
+
+
+## rollback
+class RollbackRequestEcu(_RollbackRequestEcu, MessageWrapperProtocol):
+    proto_class = v2.RollbackRequestEcu
+    data: v2.RollbackRequestEcu
+
+
+class RollbackRequest(_RollbackRequest, MessageWrapperProtocol):
+    proto_class = v2.RollbackRequest
+    data: v2.RollbackRequest
+
+
+class RollbackResponseEcu(_RollbackResponseEcu, MessageWrapperProtocol):
+    proto_class = v2.RollbackResponseEcu
+    data: v2.RollbackResponseEcu
+
+
+class RollbackResponse(_RollbackResponse, MessageWrapperProtocol):
+    proto_class = v2.RollbackResponse
+    data: v2.RollbackResponse
+
+    def iter_ecu(
+        self,
+    ) -> Generator[Tuple[str, FailureType, RollbackResponseEcu], None, None]:
+        for _ecu in self.data.ecu:
+            yield _ecu.ecu_id, FailureType(_ecu.result), RollbackResponseEcu.wrap(_ecu)
+
+    def add_ecu(self, _response_ecu: RollbackResponseEcu):
+        if not isinstance(_response_ecu, RollbackResponseEcu):
+            raise TypeError
+        self.data.ecu.append(_response_ecu.unwrap())  # type: ignore
+
+
+## status API
+class StatusProgress(_StatusProgress, MessageWrapperProtocol):
+    proto_class = v2.StatusProgress
+    data: v2.StatusProgress
+
+    def get_snapshot(self) -> StatusProgress:
+        return self.wrap(self.data)
+
+
+class Status(_Status, MessageWrapperProtocol):
+    proto_class = v2.Status
+    data: v2.Status
+
+    def get_progress(self) -> StatusProgress:
+        return StatusProgress.wrap(self.progress)
+
+    def get_failure(self) -> Tuple[FailureType, str]:
+        return FailureType(self.failure), self.failure_reason
+
+
+class StatusRequest(_StatusRequest, MessageWrapperProtocol):
+    proto_class = v2.StatusRequest
+    data: v2.StatusRequest
+
+
+class StatusResponseEcu(_StatusResponseEcu, MessageWrapperProtocol):
+    proto_class = v2.StatusResponseEcu
+    data: v2.StatusResponseEcu
+
+
+class StatusResponse(_StatusResponse, MessageWrapperProtocol):
+    proto_class = v2.StatusResponse
+    data: v2.StatusResponse
+
+    def iter_ecu_status(self) -> Generator[Tuple[str, FailureType, Status], None, None]:
+        """
+        Returns:
+            A tuple of (<ecu_id>, <failure_type>, <status>)
+        """
+        for _ecu in self.data.ecu:
+            yield _ecu.ecu_id, FailureType(_ecu.result), Status.wrap(_ecu.status)
+
+    def add_ecu(self, _response_ecu: StatusResponseEcu):
+        if not isinstance(_response_ecu, StatusResponseEcu):
+            raise TypeError
+        self.data.ecu.append(_response_ecu.export_pb())  # type: ignore
+
+    def merge_from(self, _in: Union["StatusResponse", v2.StatusResponse]):
+        if isinstance(_in, StatusResponse):
+            _in = _in.unwrap()  # type: ignore
+
+        # NOTE: available_ecu_ids will not be merged
+        for _ecu in _in.ecu:
+            self.data.ecu.append(_ecu)
+
+    def get_ecu_status(self, ecu_id: str) -> Optional[Tuple[str, FailureType, Status]]:
+        """
+        Returns:
+            A tuple of (<ecu_id>, <failure_type>, <status>)
+        """
+        for _ecu in self.data.ecu:
+            if _ecu.ecu_id == ecu_id:
+                return (
+                    _ecu.ecu_id,
+                    FailureType(_ecu.result),
+                    Status.wrap(_ecu.status),
+                )
+
+    def update_available_ecu_ids(self, *_ecu_list: str):
+        self.data.available_ecu_ids.extend(_ecu_list)
+
+
+## update API
+class UpdateRequestEcu(_UpdateRequestEcu, MessageWrapperProtocol):
+    proto_class = v2.UpdateRequestEcu
+    data: v2.UpdateRequestEcu
+
+
+class UpdateRequest(_UpdateRequest, MessageWrapperProtocol):
+    proto_class = v2.UpdateRequest
+    data: v2.UpdateRequest
+
+    def find_update_meta(self, ecu_id: str) -> Optional[UpdateRequestEcu]:
+        for _ecu in self.data.ecu:
+            if _ecu.ecu_id == ecu_id:
+                return UpdateRequestEcu.wrap(_ecu)
+
+    def iter_update_meta(self) -> Generator[UpdateRequestEcu, None, None]:
+        for _ecu in self.data.ecu:
+            yield UpdateRequestEcu.wrap(_ecu)
+
+
+class UpdateResponseEcu(_UpdateResponseEcu, MessageWrapperProtocol):
+    proto_class = v2.UpdateResponseEcu
+    data: v2.UpdateResponseEcu
+
+
+class UpdateResponse(_UpdateResponse, MessageWrapperProtocol):
+    proto_class = v2.UpdateResponse
+    data: v2.UpdateResponse
+
+    def iter_ecu(self) -> Generator[UpdateResponseEcu, None, None]:
+        for _ecu in self.data.ecu:
+            yield UpdateResponseEcu.wrap(_ecu)
+
+    def add_ecu(self, _response_ecu: UpdateResponseEcu):
+        if not isinstance(_response_ecu, UpdateResponseEcu):
+            raise TypeError
+        self.data.ecu.append(_response_ecu.export_pb())  # type: ignore
+
+
+# enum
+
+
+class FailureType(EnumWrapper):
+    NO_FAILURE = v2.NO_FAILURE
+    RECOVERABLE = v2.RECOVERABLE
+    UNRECOVERABLE = v2.UNRECOVERABLE
+
+    def to_str(self) -> str:
+        return f"{self.value:0>1}"
+
+
+class StatusOta(EnumWrapper):
+    INITIALIZED = v2.INITIALIZED
+    SUCCESS = v2.SUCCESS
+    FAILURE = v2.FAILURE
+    UPDATING = v2.UPDATING
+    ROLLBACKING = v2.ROLLBACKING
+    ROLLBACK_FAILURE = v2.ROLLBACK_FAILURE
+
+
+class StatusProgressPhase(EnumWrapper):
+    INITIAL = v2.INITIAL
+    METADATA = v2.METADATA
+    DIRECTORY = v2.DIRECTORY
+    SYMLINK = v2.SYMLINK
+    REGULAR = v2.REGULAR
+    PERSISTENT = v2.PERSISTENT
+    POST_PROCESSING = v2.POST_PROCESSING

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,11 @@ branch = true
 omit = ["app/proto/*pb2*"]
 show_missing = true
 
+[tool.pyright]
+exclude = ["**/__pycache__"]
+ignore = ["app/proto/otaclient_v2_pb2*"]
+pythonVersion = "3.8"
+
 [tool.pytest.ini_options]
 log_auto_indent = true
 log_format = "%(asctime)s %(levelname)s %(filename)s %(funcName)s,%(lineno)d %(message)s"

--- a/tests/test_proto/test_wrapper.py
+++ b/tests/test_proto/test_wrapper.py
@@ -1,0 +1,191 @@
+import pytest
+from google.protobuf import message as _message
+from typing import Any, Type
+
+from app.proto import wrapper
+from app.proto import v2
+
+
+@pytest.mark.parametrize(
+    "pb_cls, wrapper_cls, field_name, field_value",
+    (
+        (v2.RollbackRequestEcu, wrapper.RollbackRequestEcu, "ecu_id", "autoware"),
+        (v2.RollbackResponseEcu, wrapper.RollbackResponseEcu, "ecu_id", "autoware"),
+        (v2.Status, wrapper.Status, "status", v2.INITIALIZED),
+        (v2.StatusProgress, wrapper.StatusProgress, "file_size_processed_copy", 123456),
+        (v2.StatusResponseEcu, wrapper.StatusResponseEcu, "result", v2.NO_FAILURE),
+        (v2.UpdateRequestEcu, wrapper.UpdateRequestEcu, "version", "789.x"),
+        (v2.UpdateResponseEcu, wrapper.UpdateResponseEcu, "ecu_id", "autoware"),
+    ),
+)
+def test_message_wrapper_normal_field(
+    pb_cls: Type[_message.Message],
+    wrapper_cls: Type[wrapper.MessageWrapperProtocol],
+    field_name: str,
+    field_value: Any,
+):
+    # test directly init
+    _directly_init = wrapper_cls(**{field_name: field_value})  # type: ignore
+    assert getattr(_directly_init, field_name) == field_value
+    assert _directly_init[field_name] == field_value
+
+    # test wrap
+    _data = pb_cls(**{field_name: field_value})
+    _wrapped = wrapper_cls.wrap(_data)
+    assert _directly_init == _wrapped
+    # test unwrap
+    assert _data == _wrapped.unwrap()
+    # test export_pb
+    _exported = _wrapped.export_pb()
+    assert _data == _exported
+
+    # test attrs proxy
+    _wrapped = wrapper_cls()
+    setattr(_wrapped, field_name, field_value)
+    assert getattr(_wrapped, field_name) == field_value
+    assert getattr(_wrapped.data, field_name) == field_value
+    assert _wrapped[field_name] == field_value
+
+
+@pytest.mark.parametrize(
+    "pb_cls, wrapper_cls, field_name, value",
+    (
+        (
+            v2.RollbackResponse,
+            wrapper.RollbackResponse,
+            "ecu",
+            wrapper.RollbackResponseEcu(),
+        ),
+        (v2.StatusResponse, wrapper.StatusResponse, "ecu", wrapper.StatusResponseEcu()),
+        (v2.UpdateResponse, wrapper.UpdateResponse, "ecu", wrapper.UpdateResponseEcu()),
+    ),
+)
+def test_message_wrapper_repeated_field(
+    pb_cls: Type[_message.Message],
+    wrapper_cls: Type[wrapper.MessageWrapperProtocol],
+    field_name: str,
+    value: wrapper.MessageWrapperProtocol,
+):
+    # prepare data
+    _data = pb_cls()
+    _ecu = _data.ecu.add()  # type: ignore
+    _ecu.CopyFrom(value.data)  # type: ignore
+
+    # test directly init
+    _directly_init = wrapper_cls()
+    _directly_init.add_ecu(value)
+    assert _directly_init.data == _data
+
+    # test wrap
+    _wrapped = wrapper_cls.wrap(_data)
+    # test unwrap
+    assert _data == _wrapped.unwrap()
+    # test export_pb
+    _exported = _wrapped.export_pb()
+    assert _data == _exported
+
+    # test attrs proxy
+    ## getattr
+    _wrapped = wrapper_cls()
+    getattr(_wrapped, field_name).append(value.data)
+    assert _wrapped.data == _data
+    ## getitem
+    _wrapped = wrapper_cls()
+    _wrapped[field_name].append(value.data)
+    assert _wrapped.data == _data
+
+
+# TODO: test helper methods for RollbackResponse, StatusProgress and UpdateResponse
+
+
+@pytest.mark.parametrize(
+    "pb_cls, wrapper_cls, enum_field_name",
+    (
+        (v2.FailureType, wrapper.FailureType, "NO_FAILURE"),
+        (v2.StatusOta, wrapper.StatusOta, "UPDATING"),
+        (v2.StatusProgressPhase, wrapper.StatusProgressPhase, "SYMLINK"),
+    ),
+)
+def test_enum_wrapper(
+    pb_cls, wrapper_cls: Type[wrapper.EnumWrapper], enum_field_name: str
+):
+    _origin = getattr(pb_cls, enum_field_name)
+    _proxied = wrapper_cls[enum_field_name]
+    assert _proxied == getattr(wrapper_cls, enum_field_name)
+    assert _origin == _proxied  # test directly comparing to pb types
+    assert _origin == _proxied.value
+    assert _origin == _proxied.export_pb()
+
+
+# specific types test files
+
+
+def test_Status():
+    _progress = wrapper.StatusProgress(total_regular_files=123456)
+    _failure, _failure_reason = wrapper.FailureType.RECOVERABLE, "recoverable"
+    _status = wrapper.Status(
+        progress=_progress.data,
+        failure=_failure.value,
+        failure_reason=_failure_reason,
+    )
+
+    # test helper methods of _status
+    assert _status.get_progress() == _progress
+    assert _status.get_failure() == (_failure, _failure_reason)
+
+
+def test_StatusResponse():
+    _ecu_status = wrapper.Status(
+        failure=wrapper.FailureType.NO_FAILURE.value,
+        failure_reason="no_failure",
+        version="789.x",
+    )
+    _mainecu = wrapper.StatusResponseEcu(
+        ecu_id="autoware",
+        result=wrapper.FailureType.NO_FAILURE.value,
+        status=_ecu_status.data,
+    )
+    _p1 = wrapper.StatusResponseEcu(
+        ecu_id="p1",
+        result=wrapper.FailureType.NO_FAILURE.value,
+        status=_ecu_status.data,
+    )
+
+    _status = wrapper.StatusResponse(available_ecu_ids=["autoware", "p1"])
+    _status_to_merge = wrapper.StatusResponse(available_ecu_ids=["p1"])
+    # test add_ecu method
+    _status.add_ecu(_mainecu)
+    _status_to_merge.add_ecu(_p1)
+    # test merge_from method
+    _status.merge_from(_status_to_merge)
+    # test get_ecu_status
+    assert _status.get_ecu_status("autoware") == (
+        "autoware",
+        wrapper.FailureType.NO_FAILURE,
+        _ecu_status,
+    )
+    # test iter_ecu_staus
+    for _ecu_id, _ecu_result, _ecu_status in _status.iter_ecu_status():
+        if _ecu_id == "autoware":
+            assert _ecu_result == wrapper.FailureType.NO_FAILURE, _mainecu.status
+        elif _ecu_id == "p1":
+            assert _ecu_result == wrapper.FailureType.NO_FAILURE, _p1.status
+        else:
+            assert False
+
+    # test update_available_ecu_ids
+    _s1 = wrapper.StatusResponse()
+    _s2 = wrapper.StatusResponse(available_ecu_ids=["autoware", "p1"])
+    _s1.update_available_ecu_ids("autoware", "p1")
+    assert _s1.available_ecu_ids == _s2.available_ecu_ids
+
+
+def test_UpdateRequest():
+    _ecu_id = "autoware"
+    _mainecu = wrapper.UpdateRequestEcu(ecu_id=_ecu_id, version="789.x")
+    _request = wrapper.UpdateRequest()
+    _request.ecu.append(_mainecu.data)
+
+    assert _request.find_update_meta(_ecu_id) == _mainecu
+    _itered = list(_request.iter_update_meta())
+    assert _itered[0] == _mainecu


### PR DESCRIPTION
## Introduction
This PR fixes some bugs and do some refinement over the ota_client_stub.

## Bug fixed and changes
1. [T4PB-19284](https://tier4.atlassian.net/browse/T4PB-19284): 
- now the unreachable subecu will be labelled as `RECOVERABLE` status by mainecu when it is unreachable.
- mainecu will keep waiting for unreachable subecu when updating, it is the end user's decision to interrupt the update session(by reboot all ecus) if unreachable subecus keep losing contact. 
2. [T4PB-19316](https://tier4.atlassian.net/browse/T4PB-19316):
- status API now return the **current** running image's version instead of the updating version when receiving update.
- https://tier4.atlassian.net/browse/T4PB-19101
3. ~~[T4PB-19283](https://tier4.atlassian.net/browse/T4PB-19283):~~
~~- in previous `ecu_info.py`, the following code caused the problem:  
  `return self._ecu_info.get("available_ecu_ids", [self.get_ecu_id()])`~~
4. no longer include the subecus' `available_ecu_ids` into the `status` API query response anymore.
5. fix ota_client_stub.status method caches wrong response. 

## Other changes and refinement
1. implement 2 API call helper methods in ota_client_call, use these 2 methods to simplify the implementation of update and status API stub method,
2. ota_client_stub: refinement over how coros are dispatched and gathered,
3. ota_client_stub: refinement over update tracker in UpdateSession, now update_tracker method expects input coros to return a bool to indicate the result of update,
5. ota_client_stub: implement SubECUTracker for tracking subecus' update progress and wait for all subecus ready.