### PR TITLE
Bugfix: otaclient should wait on subecus with POST_PROCESSING status

### DIFF
--- a/otaclient/app/ota_client.py
+++ b/otaclient/app/ota_client.py
@@ -160,7 +160,7 @@ class _OTAUpdater:
             metadata.verify(cert_file.read_bytes())
             return metadata
 
-    def _pre_update(self, version: str, url_base: str, cookies_json: str):
+    def _pre_update(self, url_base: str, cookies_json: str):
         # parse cookies
         try:
             cookies: Dict[str, Any] = json.loads(cookies_json)
@@ -169,12 +169,6 @@ class _OTAUpdater:
             ), f"invalid cookies, expecting to be parsed into dict but {type(cookies)}"
         except (JSONDecodeError, AssertionError) as e:
             raise InvalidUpdateRequest from e
-
-        # set ota status
-        self.updating_version = version
-        self.update_phase = wrapper.StatusProgressPhase.INITIAL
-        self.update_start_time = time.time_ns()
-        self.failure_reason = ""  # clean failure reason
 
         # init ota_update_stats collector
         self.update_stats_collector.start(restart=True)
@@ -224,10 +218,6 @@ class _OTAUpdater:
         # start to constructing standby bank
         _standby_slot_creator.create_standby_slot()
         logger.info("[_in_update] finished creating standby slot")
-
-    def _post_update(self):
-        self._set_update_phase(wrapper.StatusProgressPhase.POST_PROCESSING)
-        self._boot_controller.post_update()
 
     def _set_update_phase(self, _phase: wrapper.StatusProgressPhase):
         self.update_phase = _phase
@@ -293,17 +283,24 @@ class _OTAUpdater:
                     raise OTAProxyFailedToStart("ota_proxy failed to start, abort")
                 self._downloader.configure_proxy(proxy)
 
-            self._pre_update(version, url_base, cookies_json)
+            # start the update, pre_update
+            self.updating_version = version
+            self.update_phase = wrapper.StatusProgressPhase.INITIAL
+            self.update_start_time = time.time_ns()
+            self.failure_reason = ""  # clean failure reason
+            self._pre_update(url_base, cookies_json)
 
+            # in_update
             self._in_update()
+            # local update finished, set the status to POST_PROCESSING
             fsm.client_finish_update()
+            self.update_phase = wrapper.StatusProgressPhase.POST_PROCESSING
 
+            # post_update
             logger.info("[update] leaving update, wait on all subecs...")
             # NOTE: still reboot event local cleanup failed as the update itself is successful
             fsm.client_wait_for_reboot()
-
-            logger.info("[update] apply post-update and reboot...")
-            self._post_update()
+            self._boot_controller.post_update()
             # NOTE: no need to call shutdown method here, keep the update_progress
             #       as it as we are still in updating before rebooting
         except OTAError as e:


### PR DESCRIPTION
## Introduction
This PR fixes the otaclient's behavior that otaclient should wait on subecus with otastatus as `POST_PROCESSING`.

## Changes
1. `INITIAL` and `POST_PROCESSING` otastatus are now set in the main entrance of `OTAUpdater` class(the `execute` method);
2. remove `OTAUpdater._post_update` method, directly call the `_boot_control.post_update` method as the Updater itself doesn't do anything during the post_update. 