### PR TITLE
Introduce wrapper for generated protobuf code

### DIFF
--- a/app/proto/__init__.py
+++ b/app/proto/__init__.py
@@ -36,5 +36,6 @@ del _import_proto, _import_from_file
 
 import otaclient_v2_pb2 as v2
 import otaclient_v2_pb2_grpc as v2_grpc
+from . import wrapper
 
-__all__ = ["v2", "v2_grpc"]
+__all__ = ["v2", "v2_grpc", "wrapper"]

--- a/app/proto/wrapper.py
+++ b/app/proto/wrapper.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import typing
+import otaclient_v2_pb2 as v2
+from enum import Enum
+from google.protobuf import message as _message
+from typing import Any, Type
+
+# only for type hints
+_UpdateRequest = typing.cast(Type[v2.UpdateRequest], object)
+
+
+class MessageWrapperMixin:
+    _proto_class: Type[_message.Message]
+    data: _message.Message
+
+    def export(self):
+        res = self._proto_class()
+        res.CopyFrom(self)  # type: ignore
+        return res
+
+    def __getattr__(self, __name: str) -> Any:
+        """Proxy attributes from the wrapped UpdateRequest."""
+        return getattr(self.data, __name)
+
+
+class UpdateRequestWrapper(MessageWrapperMixin, _UpdateRequest):
+    def __init__(self, _in: v2.UpdateRequest) -> None:
+        self._proto_class = _in.__class__
+        self.data = _in
+
+
+class EnumWrapperMixin:
+    @classmethod
+    def export(cls, _in: Enum):
+        if isinstance(_in, cls):
+            return _in.value
+        raise ValueError
+
+
+class StatusOtaWrapper(EnumWrapperMixin, Enum):
+    INITIALIZED = v2.INITIALIZED
+    SUCCESS = v2.SUCCESS
+    FAILURE = v2.FAILURE
+    UPDATING = v2.UPDATING
+    ROLLBACKING = v2.ROLLBACKING
+    ROLLBACK_FAILURE = v2.ROLLBACK_FAILURE
+
+
+class StatusProgressPhase(EnumWrapperMixin, Enum):
+    INITIAL = v2.INITIAL
+    METADATA = v2.METADATA
+    DIRECTORY = v2.DIRECTORY
+    SYMLINK = v2.SYMLINK
+    REGULAR = v2.REGULAR
+    PERSISTENT = v2.PERSISTENT
+    POST_PROCESSING = v2.POST_PROCESSING

--- a/app/proto/wrapper.py
+++ b/app/proto/wrapper.py
@@ -76,6 +76,9 @@ class MessageWrapperMixin:
         _new_data.CopyFrom(self.data)
         return self.wrap(_new_data)
 
+    def unwrap(self):
+        return self.data
+
 
 class EnumWrapperMixin:
     __proto_class__: ClassVar[Type]
@@ -96,24 +99,28 @@ class EnumWrapperMixin:
 
 
 ## rollback
+class RollbackRequestEcu(MessageWrapperMixin, _RollbackRequestEcu):
+    proto_class = v2.RollbackRequestEcu
+    data: v2.RollbackRequestEcu
+
+
 class RollbackRequest(MessageWrapperMixin, _RollbackRequest):
     proto_class = v2.RollbackRequest
     data: v2.RollbackRequest
 
 
-class RollbackRequestEcu(MessageWrapperMixin, _RollbackRequestEcu):
-    proto_class = v2.RollbackRequestEcu
-    data: v2.RollbackRequestEcu
+class RollbackResponseEcu(MessageWrapperMixin, _RollbackResponseEcu):
+    proto_class = v2.RollbackResponseEcu
+    data: v2.RollbackResponseEcu
 
 
 class RollbackResponse(MessageWrapperMixin, _RollbackResponse):
     proto_class = v2.RollbackResponse
     data: v2.RollbackResponse
 
-
-class RollbackResponseEcu(MessageWrapperMixin, _RollbackResponseEcu):
-    proto_class = v2.RollbackResponseEcu
-    data: v2.RollbackResponseEcu
+    def add_ecu(self, _response_ecu: RollbackResponseEcu):
+        _ecu = typing.cast(v2.RollbackResponseEcu, _response_ecu.unwrap())
+        self.data.ecu.append(_ecu)
 
 
 ## status API
@@ -132,17 +139,26 @@ class StatusRequest(MessageWrapperMixin, _StatusRequest):
     data: v2.StatusRequest
 
 
-class StatusResponse(MessageWrapperMixin, _StatusResponse):
-    proto_class = v2.StatusResponse
-    data: v2.StatusResponse
-
-
 class StatusResponseEcu(MessageWrapperMixin, _StatusResponseEcu):
     proto_class = v2.StatusResponseEcu
     data: v2.StatusResponseEcu
 
 
+class StatusResponse(MessageWrapperMixin, _StatusResponse):
+    proto_class = v2.StatusResponse
+    data: v2.StatusResponse
+
+    def add_ecu(self, _response_ecu: StatusResponseEcu):
+        _ecu = typing.cast(v2.StatusResponseEcu, _response_ecu.unwrap())
+        self.data.ecu.append(_ecu)
+
+
 ## update API
+class UpdateRequestEcu(MessageWrapperMixin, _UpdateRequestEcu):
+    proto_class = v2.UpdateRequestEcu
+    data: v2.UpdateRequestEcu
+
+
 class UpdateRequest(MessageWrapperMixin, _UpdateRequest):
     proto_class = v2.UpdateRequest
     data: v2.UpdateRequest
@@ -153,19 +169,18 @@ class UpdateRequest(MessageWrapperMixin, _UpdateRequest):
                 return UpdateRequestEcu.wrap(request_ecu)
 
 
-class UpdateRequestEcu(MessageWrapperMixin, _UpdateRequestEcu):
-    proto_class = v2.UpdateRequestEcu
-    data: v2.UpdateRequestEcu
+class UpdateResponseEcu(MessageWrapperMixin, _UpdateResponseEcu):
+    proto_class = v2.UpdateResponseEcu
+    data: v2.UpdateResponseEcu
 
 
 class UpdateResponse(MessageWrapperMixin, _UpdateResponse):
     proto_class = v2.UpdateResponse
     data: v2.UpdateResponse
 
-
-class UpdateResponseEcu(MessageWrapperMixin, _UpdateResponseEcu):
-    proto_class = v2.UpdateResponseEcu
-    data: v2.UpdateResponseEcu
+    def add_ecu(self, _response_ecu: UpdateResponseEcu):
+        _ecu = typing.cast(v2.UpdateResponseEcu, _response_ecu.unwrap())
+        self.data.ecu.append(_ecu)
 
 
 # enum

--- a/app/proto/wrapper.py
+++ b/app/proto/wrapper.py
@@ -12,7 +12,6 @@ class _WrapperBase:
     wrapped proto class instance."""
 
     proto_class: ClassVar[Type[_message.Message]]
-    data: _message.Message
 
     def __init__(self, *args, **kwargs):
         self.data = self.proto_class(*args, **kwargs)
@@ -35,12 +34,19 @@ class _WrapperBase:
         setattr(self.data, __key, __value)
 
 
-_StatusResponse = typing.cast(Type[v2.StatusResponse], _WrapperBase)
-_StatusResponseEcu = typing.cast(Type[v2.StatusResponseEcu], _WrapperBase)
+_RollbackRequest = typing.cast(Type[v2.RollbackRequest], _WrapperBase)
+_RollbackRequestEcu = typing.cast(Type[v2.RollbackRequestEcu], _WrapperBase)
+_RollbackResponse = typing.cast(Type[v2.RollbackResponse], _WrapperBase)
+_RollbackResponseEcu = typing.cast(Type[v2.RollbackResponseEcu], _WrapperBase)
 _Status = typing.cast(Type[v2.Status], _WrapperBase)
 _StatusProgress = typing.cast(Type[v2.StatusProgress], _WrapperBase)
+_StatusRequest = typing.cast(Type[v2.StatusRequest], _WrapperBase)
+_StatusResponse = typing.cast(Type[v2.StatusResponse], _WrapperBase)
+_StatusResponseEcu = typing.cast(Type[v2.StatusResponseEcu], _WrapperBase)
 _UpdateRequest = typing.cast(Type[v2.UpdateRequest], _WrapperBase)
 _UpdateRequestEcu = typing.cast(Type[v2.UpdateRequestEcu], _WrapperBase)
+_UpdateResponse = typing.cast(Type[v2.UpdateResponse], _WrapperBase)
+_UpdateResponseEcu = typing.cast(Type[v2.UpdateRequestEcu], _WrapperBase)
 
 
 class MessageWrapperMixin:
@@ -71,47 +77,92 @@ class MessageWrapperMixin:
         return self.wrap(_new_data)
 
 
-class StatusResponseWrapper(MessageWrapperMixin, _StatusResponse):
-    proto_class = v2.StatusResponse
-    data: v2.StatusResponse
-
-
-class StatusResponseEcuWrapper(MessageWrapperMixin, _StatusResponseEcu):
-    proto_class = v2.StatusResponseEcu
-    data: v2.StatusResponseEcu
-
-
-class StatusWrapper(MessageWrapperMixin, _Status):
-    proto_class = v2.Status
-    data: v2.Status
-
-
-class StatusProgressWrapper(MessageWrapperMixin, _StatusProgress):
-    proto_class = v2.StatusProgress
-    data: v2.StatusProgress
-
-
-class UpdateRequestEcuWrapper(MessageWrapperMixin, _UpdateRequestEcu):
-    proto_class = v2.UpdateRequestEcu
-    data: v2.UpdateRequestEcu
-
-
-class UpdateRequestWrapper(MessageWrapperMixin, _UpdateRequest):
-    proto_class = v2.UpdateRequest
-    data: v2.UpdateRequest
-
-    def find_request(self, ecu_id: str) -> Optional[UpdateRequestEcuWrapper]:
-        for request_ecu in self.ecu:
-            if request_ecu.ecu_id == ecu_id:
-                return UpdateRequestEcuWrapper.wrap(request_ecu)
-
-
 class EnumWrapperMixin:
     def export_pb(self):
         raise self.value  # type: ignore
 
 
-class FailureTypeWrapper(EnumWrapperMixin, Enum):
+# message
+
+
+## rollback
+class RollbackRequest(MessageWrapperMixin, _RollbackRequest):
+    proto_class = v2.RollbackRequest
+    data: v2.RollbackRequest
+
+
+class RollbackRequestEcu(MessageWrapperMixin, _RollbackRequestEcu):
+    proto_class = v2.RollbackRequestEcu
+    data: v2.RollbackRequestEcu
+
+
+class RollbackResponse(MessageWrapperMixin, _RollbackResponse):
+    proto_class = v2.RollbackResponse
+    data: v2.RollbackResponse
+
+
+class RollbackResponseEcu(MessageWrapperMixin, _RollbackResponseEcu):
+    proto_class = v2.RollbackResponseEcu
+    data: v2.RollbackResponseEcu
+
+
+## status API
+class Status(MessageWrapperMixin, _Status):
+    proto_class = v2.Status
+    data: v2.Status
+
+
+class StatusProgress(MessageWrapperMixin, _StatusProgress):
+    proto_class = v2.StatusProgress
+    data: v2.StatusProgress
+
+
+class StatusRequest(MessageWrapperMixin, _StatusRequest):
+    proto_class = v2.StatusRequest
+    data: v2.StatusRequest
+
+
+class StatusResponse(MessageWrapperMixin, _StatusResponse):
+    proto_class = v2.StatusResponse
+    data: v2.StatusResponse
+
+
+class StatusResponseEcu(MessageWrapperMixin, _StatusResponseEcu):
+    proto_class = v2.StatusResponseEcu
+    data: v2.StatusResponseEcu
+
+
+## update API
+class UpdateRequest(MessageWrapperMixin, _UpdateRequest):
+    proto_class = v2.UpdateRequest
+    data: v2.UpdateRequest
+
+    def find_request(self, ecu_id: str) -> Optional[UpdateRequestEcu]:
+        for request_ecu in self.ecu:
+            if request_ecu.ecu_id == ecu_id:
+                return UpdateRequestEcu.wrap(request_ecu)
+
+
+class UpdateRequestEcu(MessageWrapperMixin, _UpdateRequestEcu):
+    proto_class = v2.UpdateRequestEcu
+    data: v2.UpdateRequestEcu
+
+
+class UpdateResponse(MessageWrapperMixin, _UpdateResponse):
+    proto_class = v2.UpdateResponse
+    data: v2.UpdateResponse
+
+
+class UpdateResponseEcu(MessageWrapperMixin, _UpdateResponseEcu):
+    proto_class = v2.UpdateResponseEcu
+    data: v2.UpdateResponseEcu
+
+
+# enum
+
+
+class FailureType(EnumWrapperMixin, Enum):
+    _proto_class = v2.FailureType
     NO_FAILURE = v2.NO_FAILURE
     RECOVERABLE = v2.RECOVERABLE
     UNRECOVERABLE = v2.UNRECOVERABLE
@@ -120,7 +171,8 @@ class FailureTypeWrapper(EnumWrapperMixin, Enum):
         return f"{self.value:0>1}"
 
 
-class StatusOtaWrapper(EnumWrapperMixin, Enum):
+class StatusOta(EnumWrapperMixin, Enum):
+    _proto_class = v2.StatusOta
     INITIALIZED = v2.INITIALIZED
     SUCCESS = v2.SUCCESS
     FAILURE = v2.FAILURE
@@ -129,7 +181,8 @@ class StatusOtaWrapper(EnumWrapperMixin, Enum):
     ROLLBACK_FAILURE = v2.ROLLBACK_FAILURE
 
 
-class StatusProgressPhaseWrapper(EnumWrapperMixin, Enum):
+class StatusProgressPhase(EnumWrapperMixin, Enum):
+    _proto_class = v2.StatusProgressPhase
     INITIAL = v2.INITIAL
     METADATA = v2.METADATA
     DIRECTORY = v2.DIRECTORY

--- a/app/proto/wrapper.py
+++ b/app/proto/wrapper.py
@@ -4,38 +4,120 @@ import typing
 import otaclient_v2_pb2 as v2
 from enum import Enum
 from google.protobuf import message as _message
-from typing import Any, Type
+from typing import Any, ClassVar, Optional, Type
 
-# only for type hints
-_UpdateRequest = typing.cast(Type[v2.UpdateRequest], object)
+
+class _WrapperBase:
+    """A proxy wrapper base that proxies all attrs from/to the
+    wrapped proto class instance."""
+
+    proto_class: ClassVar[Type[_message.Message]]
+    data: _message.Message
+
+    def __init__(self, *args, **kwargs):
+        self.data = self.proto_class(*args, **kwargs)
+
+    def __getattr__(self, __name: str) -> Any:
+        if __name in ["data", "proto_class"]:
+            return super().__getattribute__(__name)
+        return getattr(self.data, __name)
+
+    def __getitem__(self, __name: str) -> Any:
+        return getattr(self.data, __name)
+
+    def __setattr__(self, __name: str, __value: Any):
+        if __name in ["data", "proto_class"]:
+            super().__setattr__(__name, __value)
+        else:
+            setattr(self.data, __name, __value)
+
+    def __setitem__(self, __key: str, __value: Any):
+        setattr(self.data, __key, __value)
+
+
+_StatusResponse = typing.cast(Type[v2.StatusResponse], _WrapperBase)
+_StatusResponseEcu = typing.cast(Type[v2.StatusResponseEcu], _WrapperBase)
+_Status = typing.cast(Type[v2.Status], _WrapperBase)
+_StatusProgress = typing.cast(Type[v2.StatusProgress], _WrapperBase)
+_UpdateRequest = typing.cast(Type[v2.UpdateRequest], _WrapperBase)
+_UpdateRequestEcu = typing.cast(Type[v2.UpdateRequestEcu], _WrapperBase)
 
 
 class MessageWrapperMixin:
-    _proto_class: Type[_message.Message]
+    proto_class: ClassVar[Type[_message.Message]]
     data: _message.Message
 
-    def export(self):
-        res = self._proto_class()
-        res.CopyFrom(self)  # type: ignore
+    def export_pb(self):
+        res = self.proto_class()
+        res.CopyFrom(self.data)
         return res
 
-    def __getattr__(self, __name: str) -> Any:
-        """Proxy attributes from the wrapped UpdateRequest."""
-        return getattr(self.data, __name)
+    @classmethod
+    def wrap(cls, _in: Optional[_message.Message] = None):
+        if _in is not None and not isinstance(_in, cls.proto_class):
+            raise ValueError(
+                f"wrong input type, expect={cls.proto_class}, in={_in.__class__}"
+            )
+
+        res = cls()
+        if _in is not None:
+            res.data = _in
+        return res
+
+    def copy(self):
+        """Copy the wrapped data to a new wrapper with CopyFrom."""
+        _new_data = self.proto_class()
+        _new_data.CopyFrom(self.data)
+        return self.wrap(_new_data)
+
+
+class StatusResponseWrapper(MessageWrapperMixin, _StatusResponse):
+    proto_class = v2.StatusResponse
+    data: v2.StatusResponse
+
+
+class StatusResponseEcuWrapper(MessageWrapperMixin, _StatusResponseEcu):
+    proto_class = v2.StatusResponseEcu
+    data: v2.StatusResponseEcu
+
+
+class StatusWrapper(MessageWrapperMixin, _Status):
+    proto_class = v2.Status
+    data: v2.Status
+
+
+class StatusProgressWrapper(MessageWrapperMixin, _StatusProgress):
+    proto_class = v2.StatusProgress
+    data: v2.StatusProgress
+
+
+class UpdateRequestEcuWrapper(MessageWrapperMixin, _UpdateRequestEcu):
+    proto_class = v2.UpdateRequestEcu
+    data: v2.UpdateRequestEcu
 
 
 class UpdateRequestWrapper(MessageWrapperMixin, _UpdateRequest):
-    def __init__(self, _in: v2.UpdateRequest) -> None:
-        self._proto_class = _in.__class__
-        self.data = _in
+    proto_class = v2.UpdateRequest
+    data: v2.UpdateRequest
+
+    def find_request(self, ecu_id: str) -> Optional[UpdateRequestEcuWrapper]:
+        for request_ecu in self.ecu:
+            if request_ecu.ecu_id == ecu_id:
+                return UpdateRequestEcuWrapper.wrap(request_ecu)
 
 
 class EnumWrapperMixin:
-    @classmethod
-    def export(cls, _in: Enum):
-        if isinstance(_in, cls):
-            return _in.value
-        raise ValueError
+    def export_pb(self):
+        raise self.value  # type: ignore
+
+
+class FailureTypeWrapper(EnumWrapperMixin, Enum):
+    NO_FAILURE = v2.NO_FAILURE
+    RECOVERABLE = v2.RECOVERABLE
+    UNRECOVERABLE = v2.UNRECOVERABLE
+
+    def to_str(self) -> str:
+        return f"{self.value:0>1}"
 
 
 class StatusOtaWrapper(EnumWrapperMixin, Enum):
@@ -47,7 +129,7 @@ class StatusOtaWrapper(EnumWrapperMixin, Enum):
     ROLLBACK_FAILURE = v2.ROLLBACK_FAILURE
 
 
-class StatusProgressPhase(EnumWrapperMixin, Enum):
+class StatusProgressPhaseWrapper(EnumWrapperMixin, Enum):
     INITIAL = v2.INITIAL
     METADATA = v2.METADATA
     DIRECTORY = v2.DIRECTORY

--- a/app/proto/wrapper.py
+++ b/app/proto/wrapper.py
@@ -81,7 +81,15 @@ class EnumWrapperMixin:
     __proto_class__: ClassVar[Type]
 
     def export_pb(self):
-        raise self.value  # type: ignore
+        return self.value  # type: ignore
+
+    def __eq__(self, __o: object) -> bool:
+        """Support directly comparing with v2 Enum types."""
+        if isinstance(__o, self.__proto_class__):
+            return __o == self.value  # type: ignore
+        if isinstance(__o, self.__class__):
+            return __o == self
+        return False
 
 
 # message

--- a/app/proto/wrapper.py
+++ b/app/proto/wrapper.py
@@ -66,6 +66,11 @@ class MessageWrapperProtocol(Protocol):
     def __setitem__(self, __key: str, __value: Any):
         setattr(self.data, __key, __value)
 
+    def __eq__(self, __o: object) -> bool:
+        if isinstance(__o, self.__class__):
+            return __o.data == self.data
+        return False
+
     def export_pb(self):
         res = self.proto_class()
         res.CopyFrom(self.data)

--- a/app/proto/wrapper.py
+++ b/app/proto/wrapper.py
@@ -89,8 +89,8 @@ class EnumWrapper(Enum):
     def __eq__(self, __o: object) -> bool:
         """Support directly comparing with v2 Enum types."""
         if isinstance(__o, self.__class__):
-            return __o == self
-        return __o == self.value
+            return super().__eq__(__o)
+        return self.value == __o
 
 
 # message

--- a/app/proto/wrapper.py
+++ b/app/proto/wrapper.py
@@ -4,14 +4,34 @@ import typing
 import otaclient_v2_pb2 as v2
 from enum import Enum
 from google.protobuf import message as _message
-from typing import Any, ClassVar, Optional, Type
+from typing import Any, ClassVar, Optional, Protocol, Type
 
 
 class _WrapperBase:
+    """Dummy base for wrapper types."""
+
+
+_RollbackRequest = typing.cast(Type[v2.RollbackRequest], _WrapperBase)
+_RollbackRequestEcu = typing.cast(Type[v2.RollbackRequestEcu], _WrapperBase)
+_RollbackResponse = typing.cast(Type[v2.RollbackResponse], _WrapperBase)
+_RollbackResponseEcu = typing.cast(Type[v2.RollbackResponseEcu], _WrapperBase)
+_Status = typing.cast(Type[v2.Status], _WrapperBase)
+_StatusProgress = typing.cast(Type[v2.StatusProgress], _WrapperBase)
+_StatusRequest = typing.cast(Type[v2.StatusRequest], _WrapperBase)
+_StatusResponse = typing.cast(Type[v2.StatusResponse], _WrapperBase)
+_StatusResponseEcu = typing.cast(Type[v2.StatusResponseEcu], _WrapperBase)
+_UpdateRequest = typing.cast(Type[v2.UpdateRequest], _WrapperBase)
+_UpdateRequestEcu = typing.cast(Type[v2.UpdateRequestEcu], _WrapperBase)
+_UpdateResponse = typing.cast(Type[v2.UpdateResponse], _WrapperBase)
+_UpdateResponseEcu = typing.cast(Type[v2.UpdateRequestEcu], _WrapperBase)
+
+
+class MessageWrapperProtocol(Protocol):
     """A proxy wrapper base that proxies all attrs from/to the
     wrapped proto class instance."""
 
     proto_class: ClassVar[Type[_message.Message]]
+    data: _message.Message
 
     def __init__(self, *args, **kwargs):
         self.data = self.proto_class(*args, **kwargs)
@@ -32,26 +52,6 @@ class _WrapperBase:
 
     def __setitem__(self, __key: str, __value: Any):
         setattr(self.data, __key, __value)
-
-
-_RollbackRequest = typing.cast(Type[v2.RollbackRequest], _WrapperBase)
-_RollbackRequestEcu = typing.cast(Type[v2.RollbackRequestEcu], _WrapperBase)
-_RollbackResponse = typing.cast(Type[v2.RollbackResponse], _WrapperBase)
-_RollbackResponseEcu = typing.cast(Type[v2.RollbackResponseEcu], _WrapperBase)
-_Status = typing.cast(Type[v2.Status], _WrapperBase)
-_StatusProgress = typing.cast(Type[v2.StatusProgress], _WrapperBase)
-_StatusRequest = typing.cast(Type[v2.StatusRequest], _WrapperBase)
-_StatusResponse = typing.cast(Type[v2.StatusResponse], _WrapperBase)
-_StatusResponseEcu = typing.cast(Type[v2.StatusResponseEcu], _WrapperBase)
-_UpdateRequest = typing.cast(Type[v2.UpdateRequest], _WrapperBase)
-_UpdateRequestEcu = typing.cast(Type[v2.UpdateRequestEcu], _WrapperBase)
-_UpdateResponse = typing.cast(Type[v2.UpdateResponse], _WrapperBase)
-_UpdateResponseEcu = typing.cast(Type[v2.UpdateRequestEcu], _WrapperBase)
-
-
-class MessageWrapperMixin:
-    proto_class: ClassVar[Type[_message.Message]]
-    data: _message.Message
 
     def export_pb(self):
         res = self.proto_class()
@@ -80,7 +80,7 @@ class MessageWrapperMixin:
         return self.data
 
 
-class EnumWrapperMixin:
+class EnumWrapperProtocol:
     __proto_class__: ClassVar[Type]
 
     def export_pb(self):
@@ -99,22 +99,22 @@ class EnumWrapperMixin:
 
 
 ## rollback
-class RollbackRequestEcu(MessageWrapperMixin, _RollbackRequestEcu):
+class RollbackRequestEcu(MessageWrapperProtocol, _RollbackRequestEcu):
     proto_class = v2.RollbackRequestEcu
     data: v2.RollbackRequestEcu
 
 
-class RollbackRequest(MessageWrapperMixin, _RollbackRequest):
+class RollbackRequest(MessageWrapperProtocol, _RollbackRequest):
     proto_class = v2.RollbackRequest
     data: v2.RollbackRequest
 
 
-class RollbackResponseEcu(MessageWrapperMixin, _RollbackResponseEcu):
+class RollbackResponseEcu(MessageWrapperProtocol, _RollbackResponseEcu):
     proto_class = v2.RollbackResponseEcu
     data: v2.RollbackResponseEcu
 
 
-class RollbackResponse(MessageWrapperMixin, _RollbackResponse):
+class RollbackResponse(MessageWrapperProtocol, _RollbackResponse):
     proto_class = v2.RollbackResponse
     data: v2.RollbackResponse
 
@@ -124,27 +124,27 @@ class RollbackResponse(MessageWrapperMixin, _RollbackResponse):
 
 
 ## status API
-class Status(MessageWrapperMixin, _Status):
+class Status(MessageWrapperProtocol, _Status):
     proto_class = v2.Status
     data: v2.Status
 
 
-class StatusProgress(MessageWrapperMixin, _StatusProgress):
+class StatusProgress(MessageWrapperProtocol, _StatusProgress):
     proto_class = v2.StatusProgress
     data: v2.StatusProgress
 
 
-class StatusRequest(MessageWrapperMixin, _StatusRequest):
+class StatusRequest(MessageWrapperProtocol, _StatusRequest):
     proto_class = v2.StatusRequest
     data: v2.StatusRequest
 
 
-class StatusResponseEcu(MessageWrapperMixin, _StatusResponseEcu):
+class StatusResponseEcu(MessageWrapperProtocol, _StatusResponseEcu):
     proto_class = v2.StatusResponseEcu
     data: v2.StatusResponseEcu
 
 
-class StatusResponse(MessageWrapperMixin, _StatusResponse):
+class StatusResponse(MessageWrapperProtocol, _StatusResponse):
     proto_class = v2.StatusResponse
     data: v2.StatusResponse
 
@@ -154,12 +154,12 @@ class StatusResponse(MessageWrapperMixin, _StatusResponse):
 
 
 ## update API
-class UpdateRequestEcu(MessageWrapperMixin, _UpdateRequestEcu):
+class UpdateRequestEcu(MessageWrapperProtocol, _UpdateRequestEcu):
     proto_class = v2.UpdateRequestEcu
     data: v2.UpdateRequestEcu
 
 
-class UpdateRequest(MessageWrapperMixin, _UpdateRequest):
+class UpdateRequest(MessageWrapperProtocol, _UpdateRequest):
     proto_class = v2.UpdateRequest
     data: v2.UpdateRequest
 
@@ -169,12 +169,12 @@ class UpdateRequest(MessageWrapperMixin, _UpdateRequest):
                 return UpdateRequestEcu.wrap(request_ecu)
 
 
-class UpdateResponseEcu(MessageWrapperMixin, _UpdateResponseEcu):
+class UpdateResponseEcu(MessageWrapperProtocol, _UpdateResponseEcu):
     proto_class = v2.UpdateResponseEcu
     data: v2.UpdateResponseEcu
 
 
-class UpdateResponse(MessageWrapperMixin, _UpdateResponse):
+class UpdateResponse(MessageWrapperProtocol, _UpdateResponse):
     proto_class = v2.UpdateResponse
     data: v2.UpdateResponse
 
@@ -186,7 +186,7 @@ class UpdateResponse(MessageWrapperMixin, _UpdateResponse):
 # enum
 
 
-class FailureType(EnumWrapperMixin, Enum):
+class FailureType(EnumWrapperProtocol, Enum):
     __proto_class__ = v2.FailureType
     NO_FAILURE = v2.NO_FAILURE
     RECOVERABLE = v2.RECOVERABLE
@@ -196,7 +196,7 @@ class FailureType(EnumWrapperMixin, Enum):
         return f"{self.value:0>1}"
 
 
-class StatusOta(EnumWrapperMixin, Enum):
+class StatusOta(EnumWrapperProtocol, Enum):
     __proto_class__ = v2.StatusOta
     INITIALIZED = v2.INITIALIZED
     SUCCESS = v2.SUCCESS
@@ -206,7 +206,7 @@ class StatusOta(EnumWrapperMixin, Enum):
     ROLLBACK_FAILURE = v2.ROLLBACK_FAILURE
 
 
-class StatusProgressPhase(EnumWrapperMixin, Enum):
+class StatusProgressPhase(EnumWrapperProtocol, Enum):
     __proto_class__ = v2.StatusProgressPhase
     INITIAL = v2.INITIAL
     METADATA = v2.METADATA

--- a/app/proto/wrapper.py
+++ b/app/proto/wrapper.py
@@ -78,6 +78,8 @@ class MessageWrapperMixin:
 
 
 class EnumWrapperMixin:
+    __proto_class__: ClassVar[Type]
+
     def export_pb(self):
         raise self.value  # type: ignore
 
@@ -162,7 +164,7 @@ class UpdateResponseEcu(MessageWrapperMixin, _UpdateResponseEcu):
 
 
 class FailureType(EnumWrapperMixin, Enum):
-    _proto_class = v2.FailureType
+    __proto_class__ = v2.FailureType
     NO_FAILURE = v2.NO_FAILURE
     RECOVERABLE = v2.RECOVERABLE
     UNRECOVERABLE = v2.UNRECOVERABLE
@@ -172,7 +174,7 @@ class FailureType(EnumWrapperMixin, Enum):
 
 
 class StatusOta(EnumWrapperMixin, Enum):
-    _proto_class = v2.StatusOta
+    __proto_class__ = v2.StatusOta
     INITIALIZED = v2.INITIALIZED
     SUCCESS = v2.SUCCESS
     FAILURE = v2.FAILURE
@@ -182,7 +184,7 @@ class StatusOta(EnumWrapperMixin, Enum):
 
 
 class StatusProgressPhase(EnumWrapperMixin, Enum):
-    _proto_class = v2.StatusProgressPhase
+    __proto_class__ = v2.StatusProgressPhase
     INITIAL = v2.INITIAL
     METADATA = v2.METADATA
     DIRECTORY = v2.DIRECTORY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,11 @@ branch = true
 omit = ["app/proto/*pb2*"]
 show_missing = true
 
+[tool.pyright]
+exclude = ["**/__pycache__"]
+ignore = ["app/proto/otaclient_v2_pb2*"]
+pythonVersion = "3.8"
+
 [tool.pytest.ini_options]
 log_auto_indent = true
 log_format = "%(asctime)s %(levelname)s %(filename)s %(funcName)s,%(lineno)d %(message)s"

--- a/tests/test_proto/test_wrapper.py
+++ b/tests/test_proto/test_wrapper.py
@@ -50,6 +50,7 @@ def test_message_wrapper_normal_field(
     setattr(_wrapped, field_name, field_value)
     assert getattr(_wrapped, field_name) == field_value
     assert getattr(_wrapped.data, field_name) == field_value
+    assert _wrapped[field_name] == field_value
 
 
 @pytest.mark.parametrize(
@@ -102,8 +103,15 @@ def test_message_wrapper_repeated_field(
     assert _copied.data == _wrapped.data and _copied.data is not _wrapped.data
 
     # test attrs proxy
+    ## getattr
     _wrapped = wrapper_cls()
     _field = getattr(_wrapped, field_name)
+    _ecu = _field.add()
+    _ecu.CopyFrom(value.data)
+    assert _wrapped.data == _data
+    ## getitem
+    _wrapped = wrapper_cls()
+    _field = _wrapped[field_name]
     _ecu = _field.add()
     _ecu.CopyFrom(value.data)
     assert _wrapped.data == _data

--- a/tests/test_proto/test_wrapper.py
+++ b/tests/test_proto/test_wrapper.py
@@ -1,0 +1,127 @@
+from typing import Any, Type
+from google.protobuf import message as _message
+
+import pytest
+
+from app.proto import wrapper
+from app.proto import v2
+
+
+@pytest.mark.parametrize(
+    "pb_cls, wrapper_cls, field_name, field_value",
+    (
+        (v2.RollbackRequestEcu, wrapper.RollbackRequestEcu, "ecu_id", "autoware"),
+        (v2.RollbackResponseEcu, wrapper.RollbackResponseEcu, "ecu_id", "autoware"),
+        (v2.Status, wrapper.Status, "status", v2.INITIALIZED),
+        (v2.StatusProgress, wrapper.StatusProgress, "file_size_processed_copy", 123456),
+        (v2.StatusResponseEcu, wrapper.StatusResponseEcu, "result", v2.NO_FAILURE),
+        (v2.UpdateRequestEcu, wrapper.UpdateRequestEcu, "version", "789.x"),
+        (v2.UpdateResponseEcu, wrapper.UpdateResponseEcu, "ecu_id", "autoware"),
+    ),
+)
+def test_message_wrapper_normal_field(
+    pb_cls: Type[_message.Message],
+    wrapper_cls: Type[wrapper.MessageWrapperProtocol],
+    field_name: str,
+    field_value: Any,
+):
+    # test directly init
+    _directly_init = wrapper_cls(**{field_name: field_value})  # type: ignore
+    assert getattr(_directly_init, field_name) == field_value
+
+    # test wrap
+    _data = pb_cls(**{field_name: field_value})
+    _wrapped = wrapper_cls.wrap(_data)
+    assert _directly_init.data == _wrapped.data
+    assert _wrapped.data is _data  # wrap
+    # test unwrap
+    assert _data is _wrapped.unwrap()
+    # test export_pb
+    _exported = _wrapped.export_pb()
+    assert _data == _exported and _data is not _exported
+
+    # test copy
+    _copied = _wrapped.copy()
+    # NOTE: the underlaying data is also copied
+    assert _copied.data == _wrapped.data and _copied.data is not _wrapped.data
+
+    # test attrs proxy
+    _wrapped = wrapper_cls()
+    setattr(_wrapped, field_name, field_value)
+    assert getattr(_wrapped, field_name) == field_value
+    assert getattr(_wrapped.data, field_name) == field_value
+
+
+@pytest.mark.parametrize(
+    "pb_cls, wrapper_cls, field_name, value",
+    (
+        (
+            v2.RollbackRequest,
+            wrapper.RollbackRequest,
+            "ecu",
+            wrapper.RollbackRequestEcu(),
+        ),
+        (
+            v2.RollbackResponse,
+            wrapper.RollbackResponse,
+            "ecu",
+            wrapper.RollbackResponseEcu(),
+        ),
+        (v2.UpdateRequest, wrapper.UpdateRequest, "ecu", wrapper.UpdateRequestEcu()),
+        (v2.UpdateResponse, wrapper.UpdateResponse, "ecu", wrapper.UpdateResponseEcu()),
+    ),
+)
+def test_message_wrapper_repeated_field(
+    pb_cls: Type[_message.Message],
+    wrapper_cls: Type[wrapper.MessageWrapperProtocol],
+    field_name: str,
+    value: wrapper.MessageWrapperProtocol,
+):
+    # prepare data
+    _data = pb_cls()
+    _ecu = _data.ecu.add()  # type: ignore
+    _ecu.CopyFrom(value.data)  # type: ignore
+
+    # test directly init
+    _directly_init = wrapper_cls()
+    _directly_init.add_ecu(value)
+    assert _directly_init.data == _data
+
+    # test wrap
+    _wrapped = wrapper_cls.wrap(_data)
+    assert _wrapped.data is _data  # wrap
+    # test unwrap
+    assert _data is _wrapped.unwrap()
+    # test export_pb
+    _exported = _wrapped.export_pb()
+    assert _data == _exported and _data is not _exported
+
+    # test copy
+    _copied = _wrapped.copy()
+    # NOTE: the underlaying data is also copied
+    assert _copied.data == _wrapped.data and _copied.data is not _wrapped.data
+
+    # test attrs proxy
+    _wrapped = wrapper_cls()
+    _field = getattr(_wrapped, field_name)
+    _ecu = _field.add()
+    _ecu.CopyFrom(value.data)
+    assert _wrapped.data == _data
+
+
+@pytest.mark.parametrize(
+    "pb_cls, wrapper_cls, enum_field_name",
+    (
+        (v2.FailureType, wrapper.FailureType, "NO_FAILURE"),
+        (v2.StatusOta, wrapper.StatusOta, "UPDATING"),
+        (v2.StatusProgressPhase, wrapper.StatusProgressPhase, "SYMLINK"),
+    ),
+)
+def test_enum_wrapper(
+    pb_cls, wrapper_cls: Type[wrapper.EnumWrapper], enum_field_name: str
+):
+    _origin = getattr(pb_cls, enum_field_name)
+    _proxied = wrapper_cls[enum_field_name]
+    assert _origin == _proxied  # test directly comparing to pb types
+    assert _origin == _proxied.value
+    assert _origin == _proxied.export_pb()

--- a/tests/test_proto/test_wrapper.py
+++ b/tests/test_proto/test_wrapper.py
@@ -28,6 +28,7 @@ def test_message_wrapper_normal_field(
     # test directly init
     _directly_init = wrapper_cls(**{field_name: field_value})  # type: ignore
     assert getattr(_directly_init, field_name) == field_value
+    assert _directly_init[field_name] == field_value
 
     # test wrap
     _data = pb_cls(**{field_name: field_value})
@@ -130,6 +131,7 @@ def test_enum_wrapper(
 ):
     _origin = getattr(pb_cls, enum_field_name)
     _proxied = wrapper_cls[enum_field_name]
+    assert _proxied == getattr(wrapper_cls, enum_field_name)
     assert _origin == _proxied  # test directly comparing to pb types
     assert _origin == _proxied.value
     assert _origin == _proxied.export_pb()

--- a/tests/test_proto/test_wrapper.py
+++ b/tests/test_proto/test_wrapper.py
@@ -1,7 +1,6 @@
-from typing import Any, Type
-from google.protobuf import message as _message
-
 import pytest
+from google.protobuf import message as _message
+from typing import Any, Type
 
 from app.proto import wrapper
 from app.proto import v2
@@ -41,8 +40,8 @@ def test_message_wrapper_normal_field(
     _exported = _wrapped.export_pb()
     assert _data == _exported and _data is not _exported
 
-    # test copy
-    _copied = _wrapped.copy()
+    # test copy_from
+    _copied = wrapper_cls().copy_from(_data)
     # NOTE: the underlaying data is also copied
     assert _copied.data == _wrapped.data and _copied.data is not _wrapped.data
 
@@ -58,18 +57,12 @@ def test_message_wrapper_normal_field(
     "pb_cls, wrapper_cls, field_name, value",
     (
         (
-            v2.RollbackRequest,
-            wrapper.RollbackRequest,
-            "ecu",
-            wrapper.RollbackRequestEcu(),
-        ),
-        (
             v2.RollbackResponse,
             wrapper.RollbackResponse,
             "ecu",
             wrapper.RollbackResponseEcu(),
         ),
-        (v2.UpdateRequest, wrapper.UpdateRequest, "ecu", wrapper.UpdateRequestEcu()),
+        (v2.StatusResponse, wrapper.StatusResponse, "ecu", wrapper.StatusResponseEcu()),
         (v2.UpdateResponse, wrapper.UpdateResponse, "ecu", wrapper.UpdateResponseEcu()),
     ),
 )
@@ -98,24 +91,24 @@ def test_message_wrapper_repeated_field(
     _exported = _wrapped.export_pb()
     assert _data == _exported and _data is not _exported
 
-    # test copy
-    _copied = _wrapped.copy()
+    # test copy_from
+    _copied = wrapper_cls.copy_from(_data)
     # NOTE: the underlaying data is also copied
     assert _copied.data == _wrapped.data and _copied.data is not _wrapped.data
 
     # test attrs proxy
     ## getattr
     _wrapped = wrapper_cls()
-    _field = getattr(_wrapped, field_name)
-    _ecu = _field.add()
-    _ecu.CopyFrom(value.data)
+    getattr(_wrapped, field_name).append(value.data)
     assert _wrapped.data == _data
     ## getitem
     _wrapped = wrapper_cls()
-    _field = _wrapped[field_name]
-    _ecu = _field.add()
-    _ecu.CopyFrom(value.data)
+    _wrapped[field_name].append(value.data)
     assert _wrapped.data == _data
+
+
+# TODO: test helper methods for RollbackResponse, StatusProgress,
+#       Status, StatusResponse, UpdateRequest and UpdateResponse
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Introduction
The generated protobuf code is not so convenient for directly use, according to protobuf documentation, 

> **Note**
> Protocol buffer classes are basically data holders (like structs in C) that don't provide additional functionality; they don't make good first class citizens in an object model.

If we want to bind methods to customize the behaviors of the protobuf classes, the documentation recommends to implement wrappers around the generated classes.

> If you want to add richer behavior to a generated class, the best way to do this is to wrap the generated protocol buffer class in an application-specific class. 

This PR implements a proxy type of wrappers for the generated protobuf code under the `app/proto` folder.
**NOTE**: The implemented wrappers are not yet integrated into the otaclient, the integration will be introduced in a future PR.
