### PR TITLE
Update certs folder discovery mechanism.

### DIFF
--- a/otaclient/app/configs.py
+++ b/otaclient/app/configs.py
@@ -4,7 +4,12 @@ from logging import INFO
 from pathlib import Path
 from typing import Dict
 
-EXTRA_VERSION_FILE = str(Path(__file__).parent.parent / "version.txt")
+from otaclient import __file__ as _otaclient__init__
+
+_OTACLIENT_PACKAGE_ROOT = Path(_otaclient__init__).parent
+
+# NOTE: VERSION file is installed under otaclient package root
+EXTRA_VERSION_FILE = str(_OTACLIENT_PACKAGE_ROOT / "version.txt")
 OTACLIENT_LOCK_FILE = "/var/run/otaclient.lock"
 
 
@@ -30,6 +35,9 @@ class OtaClientServerConfig:
 @dataclass
 class BaseConfig:
     """Platform neutral configuration."""
+
+    # NOTE: certs dir is located at the otaclient package root
+    CERTS_DIR = str(_OTACLIENT_PACKAGE_ROOT / "certs")
 
     DEFAULT_LOG_LEVEL: int = INFO
     LOG_LEVEL_TABLE: Dict[str, int] = field(

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -35,7 +35,6 @@ class OtaMetadata:
     If there is no root or intermediate certificate, certification verification
     is not performed.
     """
-    CERTS_DIR = Path(__file__).parent.parent / "certs"
 
     def __init__(self, ota_metadata_jwt):
         """
@@ -47,7 +46,7 @@ class OtaMetadata:
         self.__metadata_jwt = ota_metadata_jwt
         self.__metadata_dict = self._parse_metadata(ota_metadata_jwt)
         logger.info(f"metadata_dict={pformat(self.__metadata_dict)}")
-        self._certs_dir = self.CERTS_DIR
+        self._certs_dir = Path(cfg.CERTS_DIR)
         logger.info(f"certs_dir={self._certs_dir}")
 
     def verify(self, certificate: bytes):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ class TestConfiguration:
     GRUB_MODULE_PATH = "otaclient.app.boot_control.grub"
     OTACLIENT_MODULE_PATH = "otaclient.app.ota_client"
     OTACLIENT_STUB_MODULE_PATH = "otaclient.app.ota_client_stub"
+    OTAMETA_MODULE_PATH = "otaclient.app.ota_metadata"
     OTAPROXY_MODULE_PATH = "otaclient.ota_proxy"
     CREATE_STANDBY_MODULE_PATH = "otaclient.app.create_standby"
     MAIN_MODULE_PATH = "otaclient.app.main"

--- a/tests/test_ota_metadata.py
+++ b/tests/test_ota_metadata.py
@@ -6,6 +6,8 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from pytest_mock import MockerFixture
 
+from tests.conftest import TestConfiguration as cfg
+
 
 @pytest.fixture
 def dir_test() -> Path:
@@ -148,7 +150,7 @@ def test_ota_metadata_with_verify_certificate(
     cert_b_1.write_bytes(Path(dir_test / "keys" / "root.pem").read_bytes())
     cert_b_2.write_bytes(Path(dir_test / "keys" / "interm.pem").read_bytes())
 
-    mocker.patch.object(OtaMetadata, "CERTS_DIR", certs_dir)
+    mocker.patch(f"{cfg.OTAMETA_MODULE_PATH}.cfg.CERTS_DIR", str(certs_dir))
 
     metadata = OtaMetadata(generate_jwt(payload_str, dir_test))
     assert metadata.get_directories_info() == DIR_INFO
@@ -182,7 +184,7 @@ def test_ota_metadata_with_verify_certificate_exception(
     cert_a_1.write_bytes(Path(dir_test / "keys" / "sign.pem").read_bytes())
     cert_a_2.write_bytes(Path(dir_test / "keys" / "sign.pem").read_bytes())
 
-    mocker.patch.object(OtaMetadata, "CERTS_DIR", certs_dir)
+    mocker.patch(f"{cfg.OTAMETA_MODULE_PATH}.cfg.CERTS_DIR", str(certs_dir))
 
     metadata = OtaMetadata(generate_jwt(payload_str, dir_test))
     assert metadata.get_directories_info() == DIR_INFO


### PR DESCRIPTION
## Introduction
This PR makes otaclient search for `CERTS_DIR` and `VERSION` file by searching under `otaclient` package root, and move the configuration constant to `configs.py`.

This behavior is aligned to the `autoware_ecu_system_setup` ansible task file, which install certs folder and version file under `{{ ota_client_install_dir }}`(the otaclient package root).