### PR TITLE
Fix T4PB-20863: OTA update stats collector doesn't restart properly

### DIFF
--- a/otaclient/app/ota_client.py
+++ b/otaclient/app/ota_client.py
@@ -170,9 +170,6 @@ class _OTAUpdater:
         except (JSONDecodeError, AssertionError) as e:
             raise InvalidUpdateRequest from e
 
-        # init ota_update_stats collector
-        self.update_stats_collector.start(restart=True)
-
         # process metadata.jwt
         logger.debug("[update] process metadata...")
         self.update_phase = wrapper.StatusProgressPhase.METADATA
@@ -282,6 +279,10 @@ class _OTAUpdater:
                 if not fsm.client_wait_for_ota_proxy():
                     raise OTAProxyFailedToStart("ota_proxy failed to start, abort")
                 self._downloader.configure_proxy(proxy)
+
+            # launch collector
+            # init ota_update_stats collector
+            self.update_stats_collector.start()
 
             # start the update, pre_update
             self.updating_version = version

--- a/otaclient/app/ota_client_stub.py
+++ b/otaclient/app/ota_client_stub.py
@@ -290,13 +290,20 @@ class _SubECUTracker:
               2. this method will block until all tracked ecus are ready,
               2. if subecu is unreachable, this tracker will still keep pulling.
         """
-        # NOTE(20220914): it might be an edge condition that this tracker starts
+        # NOTE(20220914): It might be an edge condition that this tracker starts
         #                 faster than the subecus start their own update progress,
-        #                 so we wait for 30s here before loop pulling status.
+        #                 but the tracker is not able to tell the differences between
+        #                 SUCCESS status before update starts, or SUCCESS status after
+        #                 ota update applied.
+        #
+        #                 If the tracker receives unintended SUCCESS status from subecu,
+        #                 it will finish tracking and returns immediately.
+        #
+        #                 To avoid this unintended behavior, we wait for subecus for
+        #                 _WAIT_FOR_SUBECUS_SWITCH_OTASTATUS seconds to ensure subecus are in
+        #                 UPDATING status before we start loop pulling the subecus' status.
         await asyncio.sleep(self._WAIT_FOR_SUBECUS_SWITCH_OTASTATUS)
-        logger.info(
-            f"start to loop pulling subecus({self.tracked_ecus_dict=}) status..."
-        )
+        logger.info(f"start loop pulling subecus({self.tracked_ecus_dict=}) status...")
         while True:
             coros: List[Coroutine] = []
             for subecu_id, subecu_addr in self.tracked_ecus_dict.items():


### PR DESCRIPTION
## Introduction
This PR fix the otaclient status API doesn't report ota update progress after recovering from an recoverable OTA failure.
(NOT SURE) For the unexpected behavior that mainecu reboots before all subecus finish their update, a possible fix is applied, check changes.4 for detail. 

## Changes
1. fix `OTAUpdateStatsCollector` start/stop method, make it properly restart during recovering from an failed OTA update;
2. `OTAUpdateStatsCollector` start method now always shutdown a previously active collector if any;
3. fix `test_ota_client_stub.Test_SubECUTracker`, previous test implementation provides negative success result and doesn't test the `_SubECUTracker` properly.
4. `ota_client_stub._SubECUTracker` now will wait for 30s before starting to loop pulling the subecus' status.

## Ticket
https://tier4.atlassian.net/browse/T4PB-20863