### PR TITLE
[RC] Refine boot control module

### DIFF
--- a/app/boot_control/cboot.py
+++ b/app/boot_control/cboot.py
@@ -308,13 +308,15 @@ class CBootController(
 
         ## ota-status dir
         ### current slot
-        self.current_ota_status_dir = Path(cfg.OTA_STATUS_DIR)
+        self.current_ota_status_dir = Path(cfg.ACTIVE_ROOTFS_PATH) / Path(
+            cfg.OTA_STATUS_DIR
+        ).relative_to("/")
         self.current_ota_status_dir.mkdir(parents=True, exist_ok=True)
         ### standby slot
         # NOTE: might not yet be populated before OTA update applied!
-        self.standby_ota_status_dir = (
-            self.standby_slot_mount_point / "boot" / Path(cfg.OTA_STATUS_DIR).name
-        )
+        self.standby_ota_status_dir = self.standby_slot_mount_point / Path(
+            cfg.OTA_STATUS_DIR
+        ).relative_to("/")
 
         # init ota-status
         self._init_boot_control()

--- a/app/boot_control/cboot.py
+++ b/app/boot_control/cboot.py
@@ -18,10 +18,10 @@ from app.boot_control.common import (
 from app.boot_control.interface import BootControllerProtocol
 from app.common import (
     copytree_identical,
-    read_from_file,
+    read_str_from_file,
     subprocess_call,
     subprocess_check_output,
-    write_to_file_sync,
+    write_str_to_file_sync,
 )
 from app.configs import BOOT_LOADER, cboot_cfg as cfg
 from app.errors import (
@@ -149,7 +149,7 @@ class _CBootControl:
         try:
             # NOTE: only support rqx-580, rqx-58g platform right now!
             # detect the chip id
-            self.chip_id = read_from_file(self.TEGRA_CHIP_ID_PATH)
+            self.chip_id = read_str_from_file(self.TEGRA_CHIP_ID_PATH)
             if not self.chip_id or int(self.chip_id) not in cfg.CHIP_ID_MODEL_MAP:
                 raise NotImplementedError(
                     f"unsupported platform found (chip_id: {self.chip_id}), abort"
@@ -275,7 +275,7 @@ class _CBootControl:
             return res
 
         _repl_func = partial(_replace, repl=f"root={partuuid_str}")
-        write_to_file_sync(
+        write_str_to_file_sync(
             dst, re.compile(r"\n\s*APPEND.*").sub(_repl_func, ref.read_text())
         )
 

--- a/app/boot_control/cboot.py
+++ b/app/boot_control/cboot.py
@@ -181,14 +181,14 @@ class _CBootControl:
             logger.debug("rootfs on external storage detected, nvme rootfs is enable")
             self.is_rootfs_on_external = True
             self.standby_rootfs_dev = f"/dev/{Nvbootctrl.NVME_DEV}p{standby_partid}"
-            self.standby_slot_partuuid = CMDHelperFuncs.get_partuuid_str_by_dev(
+            self.standby_slot_partuuid_str = CMDHelperFuncs.get_partuuid_str_by_dev(
                 self.standby_rootfs_dev
             )
         elif self.current_rootfs_dev.find(Nvbootctrl.EMMC_DEV) != -1:
             logger.debug("using internal storage as rootfs")
             self.is_rootfs_on_external = False
             self.standby_rootfs_dev = f"/dev/{Nvbootctrl.EMMC_DEV}p{standby_partid}"
-            self.standby_slot_partuuid = CMDHelperFuncs.get_partuuid_str_by_dev(
+            self.standby_slot_partuuid_str = CMDHelperFuncs.get_partuuid_str_by_dev(
                 self.standby_rootfs_dev
             )
         else:
@@ -221,14 +221,14 @@ class _CBootControl:
     def get_current_rootfs_dev(self) -> str:
         return self.current_rootfs_dev
 
-    def get_current_boot_dev(self) -> str:
-        return self.current_boot_dev
-
     def get_standby_rootfs_dev(self) -> str:
         return self.standby_rootfs_dev
 
     def get_standby_slot(self) -> str:
         return self.standby_slot
+
+    def get_standby_rootfs_partuuid_str(self) -> str:
+        return self.standby_slot_partuuid_str
 
     def get_standby_boot_dev(self) -> str:
         return self.standby_boot_dev
@@ -250,15 +250,20 @@ class _CBootControl:
         logger.info(f"switch boot to {slot=}")
         Nvbootctrl.set_active_boot_slot(slot)
 
-    def is_current_slot_bootable(self) -> bool:
-        slot = self.current_slot
-        return Nvbootctrl.is_slot_bootable(slot)
-
     def is_current_slot_marked_successful(self) -> bool:
         slot = self.current_slot
         return Nvbootctrl.is_slot_marked_successful(slot)
 
-    def update_extlinux_cfg(self, dst: Path, ref: Path):
+    @staticmethod
+    def update_extlinux_cfg(dst: Path, ref: Path, partuuid_str: str):
+        """Write dst extlinux.conf based on reference extlinux.conf and partuuid_str.
+
+        Params:
+            dst: path to dst extlinux.conf file
+            ref: reference extlinux.conf file
+            partuuid_str: rootfs specification string like "PARTUUID=<partuuid>"
+        """
+
         def _replace(ma: re.Match, repl: str):
             append_l: str = ma.group(0)
             if append_l.startswith("#"):
@@ -269,7 +274,7 @@ class _CBootControl:
 
             return res
 
-        _repl_func = partial(_replace, repl=f"root={self.standby_slot_partuuid}")
+        _repl_func = partial(_replace, repl=f"root={partuuid_str}")
         write_to_file_sync(
             dst, re.compile(r"\n\s*APPEND.*").sub(_repl_func, ref.read_text())
         )
@@ -282,8 +287,6 @@ class CBootController(
     VersionControlMixin,
     BootControllerProtocol,
 ):
-    EXTLINUX_FILE = "/boot/extlinux/extlinux.conf"
-
     def __init__(self) -> None:
         self._cboot_control: _CBootControl = _CBootControl()
 
@@ -307,12 +310,11 @@ class CBootController(
         ### current slot
         self.current_ota_status_dir = Path(cfg.OTA_STATUS_DIR)
         self.current_ota_status_dir.mkdir(parents=True, exist_ok=True)
-
-        ## standby slot
-        ### NOTE: not yet available before ota update starts
-        self.standby_ota_status_dir = self.standby_slot_mount_point / Path(
-            cfg.OTA_STATUS_DIR
-        ).relative_to("/")
+        ### standby slot
+        # NOTE: might not yet be populated before OTA update applied!
+        self.standby_ota_status_dir = (
+            self.standby_slot_mount_point / "boot" / Path(cfg.OTA_STATUS_DIR).name
+        )
 
         # init ota-status
         self._init_boot_control()
@@ -324,7 +326,7 @@ class CBootController(
         # load ota_status str and slot_in_use
         _ota_status = self._load_current_ota_status()
         _slot_in_use = self._load_current_slot_in_use()
-        current_slot = Nvbootctrl.get_current_slot()
+        current_slot = self._cboot_control.get_current_slot()
         if not (_ota_status and _slot_in_use):
             logger.info("initializing boot control files...")
             _ota_status = wrapper.StatusOta.INITIALIZED
@@ -454,12 +456,9 @@ class CBootController(
                 standby_as_ref=standby_as_ref,
             )
 
-            ### re-populate /boot/ota-status folder
+            ### re-populate /boot/ota-status folder for standby slot
             # create the ota-status folder unconditionally
-            _ota_status_dir = self.standby_slot_mount_point / Path(
-                cfg.OTA_STATUS_DIR
-            ).relative_to("/")
-            _ota_status_dir.mkdir(exist_ok=True, parents=True)
+            self.standby_ota_status_dir.mkdir(exist_ok=True, parents=True)
             # store status to standby slot
             self._store_standby_ota_status(wrapper.StatusOta.UPDATING)
             self._store_standby_version(version)
@@ -474,10 +473,12 @@ class CBootController(
         try:
             # update extlinux_cfg file
             _extlinux_cfg = self.standby_slot_mount_point / Path(
-                self.EXTLINUX_FILE
+                cfg.EXTLINUX_FILE
             ).relative_to("/")
             self._cboot_control.update_extlinux_cfg(
-                dst=_extlinux_cfg, ref=_extlinux_cfg
+                dst=_extlinux_cfg,
+                ref=_extlinux_cfg,
+                partuuid_str=self._cboot_control.get_standby_rootfs_partuuid_str(),
             )
 
             # NOTE: we didn't prepare /boot/ota here,

--- a/app/boot_control/common.py
+++ b/app/boot_control/common.py
@@ -381,14 +381,6 @@ class CMDHelperFuncs:
             logger.exception("failed to reboot")
             raise
 
-    @classmethod
-    def grub_reboot(cls, idx: int):
-        try:
-            subprocess_call(f"grub-reboot {idx}", raise_exception=True)
-        except CalledProcessError:
-            logger.exception(f"failed to grub-reboot to {idx}")
-            raise
-
 
 ###### helper mixins ######
 class SlotInUseMixin:

--- a/app/boot_control/common.py
+++ b/app/boot_control/common.py
@@ -381,6 +381,14 @@ class CMDHelperFuncs:
             logger.exception("failed to reboot")
             raise
 
+    @classmethod
+    def grub_reboot(cls, idx: int):
+        try:
+            subprocess_call(f"grub-reboot {idx}", raise_exception=True)
+        except CalledProcessError:
+            logger.exception(f"failed to grub-reboot to {idx}")
+            raise
+
 
 ###### helper mixins ######
 class SlotInUseMixin:

--- a/app/boot_control/common.py
+++ b/app/boot_control/common.py
@@ -485,3 +485,7 @@ class PrepareMountMixin:
     def _umount_all(self, *, ignore_error: bool = False):
         CMDHelperFuncs.umount(self.standby_slot_mount_point, ignore_error=ignore_error)
         CMDHelperFuncs.umount(self.ref_slot_mount_point, ignore_error=ignore_error)
+
+
+def cat_proc_cmdline(target: str = "/proc/cmdline") -> str:
+    return read_from_file(target, missing_ok=False)

--- a/app/boot_control/common.py
+++ b/app/boot_control/common.py
@@ -7,10 +7,10 @@ from typing import Callable, List, Optional, Union
 from app import log_util
 from app.configs import config as cfg
 from app.common import (
-    read_from_file,
+    read_str_from_file,
     subprocess_call,
     subprocess_check_output,
-    write_to_file_sync,
+    write_str_to_file_sync,
 )
 from app.proto import wrapper
 
@@ -388,13 +388,17 @@ class SlotInUseMixin:
     standby_ota_status_dir: Path
 
     def _store_current_slot_in_use(self, _slot: str):
-        write_to_file_sync(self.current_ota_status_dir / cfg.SLOT_IN_USE_FNAME, _slot)
+        write_str_to_file_sync(
+            self.current_ota_status_dir / cfg.SLOT_IN_USE_FNAME, _slot
+        )
 
     def _store_standby_slot_in_use(self, _slot: str):
-        write_to_file_sync(self.standby_ota_status_dir / cfg.SLOT_IN_USE_FNAME, _slot)
+        write_str_to_file_sync(
+            self.standby_ota_status_dir / cfg.SLOT_IN_USE_FNAME, _slot
+        )
 
     def _load_current_slot_in_use(self) -> Optional[str]:
-        if res := read_from_file(
+        if res := read_str_from_file(
             self.current_ota_status_dir / cfg.SLOT_IN_USE_FNAME, default=""
         ):
             return res
@@ -406,17 +410,17 @@ class OTAStatusMixin:
     ota_status: wrapper.StatusOta
 
     def _store_current_ota_status(self, _status: wrapper.StatusOta):
-        write_to_file_sync(
+        write_str_to_file_sync(
             self.current_ota_status_dir / cfg.OTA_STATUS_FNAME, _status.name
         )
 
     def _store_standby_ota_status(self, _status: wrapper.StatusOta):
-        write_to_file_sync(
+        write_str_to_file_sync(
             self.standby_ota_status_dir / cfg.OTA_STATUS_FNAME, _status.name
         )
 
     def _load_current_ota_status(self) -> Optional[wrapper.StatusOta]:
-        if _status_str := read_from_file(
+        if _status_str := read_str_from_file(
             self.current_ota_status_dir / cfg.OTA_STATUS_FNAME
         ).upper():
             try:
@@ -433,13 +437,13 @@ class VersionControlMixin:
     standby_ota_status_dir: Path
 
     def _store_standby_version(self, _version: str):
-        write_to_file_sync(
+        write_str_to_file_sync(
             self.standby_ota_status_dir / cfg.OTA_VERSION_FNAME,
             _version,
         )
 
     def load_version(self) -> str:
-        _version = read_from_file(
+        _version = read_str_from_file(
             self.current_ota_status_dir / cfg.OTA_VERSION_FNAME,
             missing_ok=True,
             default="",
@@ -488,4 +492,4 @@ class PrepareMountMixin:
 
 
 def cat_proc_cmdline(target: str = "/proc/cmdline") -> str:
-    return read_from_file(target, missing_ok=False)
+    return read_str_from_file(target, missing_ok=False)

--- a/app/boot_control/grub.py
+++ b/app/boot_control/grub.py
@@ -83,20 +83,20 @@ class GrubHelper:
     menuentry_pa: ClassVar[re.Pattern] = re.compile(
         # whole capture group
         r"^(?P<menu_entry>\s*menuentry\s+"
-        # menuentry title:
-        # format: <os>, with Linux <kernel_ver>[ [<recovery>] [<os_probe>]]
-        r"'(?P<title>[^,]*, +with +Linux +(?P<kernel_ver>[^'\s]*)(?P<other>( *\([^\)]*\))*)?)'"
         r"[^\{]*"  # menuentry options
         r"\{(?P<entry>[^\}]*)\}"  # menuentry block
         r")",  # end of whole capture
         re.MULTILINE | re.DOTALL,
     )
     linux_pa: ClassVar[re.Pattern] = re.compile(
-        r"(?P<left>^\s+linux.*(?P<kernel>vmlinuz-(?P<ver>[\.\w\-]*)) +.*)"
-        r"(?P<rootfs>root=(?P<rootfs_str>[\w\-=]*))"
-        r"(?P<right>.*)",
+        r"(?P<load_linux>^\s+linux\s+(?P<kernel_path>.*vmlinuz-(?P<ver>[\.\w\-]*)))"
+        r"\s+(?P<cmdline>.*(?P<rootfs>root=(?P<rootfs_str>[\w\-=]*)).*)\s*$",
         re.MULTILINE,
     )
+    rootfs_pa: ClassVar[re.Pattern] = re.compile(
+        r"(?P<rootfs>root=(?P<rootfs_str>[\w\-=]*))"
+    )
+
     initrd_pa: ClassVar[re.Pattern] = re.compile(
         r"^\s+initrd.*(?P<initrd>initrd.img-(?P<ver>[\.\w-]*))", re.MULTILINE
     )

--- a/app/boot_control/grub.py
+++ b/app/boot_control/grub.py
@@ -580,7 +580,7 @@ class _GrubControl:
             read_str_from_file(self.grub_file),
             kernel_ver=GrubHelper.SUFFIX_OTA_STANDBY,
         )
-        CMDHelperFuncs.reboot()
+        CMDHelperFuncs.grub_reboot(idx)
         logger.info(f"system will reboot to {self.standby_slot=}: boot entry {idx}")
 
     finalize_update_switch_boot = reprepare_active_ota_partition_file

--- a/app/boot_control/grub.py
+++ b/app/boot_control/grub.py
@@ -156,8 +156,9 @@ class GrubHelper:
     @classmethod
     def get_entry(cls, grub_cfg: str, *, kernel_ver: str) -> Tuple[int, GrubMenuEntry]:
         for index, entry_ma in enumerate(cls.menuentry_pa.finditer(grub_cfg)):
-            if kernel_ver == entry_ma.group("kernel_ver"):
-                return index, GrubMenuEntry(entry_ma)
+            if _linux := cls.linux_pa.search(entry_ma.group()):
+                if kernel_ver == _linux.group("ver"):
+                    return index, GrubMenuEntry(entry_ma)
 
         raise ValueError(f"requested entry for {kernel_ver} not found")
 

--- a/app/boot_control/grub.py
+++ b/app/boot_control/grub.py
@@ -177,6 +177,11 @@ class GrubHelper:
 
     @classmethod
     def get_entry(cls, grub_cfg: str, *, kernel_ver: str) -> Tuple[int, GrubMenuEntry]:
+        """Find the FIRST entry that matches the <kernel_ver>.
+        NOTE: assume that the FIRST matching entry is the normal entry,
+              which is correct in most cases(recovery entry will always
+              be after the normal boot entry.)
+        """
         for index, entry_ma in enumerate(cls.menuentry_pa.finditer(grub_cfg)):
             if _linux := cls.linux_pa.search(entry_ma.group()):
                 if kernel_ver == _linux.group("ver"):

--- a/app/boot_control/grub.py
+++ b/app/boot_control/grub.py
@@ -137,7 +137,6 @@ class GrubHelper:
         """
         new_entry_block: Optional[str] = None
         entry_l, entry_r = None, None
-        is_updated = False
 
         # loop over normal entry, find the target entry,
         # and then replace the rootfs string
@@ -153,15 +152,14 @@ class GrubHelper:
                     )
                     if _count == 1:
                         # replace rootfs string
-                        new_entry_block = "%s%s%s" % (
-                            entry_block[:linux_line_l],
-                            _new_linux_line,
-                            entry_block[linux_line_r:],
+                        new_entry_block = (
+                            f"{entry_block[:linux_line_l]}"
+                            f"{_new_linux_line}"
+                            f"{entry_block[linux_line_r:]}"
                         )
-                        is_updated = True
                         break
 
-        if is_updated and new_entry_block is not None:
+        if new_entry_block is not None:
             updated_grub_cfg = (
                 f"{grub_cfg[:entry_l]}{new_entry_block}{grub_cfg[entry_r:]}"
             )

--- a/app/common.py
+++ b/app/common.py
@@ -78,7 +78,7 @@ def verify_file(fpath: Path, fhash: str, fsize: Optional[int]) -> bool:
 
 
 # handled file read/write
-def read_from_file(path: Union[Path, str], *, missing_ok=True, default="") -> str:
+def read_str_from_file(path: Union[Path, str], *, missing_ok=True, default="") -> str:
     """
     Params:
         missing_ok: if set to False, FileNotFoundError will be raised to upper
@@ -93,11 +93,11 @@ def read_from_file(path: Union[Path, str], *, missing_ok=True, default="") -> st
         raise
 
 
-def write_to_file(path: Path, input: str):
+def write_str_to_file(path: Path, input: str):
     path.write_text(input)
 
 
-def write_to_file_sync(path: Union[Path, str], input: str):
+def write_str_to_file_sync(path: Union[Path, str], input: str):
     with open(path, "w") as f:
         f.write(input)
         f.flush()

--- a/app/configs.py
+++ b/app/configs.py
@@ -101,6 +101,7 @@ class CBootControlConfig(BaseConfig):
     BOOTLOADER: str = "cboot"
     CHIP_ID_MODEL_MAP: Dict[int, str] = field(default_factory=lambda: {0x19: "rqx_580"})
     OTA_STATUS_DIR: str = "/boot/ota-status"
+    EXTLINUX_FILE: str = "/boot/extlinux/extlinux.conf"
 
     # mount point
     SEPARATE_BOOT_MOUNT_POINT: str = "/mnt/standby_boot"

--- a/app/configs.py
+++ b/app/configs.py
@@ -43,6 +43,7 @@ class BaseConfig:
             "ota_status": INFO,
         }
     )
+    ACTIVE_ROOTFS_PATH: str = "/"
     BOOT_DIR: str = "/boot"
     ECU_INFO_FILE: str = "/boot/ota/ecu_info.yaml"
     PROXY_INFO_FILE: str = "/boot/ota/proxy_info.yaml"

--- a/app/main.py
+++ b/app/main.py
@@ -14,7 +14,7 @@ except ModuleNotFoundError:
     sys.path.insert(0, str(project_dir))
 
 from app import log_util
-from app.common import read_from_file, write_to_file_sync
+from app.common import read_str_from_file, write_str_to_file_sync
 from app.configs import config as cfg
 from app.ota_client_service import launch_otaclient_grpc_server
 
@@ -31,13 +31,13 @@ def _check_other_otaclient():
     # create a lock file to prevent multiple ota-client instances start
     lock_file = Path("/var/run/ota-client.lock")
     our_pid = os.getpid()
-    if pid := read_from_file(lock_file):
+    if pid := read_str_from_file(lock_file):
         # running process will have a folder under /proc
         if Path(f"/proc/{pid}").is_dir():
             msg = f"another instance of ota-client(pid: {pid}) is running, abort"
             sys.exit(msg)
     # write our pid to the lock file
-    write_to_file_sync(lock_file, f"{our_pid}")
+    write_str_to_file_sync(lock_file, f"{our_pid}")
 
 
 def main():

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -15,11 +15,11 @@ from app.common import (
     copytree_identical,
     file_sha256,
     re_symlink_atomic,
-    read_from_file,
+    read_str_from_file,
     subprocess_call,
     subprocess_check_output,
     verify_file,
-    write_to_file_sync,
+    write_str_to_file_sync,
 )
 from tests.utils import compare_dir
 
@@ -77,16 +77,16 @@ def test_read_from_file(file_t: Tuple[str, str, int]):
     with open(_path, "a") as f:
         f.write(_append)
 
-    assert read_from_file(_path) == _TEST_FILE_CONTENT
-    assert read_from_file("/non-existed", missing_ok=True, default="") == ""
-    assert read_from_file("/non-existed", missing_ok=True, default="abc") == "abc"
+    assert read_str_from_file(_path) == _TEST_FILE_CONTENT
+    assert read_str_from_file("/non-existed", missing_ok=True, default="") == ""
+    assert read_str_from_file("/non-existed", missing_ok=True, default="abc") == "abc"
     with pytest.raises(FileNotFoundError):
-        read_from_file("/non-existed", missing_ok=False)
+        read_str_from_file("/non-existed", missing_ok=False)
 
 
 def test_write_to_file_sync(tmp_path: Path):
     _path = tmp_path / "write_to_file"
-    write_to_file_sync(_path, _TEST_FILE_CONTENT)
+    write_str_to_file_sync(_path, _TEST_FILE_CONTENT)
     assert _path.read_text() == _TEST_FILE_CONTENT
 
 


### PR DESCRIPTION
## Introduction
This PR fixes and updates the boot_control module modules. It fixes the behavior of parsing/processing `grub.conf` for grub controller, and minor updates to cboot controller.

## Changes
1. grub: now grub controller find entry by looking up the `linux` line of the entry menu, instead of parsing the menu title(which is not recommended by the grub document). These changes fix the issue [[OTA] OTA client installed with USB installer doesn't work properly](https://tier4.atlassian.net/browse/T4PB-20054).
2. grub: `find_entry` will find and return the FIRST matching entry by kernel, assuming that the FIRST matched entry is the normal entry, not the recovery entry(in normal cases this assumption is correct).
3. common: rename <read|write>_to_file to <read|write>_str_to_file to avoid ambiguous.
4. cboot: rename class variable `standby_slot_partuuid` to `standby_slot_partuuid_str`, as we store `PARTUUID=<UUID>` string in this variable.
5. cboot: make `update_extlinux_cfg` a static method.
6. other cleanup.