### PR TITLE
Fix otaclient failed to recover from a RECOVERABLE ota failure

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -22,6 +22,7 @@ class OTAModules(Enum):
     StandbySlotCreater = 2
     Downloader = 3
     API = 4
+    OTASERVICE = 5
 
     def to_str(self) -> str:
         return f"{self.value:0>2}"
@@ -140,6 +141,7 @@ class OTAErrorCode(Enum):
     E_UPDATEDELTA_GENERATION_FAILED = 206
     E_APPLY_OTAUPDATE_FAILED = 207
     E_BASE_OTAMETA_VERIFICATION_FAILED = 208
+    E_OTAPROXY_FAILED_TO_START = 209
 
     E_OTA_ERR_UNRECOVERABLE = 300
     E_BOOTCONTROL_PLATFORM_UNSUPPORTED = 301
@@ -253,6 +255,14 @@ class BaseOTAMetaVerificationFailed(OTAErrorRecoverable):
     module: OTAModules = OTAModules.API
     errcode: OTAErrorCode = OTAErrorCode.E_BASE_OTAMETA_VERIFICATION_FAILED
     desc: str = f"{_RECOVERABLE_DEFAULT_DESC}: verification failed for base otameta"
+
+
+class OTAProxyFailedToStart(OTAErrorRecoverable):
+    module: OTAModules = OTAModules.OTASERVICE
+    errcode: OTAErrorCode = OTAErrorCode.E_OTAPROXY_FAILED_TO_START
+    desc: str = (
+        f"{_RECOVERABLE_DEFAULT_DESC}: ota_proxy is required but failed to start"
+    )
 
 
 ### unrecoverable error ###

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -13,6 +13,7 @@ from app.errors import (
     OTA_APIError,
     OTAError,
     OTAFailureType,
+    OTAProxyFailedToStart,
     OTARollbackError,
     OTAUpdateError,
 )
@@ -275,7 +276,7 @@ class _OTAUpdater:
                 logger.info("use local ota_proxy")
                 # wait for stub to setup the local ota_proxy server
                 if not fsm.client_wait_for_ota_proxy():
-                    raise OTAError("ota_proxy failed to start, abort")
+                    raise OTAProxyFailedToStart("ota_proxy failed to start, abort")
                 self._downloader.configure_proxy(proxy)
 
             self._pre_update(version, url_base, cookies_json)

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -37,30 +37,54 @@ logger = log_util.get_logger(
 
 
 class OTAUpdateFSM:
+    WAIT_INTERVAL = 3
+
     def __init__(self) -> None:
         self._ota_proxy_ready = Event()
         self._otaclient_finish_update = Event()
         self._stub_cleanup_finish = Event()
+        self.otaclient_failed = Event()
+        self.otaservice_failed = Event()
+
+    def on_otaclient_failed(self):
+        self.otaclient_failed.set()
+
+    def on_otaservice_failed(self):
+        self.otaservice_failed.set()
 
     def stub_pre_update_ready(self):
         self._ota_proxy_ready.set()
 
-    def client_wait_for_ota_proxy(self, *, timeout: Optional[float] = None):
-        """Local otaclient wait for stub(to setup ota_proxy server)."""
-        self._ota_proxy_ready.wait(timeout=timeout)
-
     def client_finish_update(self):
         self._otaclient_finish_update.set()
-
-    def stub_wait_for_local_update(self, *, timeout: Optional[float] = None):
-        self._otaclient_finish_update.wait(timeout=timeout)
 
     def stub_cleanup_finished(self):
         self._stub_cleanup_finish.set()
 
-    def client_wait_for_reboot(self):
+    def client_wait_for_ota_proxy(self) -> bool:
+        """Local otaclient wait for stub(to setup ota_proxy server)."""
+        while (
+            not self.otaservice_failed.is_set() and not self._ota_proxy_ready.is_set()
+        ):
+            time.sleep(self.WAIT_INTERVAL)
+        return not self.otaclient_failed.is_set()
+
+    def client_wait_for_reboot(self) -> bool:
         """Local otaclient should reboot after the stub cleanup finished."""
-        self._stub_cleanup_finish.wait()
+        while (
+            not self.otaservice_failed.is_set()
+            and not self._stub_cleanup_finish.is_set()
+        ):
+            time.sleep(self.WAIT_INTERVAL)
+        return not self.otaclient_failed.is_set()
+
+    def stub_wait_for_local_update(self) -> bool:
+        while (
+            not self.otaclient_failed.is_set()
+            and not self._otaclient_finish_update.is_set()
+        ):
+            time.sleep(self.WAIT_INTERVAL)
+        return not self.otaclient_failed.is_set()
 
 
 class _OTAUpdater:
@@ -250,7 +274,8 @@ class _OTAUpdater:
             if proxy := proxy_cfg.get_proxy_for_local_ota():
                 logger.info("use local ota_proxy")
                 # wait for stub to setup the local ota_proxy server
-                fsm.client_wait_for_ota_proxy()
+                if not fsm.client_wait_for_ota_proxy():
+                    raise OTAError("ota_proxy failed to start, abort")
                 self._downloader.configure_proxy(proxy)
 
             self._pre_update(version, url_base, cookies_json)
@@ -259,6 +284,7 @@ class _OTAUpdater:
             fsm.client_finish_update()
 
             logger.info("[update] leaving update, wait on all subecs...")
+            # NOTE: still reboot event local cleanup failed
             fsm.client_wait_for_reboot()
 
             logger.info("[update] apply post-update and reboot...")
@@ -339,6 +365,7 @@ class OTAClient(OTAClientProtocol):
         except OTAUpdateError as e:
             self.live_ota_status.set_ota_status(OTAStatusEnum.FAILURE)
             self.last_failure = e
+            fsm.on_otaclient_failed()
         finally:
             self._update_lock.release()
 

--- a/app/ota_client.py
+++ b/app/ota_client.py
@@ -63,7 +63,11 @@ class OTAUpdateFSM:
         self._stub_cleanup_finish.set()
 
     def client_wait_for_ota_proxy(self) -> bool:
-        """Local otaclient wait for stub(to setup ota_proxy server)."""
+        """Local otaclient wait for stub(to setup ota_proxy server).
+
+        Return:
+            A bool to indicate whether the ota_proxy launching is successful or not.
+        """
         while (
             not self.otaservice_failed.is_set() and not self._ota_proxy_ready.is_set()
         ):
@@ -71,7 +75,11 @@ class OTAUpdateFSM:
         return not self.otaclient_failed.is_set()
 
     def client_wait_for_reboot(self) -> bool:
-        """Local otaclient should reboot after the stub cleanup finished."""
+        """Local otaclient should reboot after the stub cleanup finished.
+
+        Return:
+            A bool indicates whether the ota_client_stub cleans up successfully.
+        """
         while (
             not self.otaservice_failed.is_set()
             and not self._stub_cleanup_finish.is_set()
@@ -80,6 +88,11 @@ class OTAUpdateFSM:
         return not self.otaclient_failed.is_set()
 
     def stub_wait_for_local_update(self) -> bool:
+        """OTA client stub should wait for local update finish before cleanup.
+
+        Return:
+            A bool indicates whether the local update is successful or not.
+        """
         while (
             not self.otaclient_failed.is_set()
             and not self._otaclient_finish_update.is_set()
@@ -285,7 +298,7 @@ class _OTAUpdater:
             fsm.client_finish_update()
 
             logger.info("[update] leaving update, wait on all subecs...")
-            # NOTE: still reboot event local cleanup failed
+            # NOTE: still reboot event local cleanup failed as the update itself is successful
             fsm.client_wait_for_reboot()
 
             logger.info("[update] apply post-update and reboot...")


### PR DESCRIPTION
## Introduction
This PR fix the issue that prevent otaclient recovering from a RECOVERABLE ota failure(like network errors). The cause of this issue is the `OTAUpdateFSM` doesn't  take otaclient failure and ota service failure into account, make otaclient/ota_service keep waiting even ota_service/otaclient failed.

## Changes
1. update `OTAUpdateFSM`, implement `on_<otaclient/otaservice>_failed`methods to allow interrupting fsm on failure,
2. `OTAUpdateFSM` wait methods now support return a bool to indicate the waited event is successful or not,
3. updates `ota_client_stub` and `ota_client` according to `OTAUpdateFSM` changes,
4. define `E_OTAPROXY_FAILED_TO_START` OTAError type, ota_proxy lauching failed now will be reported by the otaclient.

## Tests

- [x] recovered from RECOVERABLE failure at pre_update/METADATA stage
- [x] recovered from RECOVERABLE failure at in_update/REGULAR stage