### PR TITLE
Support compressed OTA image

### DIFF
--- a/docker/test_base/Dockerfile
+++ b/docker/test_base/Dockerfile
@@ -58,12 +58,15 @@ RUN source ota-metadata/.venv/bin/activate && \
     python3 -m pip install --no-cache-dir -q \
         -r ota-metadata/metadata/ota_metadata/requirements.txt && \
     python3 ota-metadata/metadata/ota_metadata/metadata_gen.py \
-        --target-dir data --ignore-file ota-metadata/metadata/ignore.txt && \
+        --target-dir data \
+        --compressed-dir data.zst \
+        --ignore-file ota-metadata/metadata/ignore.txt && \
     python3 ota-metadata/metadata/ota_metadata/metadata_sign.py \
         --sign-key sign.key \
         --cert-file sign.pem \
         --persistent-file ota-metadata/metadata/persistents.txt \
-        --rootfs-directory data && \
+        --rootfs-directory data \
+        --compressed-rootfs-directory data.zst && \
     cp ota-metadata/metadata/persistents.txt .
 
 # cleanup

--- a/otaclient/app/common.py
+++ b/otaclient/app/common.py
@@ -325,7 +325,7 @@ class SimpleTasksTracker:
         if self._interrupted.is_set() or self._register_finished:
             return
 
-        self._se.acquire()
+        self._se.acquire(blocking=True)
         self._in_num = next(self._in_counter)
         self._futs.add(fut)
 

--- a/otaclient/app/common.py
+++ b/otaclient/app/common.py
@@ -26,6 +26,7 @@ from hashlib import sha256
 from pathlib import Path
 from threading import Event, Semaphore
 from typing import Callable, Optional, Set, Union
+from urllib.parse import urljoin
 
 from .log_util import get_logger
 from .configs import config as cfg
@@ -284,6 +285,17 @@ def re_symlink_atomic(src: Path, target: Union[Path, str]):
         except Exception:
             tmp_link.unlink(missing_ok=True)
             raise
+
+
+def urljoin_ensure_base(base: str, url: str):
+    """
+    NOTE: this method ensure the base_url will be preserved.
+          for example:
+            base="http://example.com/data", url="path/to/file"
+          with urljoin, joined url will be "http://example.com/path/to/file",
+          with this func, joined url will be "http://example.com/data/path/to/file"
+    """
+    return urljoin(f"{base.rstrip('/')}/", url)
 
 
 class SimpleTasksTracker:

--- a/otaclient/app/configs.py
+++ b/otaclient/app/configs.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from enum import Enum, auto
 from logging import INFO
 from pathlib import Path
-from typing import Dict, Set
+from typing import Dict, Tuple
 
 from otaclient import __file__ as _otaclient__init__
 
@@ -107,7 +107,7 @@ class BaseConfig:
     META_FOLDER: str = "/opt/ota/image-meta"
 
     # compressed OTA image support
-    SUPPORTED_COMPRESS_ALG: Set[str] = {"zst"}
+    SUPPORTED_COMPRESS_ALG: Tuple[str] = ("zst",)
 
 
 @dataclass

--- a/otaclient/app/configs.py
+++ b/otaclient/app/configs.py
@@ -107,7 +107,7 @@ class BaseConfig:
     META_FOLDER: str = "/opt/ota/image-meta"
 
     # compressed OTA image support
-    SUPPORTED_COMPRESS_ALG: Tuple[str] = ("zst",)
+    SUPPORTED_COMPRESS_ALG: Tuple[str, ...] = ("zst", "zstd")
 
 
 @dataclass

--- a/otaclient/app/configs.py
+++ b/otaclient/app/configs.py
@@ -97,8 +97,8 @@ class BaseConfig:
     DOWNLOAD_RETRY: int = 10
     DOWNLOAD_BACKOFF_MAX: int = 3  # seconds
     MAX_CONCURRENT_TASKS: int = 128
-    MAX_DOWNLOAD_THREAD: int = 3
-    MAX_CONCURRENT_DOWNLOAD_PER_THREAD: int = 3
+    MAX_DOWNLOAD_THREAD: int = 8
+    DOWNLOADER_CONNPOOL_SIZE_PER_THREAD: int = 8
     STATS_COLLECT_INTERVAL: int = 1  # second
     ## standby creation mode, default to rebuild now
     STANDBY_CREATION_MODE = CreateStandbyMechanism.REBUILD

--- a/otaclient/app/configs.py
+++ b/otaclient/app/configs.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from enum import Enum, auto
 from logging import INFO
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Set
 
 from otaclient import __file__ as _otaclient__init__
 
@@ -96,14 +96,18 @@ class BaseConfig:
     LOCAL_CHUNK_SIZE: int = 4 * 1024 * 1024  # 4MB
     DOWNLOAD_RETRY: int = 10
     DOWNLOAD_BACKOFF_MAX: int = 3  # seconds
-    MAX_CONCURRENT_DOWNLOAD: int = 8
     MAX_CONCURRENT_TASKS: int = 128
+    MAX_DOWNLOAD_THREAD: int = 3
+    MAX_CONCURRENT_DOWNLOAD_PER_THREAD: int = 3
     STATS_COLLECT_INTERVAL: int = 1  # second
     ## standby creation mode, default to rebuild now
     STANDBY_CREATION_MODE = CreateStandbyMechanism.REBUILD
     # NOTE: the following 2 folders are meant to be located under standby_slot
     OTA_TMP_STORE: str = "/ota-tmp"
     META_FOLDER: str = "/opt/ota/image-meta"
+
+    # compressed OTA image support
+    SUPPORTED_COMPRESS_ALG: Set[str] = {"zst"}
 
 
 @dataclass

--- a/otaclient/app/create_standby/interface.py
+++ b/otaclient/app/create_standby/interface.py
@@ -16,6 +16,8 @@
 from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Protocol
+
+from otaclient.app.downloader import Downloader
 from ..ota_metadata import OTAMetadata
 from ..proto import wrapper
 from ..update_stats import OTAUpdateStatsCollector
@@ -53,6 +55,7 @@ class StandbySlotCreatorProtocol(Protocol):
         update_meta: UpdateMeta,
         stats_collector: OTAUpdateStatsCollector,
         update_phase_tracker: Callable[[wrapper.StatusProgressPhase], None],
+        downloader: Downloader,
     ) -> None:
         ...
 

--- a/otaclient/app/create_standby/interface.py
+++ b/otaclient/app/create_standby/interface.py
@@ -16,7 +16,7 @@
 from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Protocol
-from ..ota_metadata import OtaMetadata
+from ..ota_metadata import OTAMetadata
 from ..proto import wrapper
 from ..update_stats import OTAUpdateStatsCollector
 
@@ -26,7 +26,7 @@ class UpdateMeta:
     """Meta info for standby slot creator to update slot."""
 
     cookies: Dict[str, Any]  # cookies needed for requesting remote ota files
-    metadata: OtaMetadata  # meta data for the update request
+    metadata: OTAMetadata  # meta data for the update request
     url_base: str  # base url of the remote ota image
     boot_dir: str  # where to populate files under /boot
     standby_slot_mount_point: str

--- a/otaclient/app/create_standby/legacy_mode.py
+++ b/otaclient/app/create_standby/legacy_mode.py
@@ -80,8 +80,9 @@ class LegacyMode(StandbySlotCreatorProtocol):
         self.boot_dir = Path(update_meta.boot_dir)
 
         # the location of image at the ota server root
-        self.image_base_dir = self.metadata.get_rootfsdir_info()["file"]
-        self.image_base_url = urljoin(update_meta.url_base, f"{self.image_base_dir}/")
+        self.image_base_url = urljoin(
+            update_meta.url_base, f"{self.metadata.rootfs_directory}/"
+        )
 
         # internal used vars
         self._passwd_file = Path(cfg.PASSWD_FILE)
@@ -98,13 +99,13 @@ class LegacyMode(StandbySlotCreatorProtocol):
     def _process_directory(self):
         self.update_phase_tracker(wrapper.StatusProgressPhase.DIRECTORY)
 
-        list_info = self.metadata.get_directories_info()
+        list_info = self.metadata.directory
         with tempfile.NamedTemporaryFile(prefix=__name__) as f:
             # NOTE: do not use cache when fetching dir list
             self._downloader.download(
-                list_info["file"],
+                list_info.file,
                 Path(f.name),
-                list_info["hash"],
+                list_info.hash,
                 cookies=self.cookies,
                 url_base=self.url_base,
                 headers={
@@ -126,13 +127,13 @@ class LegacyMode(StandbySlotCreatorProtocol):
     def _process_symlink(self):
         self.update_phase_tracker(wrapper.StatusProgressPhase.SYMLINK)
 
-        list_info = self.metadata.get_symboliclinks_info()
+        list_info = self.metadata.symboliclink
         with tempfile.NamedTemporaryFile(prefix=__name__) as f:
             # NOTE: do not use cache when fetching symlink list
             self._downloader.download(
-                list_info["file"],
+                list_info.file,
                 Path(f.name),
-                list_info["hash"],
+                list_info.hash,
                 url_base=self.url_base,
                 cookies=self.cookies,
                 headers={
@@ -149,14 +150,14 @@ class LegacyMode(StandbySlotCreatorProtocol):
     def _process_regular(self):
         self.update_phase_tracker(wrapper.StatusProgressPhase.REGULAR)
 
-        list_info = self.metadata.get_regulars_info()
+        list_info = self.metadata.regular
         with tempfile.NamedTemporaryFile(prefix=__name__) as f:
             # download the regulars.txt
             # NOTE: do not use cache when fetching regular files list
             self._downloader.download(
-                list_info["file"],
+                list_info.file,
                 Path(f.name),
-                list_info["hash"],
+                list_info.hash,
                 url_base=self.url_base,
                 cookies=self.cookies,
                 headers={
@@ -169,13 +170,13 @@ class LegacyMode(StandbySlotCreatorProtocol):
     def _process_persistent(self):
         self.update_phase_tracker(wrapper.StatusProgressPhase.PERSISTENT)
 
-        list_info = self.metadata.get_persistent_info()
+        list_info = self.metadata.persistent
         with tempfile.NamedTemporaryFile(prefix=__name__) as f:
             # NOTE: do not use cache when fetching persist files list
             self._downloader.download(
-                list_info["file"],
+                list_info.file,
                 Path(f.name),
-                list_info["hash"],
+                list_info.hash,
                 url_base=self.url_base,
                 cookies=self.cookies,
                 headers={

--- a/otaclient/app/create_standby/legacy_mode.py
+++ b/otaclient/app/create_standby/legacy_mode.py
@@ -18,7 +18,6 @@ import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from threading import Semaphore
 from typing import Callable
 from urllib.parse import urljoin
 
@@ -58,7 +57,6 @@ logger = log_util.get_logger(
 
 # implementation
 class LegacyMode(StandbySlotCreatorProtocol):
-    MAX_CONCURRENT_DOWNLOAD = cfg.MAX_CONCURRENT_DOWNLOAD
     MAX_CONCURRENT_TASKS = cfg.MAX_CONCURRENT_TASKS
 
     def __init__(
@@ -67,10 +65,11 @@ class LegacyMode(StandbySlotCreatorProtocol):
         update_meta: UpdateMeta,
         stats_collector: OTAUpdateStatsCollector,
         update_phase_tracker: Callable,
+        downloader: Downloader,
     ) -> None:
         self.cookies = update_meta.cookies
         self.metadata = update_meta.metadata
-        self.url_base = update_meta.url_base
+        self.url_base = f"{update_meta.url_base.rstrip('/')}/"
 
         self.stats_collector = stats_collector
         self.update_phase_tracker: Callable = update_phase_tracker
@@ -79,35 +78,30 @@ class LegacyMode(StandbySlotCreatorProtocol):
         self.standby_slot_mp = Path(update_meta.standby_slot_mount_point)
         self.boot_dir = Path(update_meta.boot_dir)
 
-        # the location of image at the ota server root
-        self.image_base_url = urljoin(
-            update_meta.url_base, f"{self.metadata.rootfs_directory}/"
-        )
-
         # internal used vars
         self._passwd_file = Path(cfg.PASSWD_FILE)
         self._group_file = Path(cfg.GROUP_FILE)
 
         # configure the downloader
-        self._downloader = Downloader()
-        proxy = proxy_cfg.get_proxy_for_local_ota()
-        logger.info(f"configuring {proxy=}")
-
-        if proxy:
-            self._downloader.configure_proxy(proxy)
+        self._downloader = downloader
+        self.proxies = None
+        if proxy := proxy_cfg.get_proxy_for_local_ota():
+            logger.info(f"configuring {proxy=}")
+            self.proxies = {"http": proxy}
 
     def _process_directory(self):
         self.update_phase_tracker(wrapper.StatusProgressPhase.DIRECTORY)
 
         list_info = self.metadata.directory
         with tempfile.NamedTemporaryFile(prefix=__name__) as f:
+            url = urljoin(self.url_base, list_info.file)
             # NOTE: do not use cache when fetching dir list
             self._downloader.download(
-                list_info.file,
+                url,
                 Path(f.name),
-                list_info.hash,
+                digest=list_info.hash,
+                proxies=self.proxies,
                 cookies=self.cookies,
-                url_base=self.url_base,
                 headers={
                     OTAFileCacheControl.header_lower.value: OTAFileCacheControl.no_cache.value
                 },
@@ -129,12 +123,13 @@ class LegacyMode(StandbySlotCreatorProtocol):
 
         list_info = self.metadata.symboliclink
         with tempfile.NamedTemporaryFile(prefix=__name__) as f:
+            url = urljoin(self.url_base, list_info.file)
             # NOTE: do not use cache when fetching symlink list
             self._downloader.download(
-                list_info.file,
+                url,
                 Path(f.name),
-                list_info.hash,
-                url_base=self.url_base,
+                digest=list_info.hash,
+                proxies=self.proxies,
                 cookies=self.cookies,
                 headers={
                     OTAFileCacheControl.header_lower.value: OTAFileCacheControl.no_cache.value
@@ -152,13 +147,14 @@ class LegacyMode(StandbySlotCreatorProtocol):
 
         list_info = self.metadata.regular
         with tempfile.NamedTemporaryFile(prefix=__name__) as f:
+            url = urljoin(self.url_base, list_info.file)
             # download the regulars.txt
             # NOTE: do not use cache when fetching regular files list
             self._downloader.download(
-                list_info.file,
+                url,
                 Path(f.name),
-                list_info.hash,
-                url_base=self.url_base,
+                digest=list_info.hash,
+                proxies=self.proxies,
                 cookies=self.cookies,
                 headers={
                     OTAFileCacheControl.header_lower.value: OTAFileCacheControl.no_cache.value
@@ -172,12 +168,13 @@ class LegacyMode(StandbySlotCreatorProtocol):
 
         list_info = self.metadata.persistent
         with tempfile.NamedTemporaryFile(prefix=__name__) as f:
+            url = urljoin(self.url_base, list_info.file)
             # NOTE: do not use cache when fetching persist files list
             self._downloader.download(
-                list_info.file,
+                url,
                 Path(f.name),
-                list_info.hash,
-                url_base=self.url_base,
+                digest=list_info.hash,
+                proxies=self.proxies,
                 cookies=self.cookies,
                 headers={
                     OTAFileCacheControl.header_lower.value: OTAFileCacheControl.no_cache.value
@@ -202,7 +199,7 @@ class LegacyMode(StandbySlotCreatorProtocol):
                     ):  # NOTE: not equivalent to perinf.path.exists()
                         copy_tree.copy_with_parents(perinf.path, self.standby_slot_mp)
 
-    def _create_regular_file(self, reginf: RegularInf, *, download_se: Semaphore):
+    def _create_regular_file(self, reginf: RegularInf):
         # thread_time for multithreading function
         # NOTE: for multithreading implementation,
         # when a thread is sleeping, the GIL will be released
@@ -248,17 +245,19 @@ class LegacyMode(StandbySlotCreatorProtocol):
                         )
                         processed.op = RegProcessOperation.OP_COPY
                     else:
-                        # limit the concurrent downloading tasks
-                        with download_se:
-                            processed.errors = self._downloader.download(
-                                reginf.path,
-                                dst,
-                                digest=reginf.sha256hash,
-                                size=reginf.size,
-                                url_base=self.image_base_url,
-                                cookies=self.cookies,
-                            )
-                            processed.op = RegProcessOperation.OP_DOWNLOAD
+                        url, compressed = self.metadata.get_download_url(
+                            reginf, base_url=self.url_base
+                        )
+                        processed.errors = self._downloader.download(
+                            url,
+                            dst,
+                            digest=reginf.sha256hash,
+                            size=reginf.size,
+                            proxies=self.proxies,
+                            cookies=self.cookies,
+                            zstd_decompressed=compressed,
+                        )
+                        processed.op = RegProcessOperation.OP_DOWNLOAD
 
                         # set file permission as RegInf says
                         os.chown(dst, reginf.uid, reginf.gid)
@@ -284,17 +283,19 @@ class LegacyMode(StandbySlotCreatorProtocol):
                 )
                 processed.op = RegProcessOperation.OP_COPY
             else:
-                # limit the concurrent downloading tasks
-                with download_se:
-                    processed.errors = self._downloader.download(
-                        reginf.path,
-                        dst,
-                        digest=reginf.sha256hash,
-                        size=reginf.size,
-                        url_base=self.image_base_url,
-                        cookies=self.cookies,
-                    )
-                    processed.op = RegProcessOperation.OP_DOWNLOAD
+                url, compressed = self.metadata.get_download_url(
+                    reginf, base_url=self.url_base
+                )
+                processed.errors = self._downloader.download(
+                    url,
+                    dst,
+                    digest=reginf.sha256hash,
+                    size=reginf.size,
+                    proxies=self.proxies,
+                    cookies=self.cookies,
+                    zstd_decompressed=compressed,
+                )
+                processed.op = RegProcessOperation.OP_DOWNLOAD
 
                 # set file permission as RegInf says
                 os.chown(dst, reginf.uid, reginf.gid)
@@ -318,7 +319,6 @@ class LegacyMode(StandbySlotCreatorProtocol):
         self._hardlink_register = HardlinkRegister()
 
         # limit the cocurrent tasks and downloading
-        _download_se = Semaphore(self.MAX_CONCURRENT_DOWNLOAD)
         _tasks_tracker = SimpleTasksTracker(
             max_concurrent=self.MAX_CONCURRENT_TASKS,
             title="process_regulars",
@@ -335,11 +335,7 @@ class LegacyMode(StandbySlotCreatorProtocol):
                     logger.error(f"interrupt update due to {e!r}")
                     raise e
 
-                fut = pool.submit(
-                    self._create_regular_file,
-                    entry,
-                    download_se=_download_se,
-                )
+                fut = pool.submit(self._create_regular_file, entry)
                 _tasks_tracker.add_task(fut)
                 fut.add_done_callback(_tasks_tracker.done_callback)
 

--- a/otaclient/app/create_standby/legacy_mode.py
+++ b/otaclient/app/create_standby/legacy_mode.py
@@ -244,7 +244,7 @@ class LegacyMode(StandbySlotCreatorProtocol):
                         )
                         processed.op = RegProcessOperation.OP_COPY
                     else:
-                        url, compressed = self.metadata.get_download_url(
+                        url, compression_alg = self.metadata.get_download_url(
                             reginf, base_url=self.url_base
                         )
                         processed.errors = self._downloader.download(
@@ -254,7 +254,7 @@ class LegacyMode(StandbySlotCreatorProtocol):
                             size=reginf.size,
                             proxies=self.proxies,
                             cookies=self.cookies,
-                            zstd_decompressed=compressed,
+                            compression_alg=compression_alg,
                         )
                         processed.op = RegProcessOperation.OP_DOWNLOAD
 
@@ -282,7 +282,7 @@ class LegacyMode(StandbySlotCreatorProtocol):
                 )
                 processed.op = RegProcessOperation.OP_COPY
             else:
-                url, compressed = self.metadata.get_download_url(
+                url, compression_alg = self.metadata.get_download_url(
                     reginf, base_url=self.url_base
                 )
                 processed.errors = self._downloader.download(
@@ -292,7 +292,7 @@ class LegacyMode(StandbySlotCreatorProtocol):
                     size=reginf.size,
                     proxies=self.proxies,
                     cookies=self.cookies,
-                    zstd_decompressed=compressed,
+                    compression_alg=compression_alg,
                 )
                 processed.op = RegProcessOperation.OP_DOWNLOAD
 

--- a/otaclient/app/create_standby/legacy_mode.py
+++ b/otaclient/app/create_standby/legacy_mode.py
@@ -19,10 +19,9 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Callable
-from urllib.parse import urljoin
 
 from ..errors import ApplyOTAUpdateFailed, OTAError, StandbySlotSpaceNotEnoughError
-from ..common import SimpleTasksTracker, OTAFileCacheControl
+from ..common import SimpleTasksTracker, OTAFileCacheControl, urljoin_ensure_base
 from ..configs import config as cfg
 from ..copy_tree import CopyTree
 from ..downloader import (
@@ -69,7 +68,7 @@ class LegacyMode(StandbySlotCreatorProtocol):
     ) -> None:
         self.cookies = update_meta.cookies
         self.metadata = update_meta.metadata
-        self.url_base = f"{update_meta.url_base.rstrip('/')}/"
+        self.url_base = update_meta.url_base
 
         self.stats_collector = stats_collector
         self.update_phase_tracker: Callable = update_phase_tracker
@@ -94,7 +93,7 @@ class LegacyMode(StandbySlotCreatorProtocol):
 
         list_info = self.metadata.directory
         with tempfile.NamedTemporaryFile(prefix=__name__) as f:
-            url = urljoin(self.url_base, list_info.file)
+            url = urljoin_ensure_base(self.url_base, list_info.file)
             # NOTE: do not use cache when fetching dir list
             self._downloader.download(
                 url,
@@ -123,7 +122,7 @@ class LegacyMode(StandbySlotCreatorProtocol):
 
         list_info = self.metadata.symboliclink
         with tempfile.NamedTemporaryFile(prefix=__name__) as f:
-            url = urljoin(self.url_base, list_info.file)
+            url = urljoin_ensure_base(self.url_base, list_info.file)
             # NOTE: do not use cache when fetching symlink list
             self._downloader.download(
                 url,
@@ -147,7 +146,7 @@ class LegacyMode(StandbySlotCreatorProtocol):
 
         list_info = self.metadata.regular
         with tempfile.NamedTemporaryFile(prefix=__name__) as f:
-            url = urljoin(self.url_base, list_info.file)
+            url = urljoin_ensure_base(self.url_base, list_info.file)
             # download the regulars.txt
             # NOTE: do not use cache when fetching regular files list
             self._downloader.download(
@@ -168,7 +167,7 @@ class LegacyMode(StandbySlotCreatorProtocol):
 
         list_info = self.metadata.persistent
         with tempfile.NamedTemporaryFile(prefix=__name__) as f:
-            url = urljoin(self.url_base, list_info.file)
+            url = urljoin_ensure_base(self.url_base, list_info.file)
             # NOTE: do not use cache when fetching persist files list
             self._downloader.download(
                 url,

--- a/otaclient/app/create_standby/rebuild_mode.py
+++ b/otaclient/app/create_standby/rebuild_mode.py
@@ -124,15 +124,16 @@ class RebuildMode(StandbySlotCreatorProtocol):
     def _cal_and_prepare_delta(self):
         self.update_phase_tracker(wrapper.StatusProgressPhase.REGULAR)
 
-        # TODO: hardcoded regulars.txt
         # TODO 2: old_reg is not used currently
         logger.info("generating delta...")
 
+        regular_inf_fname = self.metadata.regular.file
+        dir_inf_fname = self.metadata.directory.file
         try:
             delta_calculator = DeltaGenerator(
-                old_reg=Path(self.META_FOLDER) / "regulars.txt",
-                new_reg=self._recycle_folder / "regulars.txt",
-                new_dirs=self._recycle_folder / "dirs.txt",
+                old_reg=Path(self.META_FOLDER) / regular_inf_fname,
+                new_reg=self._recycle_folder / regular_inf_fname,
+                new_dirs=self._recycle_folder / dir_inf_fname,
                 ref_root=self.reference_slot_mp,
                 recycle_folder=self._recycle_folder,
                 stats_collector=self.stats_collector,
@@ -167,7 +168,8 @@ class RebuildMode(StandbySlotCreatorProtocol):
             dst_group_file=self.standby_slot_mp / _group_file.relative_to("/"),
         )
 
-        with open(self._recycle_folder / "persistents.txt", "r") as f:
+        persist_inf_fname = self.metadata.persistent.file
+        with open(self._recycle_folder / persist_inf_fname, "r") as f:
             for entry_line in f:
                 perinf = PersistentInf(entry_line)
                 if (
@@ -188,7 +190,8 @@ class RebuildMode(StandbySlotCreatorProtocol):
             shutil.copy(_src, _dst)
 
     def _process_symlinks(self):
-        with open(self._recycle_folder / "symlinks.txt", "r") as f:
+        symlink_inf_fname = self.metadata.symboliclink.file
+        with open(self._recycle_folder / symlink_inf_fname, "r") as f:
             for entry_line in f:
                 SymbolicLinkInf(entry_line).link_at_mount_point(self.standby_slot_mp)
 

--- a/otaclient/app/create_standby/rebuild_mode.py
+++ b/otaclient/app/create_standby/rebuild_mode.py
@@ -18,10 +18,10 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Callable, List
-from urllib.parse import quote, urljoin
+from urllib.parse import quote
 
 from ..errors import NetworkError, OTAError, StandbySlotSpaceNotEnoughError
-from ..common import SimpleTasksTracker, OTAFileCacheControl
+from ..common import SimpleTasksTracker, OTAFileCacheControl, urljoin_ensure_base
 from ..configs import config as cfg
 from ..errors import (
     ApplyOTAUpdateFailed,
@@ -75,7 +75,7 @@ class RebuildMode(StandbySlotCreatorProtocol):
     ) -> None:
         self.cookies = update_meta.cookies
         self.metadata = update_meta.metadata
-        self.url_base = f"{update_meta.url_base.rstrip('/')}/"
+        self.url_base = update_meta.url_base
         self.stats_collector = stats_collector
         self.update_phase_tracker = update_phase_tracker
 
@@ -103,7 +103,7 @@ class RebuildMode(StandbySlotCreatorProtocol):
         self.update_phase_tracker(wrapper.StatusProgressPhase.METADATA)
         try:
             for meta_f in self.metadata.get_metafiles():
-                meta_f_url = urljoin(self.url_base, quote(meta_f.file))
+                meta_f_url = urljoin_ensure_base(self.url_base, quote(meta_f.file))
                 self._downloader.download(
                     meta_f_url,
                     self._recycle_folder / meta_f.file,

--- a/otaclient/app/create_standby/rebuild_mode.py
+++ b/otaclient/app/create_standby/rebuild_mode.py
@@ -244,7 +244,7 @@ class RebuildMode(StandbySlotCreatorProtocol):
             if not _local_copy_available:
                 cur_stat.op = RegProcessOperation.OP_DOWNLOAD
 
-                entry_url, zstd_enabled = self.metadata.get_download_url(
+                entry_url, compression_alg = self.metadata.get_download_url(
                     entry, base_url=self.url_base
                 )
                 cur_stat.errors = self._downloader.download(
@@ -254,7 +254,7 @@ class RebuildMode(StandbySlotCreatorProtocol):
                     size=entry.size,
                     proxies=self.proxies,
                     cookies=self.cookies,
-                    zstd_decompressed=zstd_enabled,
+                    compression_alg=compression_alg,
                 )
                 _local_copy_available = True
 

--- a/otaclient/app/downloader.py
+++ b/otaclient/app/downloader.py
@@ -26,8 +26,9 @@ from typing import Any, Callable, Dict, Optional, Union
 from requests.adapters import HTTPAdapter
 from requests.exceptions import (
     HTTPError,
-    RequestException,
     ChunkedEncodingError,
+    ConnectionError,
+    RequestException,
     RetryError,
 )
 from urllib3.util.retry import Retry
@@ -232,7 +233,7 @@ class Downloader:
                     _downloaded_bytes += len(data)
         except RetryError as e:
             raise ExceedMaxRetryError(url, dst, f"{e!r}")
-        except ChunkedEncodingError as e:
+        except (ChunkedEncodingError, ConnectionError) as e:
             # streaming interrupted
             raise ChunkStreamingError(url, dst) from e
         except HTTPError as e:

--- a/otaclient/app/downloader.py
+++ b/otaclient/app/downloader.py
@@ -142,8 +142,6 @@ class Downloader:
     RETRY_ON_STATUS_CODE = {413, 429, 500, 502, 503, 504}
 
     def _thread_initializer(self):
-        self._local = threading.local()
-
         ### setup the requests.Session ###
         session = requests.Session()
         # init retry mechanism
@@ -183,6 +181,7 @@ class Downloader:
         return self._local._zstd_dctx
 
     def __init__(self) -> None:
+        self._local = threading.local()
         self._executor = ThreadPoolExecutor(
             max_workers=min(self.MAX_DOWNLOAD_THREADS, (os.cpu_count() or 1) + 4),
             thread_name_prefix="downloader",

--- a/otaclient/app/downloader.py
+++ b/otaclient/app/downloader.py
@@ -133,7 +133,7 @@ class Downloader:
         r"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     )
     MAX_DOWNLOAD_THREADS = cfg.MAX_DOWNLOAD_THREAD
-    MAX_CONCURRENT_DOWNLOAD = cfg.MAX_CONCURRENT_DOWNLOAD_PER_THREAD
+    MAX_CONCURRENT_DOWNLOAD = cfg.DOWNLOADER_CONNPOOL_SIZE_PER_THREAD
     CHUNK_SIZE = cfg.CHUNK_SIZE
     RETRY_COUNT = cfg.DOWNLOAD_RETRY
     BACKOFF_FACTOR = 1
@@ -267,10 +267,27 @@ class Downloader:
 
         return _err_count
 
-    def download(self, *args, **kwargs):
+    def download(
+        self,
+        url: str,
+        dst: Union[str, Path],
+        *,
+        size: Optional[int] = None,
+        digest: Optional[str] = None,
+        proxies: Optional[Dict[str, str]] = None,
+        cookies: Optional[Dict[str, str]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        zstd_decompressed=False,
+    ):
         """Dispatcher for download tasks."""
         return self._executor.submit(
             self._download_task,
-            *args,
-            **kwargs,
+            url,
+            dst,
+            size=size,
+            digest=digest,
+            proxies=proxies,
+            cookies=cookies,
+            headers=headers,
+            zstd_decompressed=zstd_decompressed,
         ).result()

--- a/otaclient/app/downloader.py
+++ b/otaclient/app/downloader.py
@@ -12,20 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import requests
-import time
 import errno
+import os
+import requests
+import threading
+import time
+import zstandard
+from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from hashlib import sha256
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Union
-from urllib.parse import quote_from_bytes, urljoin, urlparse
+from requests.adapters import HTTPAdapter
 from requests.exceptions import (
-    ConnectionError,
+    HTTPError,
+    RequestException,
     ChunkedEncodingError,
-    StreamConsumedError,
+    RetryError,
 )
+from urllib3.util.retry import Retry
 
 from .configs import config as cfg
 from .common import OTAFileCacheControl
@@ -47,6 +52,15 @@ class DownloadError(Exception):
         return f"{_inject}{super().__str__()}"
 
     __repr__ = __str__
+
+
+class UnhandledHTTPError(DownloadError):
+    """HTTPErrors that cannot be handled by us.
+
+    Currently include 403 and 404.
+    """
+
+    pass
 
 
 class DestinationNotAvailableError(DownloadError):
@@ -78,9 +92,9 @@ REQUEST_RECACHE_HEADER: Dict[str, str] = {
 
 def _retry(retry: int, backoff_factor: float, backoff_max: int, func: Callable):
     """
-    NOTE: this retry decorator expects the input func to
-    have 'headers' kwarg.
-    NOTE 2: only retry on ChunkStreamingError and HashVerificationError
+    NOTE: this retry decorator expects the input func to have 'headers' kwarg.
+    NOTE: only retry on errors that doesn't handled by the urllib3.Retry module,
+          which are ChunkStreamingError and HashVerificationError.
     """
     from functools import wraps
 
@@ -90,6 +104,10 @@ def _retry(retry: int, backoff_factor: float, backoff_max: int, func: Callable):
         while True:
             try:
                 return func(*args, **kwargs)
+            except (ExceedMaxRetryError, UnhandledHTTPError):
+                # if urllib3.Retry has already handled the retry,
+                # or we hit an UnhandledHTTPError, just re-raise
+                raise
             except (HashVerificaitonError, ChunkStreamingError):
                 _retry_count += 1
                 _backoff = min(backoff_max, backoff_factor * (2 ** (_retry_count - 1)))
@@ -110,34 +128,35 @@ def _retry(retry: int, backoff_factor: float, backoff_max: int, func: Callable):
 
 
 class Downloader:
+    EMPTY_STR_SHA256 = (
+        r"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    )
+    MAX_DOWNLOAD_THREADS = cfg.MAX_DOWNLOAD_THREAD
+    MAX_CONCURRENT_DOWNLOAD = cfg.MAX_CONCURRENT_DOWNLOAD_PER_THREAD
     CHUNK_SIZE = cfg.CHUNK_SIZE
     RETRY_COUNT = cfg.DOWNLOAD_RETRY
     BACKOFF_FACTOR = 1
     OUTER_BACKOFF_FACTOR = 0.01
     BACKOFF_MAX = cfg.DOWNLOAD_BACKOFF_MAX
-    MAX_CONCURRENT_DOWNLOAD = cfg.MAX_CONCURRENT_DOWNLOAD
-    EMPTY_STR_SHA256 = (
-        r"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-    )
+    RETRY_ON_STATUS_CODE = {413, 429, 500, 502, 503, 504}
 
-    def __init__(self):
-        from requests.adapters import HTTPAdapter
-        from urllib3.util.retry import Retry
+    def _thread_initializer(self):
+        self._local = threading.local()
 
-        # base session
+        ### setup the requests.Session ###
         session = requests.Session()
-
         # init retry mechanism
-        # NOTE: for urllib3 version below 2.0, we have to change Retry class' DEFAULT_BACKOFF_MAX,
-        # to configure the backoff max, set the value to the instance will not work as increment() method
-        # will create a new instance of Retry on every try without inherit the change to instance's DEFAULT_BACKOFF_MAX
+        # NOTE: for urllib3 version below 2.0, we have to change Retry class'
+        # DEFAULT_BACKOFF_MAX, to configure the backoff max, set the value to
+        # the instance will not work as increment() method will create a new
+        # instance of Retry on every try without inherit the change to
+        # instance's DEFAULT_BACKOFF_MAX
         Retry.DEFAULT_BACKOFF_MAX = self.BACKOFF_MAX
         retry_strategy = Retry(
             total=self.RETRY_COUNT,
-            raise_on_status=True,
             backoff_factor=self.BACKOFF_FACTOR,
-            # retry on common server side errors and non-critical client side errors
-            status_forcelist={413, 429, 500, 502, 503, 504},
+            # retry on common serverside errors and clientside errors
+            status_forcelist=self.RETRY_ON_STATUS_CODE,
             allowed_methods=["GET"],
         )
         adapter = HTTPAdapter(
@@ -147,115 +166,110 @@ class Downloader:
         )
         session.mount("https://", adapter)
         session.mount("http://", adapter)
+        self._local.session = session
 
-        # cleanup proxy if any
-        proxies = {"http": "", "https": ""}
-        session.proxies.update(proxies)
+        ### setup zstd decompressor ###
+        self._local._zstd_dctx = zstandard.ZstdDecompressor()
 
-        # register the connection pool
-        self.session = session
-        self._proxy_set = False
+    @property
+    def _session(self) -> requests.Session:
+        """A thread-local private session."""
+        return self._local.session
+
+    @property
+    def _zstd_dctx(self) -> zstandard.ZstdDecompressor:
+        """A thread-local private zstd decompressor."""
+        return self._local._zstd_dctx
+
+    def __init__(self) -> None:
+        self._executor = ThreadPoolExecutor(
+            max_workers=min(self.MAX_DOWNLOAD_THREADS, (os.cpu_count() or 1) + 4),
+            thread_name_prefix="downloader",
+            initializer=self._thread_initializer,
+        )
+        self._hash_func = sha256
 
     def shutdown(self):
-        self.session.close()
-
-    def configure_proxy(self, proxy: str):
-        # configure proxy
-        self._proxy_set = True
-        proxies = {"http": proxy, "https": ""}
-        self.session.proxies.update(proxies)
-
-    def cleanup_proxy(self):
-        self._proxy_set = False
-        self.configure_proxy("")
-
-    def _path_to_url(self, base: str, path: Union[Path, str]) -> str:
-        # regulate base url, add suffix / to it if not existed
-        base = f"{base}/" if not base.endswith("/") else base
-        # convert to Path if path is str
-        path = Path(path) if isinstance(path, str) else path
-
-        relative_path = path
-        # if the path is relative to /
-        try:
-            relative_path = path.relative_to("/")
-        except ValueError:
-            pass
-
-        quoted_path = quote_from_bytes(bytes(relative_path))
-
-        # switch scheme if needed
-        _url_parsed = urlparse(urljoin(base, quoted_path))
-        # unconditionally set scheme to HTTP if proxy is applied
-        if self._proxy_set:
-            _url_parsed = _url_parsed._replace(scheme="http")
-
-        return _url_parsed.geturl()
+        self._executor.shutdown()
 
     @partial(_retry, RETRY_COUNT, OUTER_BACKOFF_FACTOR, BACKOFF_MAX)
-    def download(
+    def _download_task(
         self,
-        path: Union[Path, str],
-        dst: Union[Path, str],
-        digest: Optional[str] = None,
-        size: Optional[int] = None,
+        url: str,
+        dst: Union[str, Path],
         *,
-        url_base: str,
+        size: Optional[int] = None,
+        digest: Optional[str] = None,
+        proxies: Optional[Dict[str, str]] = None,
         cookies: Optional[Dict[str, str]] = None,
         headers: Optional[Dict[str, str]] = None,
+        zstd_decompressed=False,
     ) -> int:
-        url = self._path_to_url(url_base, path)
-        cookies = cookies if cookies else {}
-        headers = headers if headers else {}
-        dst = Path(dst)
-
-        # specially deal with empty file
-        if digest == self.EMPTY_STR_SHA256:
-            dst.write_bytes(b"")
+        # special treatment for empty file
+        if dst == self.EMPTY_STR_SHA256 and not (dst_p := Path(dst)).is_file():
+            dst_p.write_bytes(b"")
             return 0
 
+        _hash_inst, _downloaded_bytes = self._hash_func(), 0
+        _err_count = 0
         try:
-            error_count = 0
-            response = self.session.get(
-                url, stream=True, cookies=cookies, headers=headers
-            )
-
-            raw_r = response.raw
-            if raw_r.retries:
-                error_count = len(raw_r.retries.history)
-        except Exception as e:
-            raise ExceedMaxRetryError(url, dst) from e
-
-        hash_f = sha256()
-        _downloaded_size = 0
-        try:
-            with open(dst, "wb") as f:
-                for chunk in response.iter_content(chunk_size=self.CHUNK_SIZE):
-                    hash_f.update(chunk)
-                    f.write(chunk)
-                    _downloaded_size += len(chunk)
-        except (ChunkedEncodingError, ConnectionError, StreamConsumedError) as e:
+            with self._session.get(
+                url,
+                stream=True,
+                proxies=proxies,
+                cookies=cookies,
+                headers=headers,
+            ) as resp, open(dst, "wb") as f:
+                resp.raise_for_status()
+                raw_resp = resp.raw
+                if raw_resp.retries:
+                    _err_count = len(raw_resp.retries.history)
+                if zstd_decompressed:
+                    raw_resp = self._zstd_dctx.stream_reader(raw_resp)
+                while data := raw_resp.read(self.CHUNK_SIZE):
+                    _hash_inst.update(data)
+                    f.write(data)
+                    _downloaded_bytes += len(data)
+        except RetryError as e:
+            raise ExceedMaxRetryError(url, dst, f"{e!r}")
+        except ChunkedEncodingError as e:
+            # streaming interrupted
             raise ChunkStreamingError(url, dst) from e
+        except HTTPError as e:
+            # HTTPErrors that cannot be handled by retry,
+            # include 403 and 404
+            raise UnhandledHTTPError(url, dst, e.strerror)
+        except RequestException as e:
+            # any errors that happens during handling request
+            # and are not the above exceptions
+            raise ExceedMaxRetryError(url, dst) from e
         except FileNotFoundError as e:
+            # dst is not available
             raise DestinationNotAvailableError(url, dst) from e
         except OSError as e:
-            # space not enough error
+            # only handle disk out-of-space error
             if e.errno == errno.ENOSPC:
                 raise DownloadFailedSpaceNotEnough(url, dst) from None
 
-        # throw a network error if the file is not fully downloaded
-        if size is not None and size != _downloaded_size:
-            raise ChunkStreamingError(url, dst) from ValueError(
-                "partial download detected"
-            )
-
-        calc_digest = hash_f.hexdigest()
-        if digest and calc_digest != digest:
+        # checking the download result
+        if size is not None and size != _downloaded_bytes:
+            msg = f"partial download detected: {size=},{_downloaded_bytes=}"
+            logger.error(msg)
+            raise ChunkStreamingError(url, dst, msg)
+        if digest and ((calc_digest := _hash_inst.hexdigest()) != digest):
             msg = (
-                f"hash check failed detected: "
+                "sha256hash check failed detected: "
                 f"act={calc_digest}, exp={digest}, {url=}"
             )
             logger.error(msg)
             raise HashVerificaitonError(url, dst, msg)
 
-        return error_count
+        return _err_count
+
+    def download(self, *args, **kwargs):
+        """Dispatcher for download tasks."""
+        return self._executor.submit(
+            self._download_task,
+            *args,
+            **kwargs,
+        ).result()

--- a/otaclient/app/ota_client.py
+++ b/otaclient/app/ota_client.py
@@ -20,7 +20,7 @@ from json.decoder import JSONDecodeError
 from pathlib import Path
 from threading import Event, Lock
 from typing import Any, Dict, Optional, Tuple, Type
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urlparse
 
 from .errors import (
     BaseOTAMetaVerificationFailed,
@@ -32,7 +32,7 @@ from .errors import (
     OTAUpdateError,
 )
 from .boot_control import BootControllerProtocol
-from .common import OTAFileCacheControl
+from .common import OTAFileCacheControl, urljoin_ensure_base
 from .configs import config as cfg
 from .create_standby import StandbySlotCreatorProtocol, UpdateMeta
 from .downloader import DownloadError, Downloader
@@ -145,7 +145,7 @@ class _OTAUpdater:
         with tempfile.TemporaryDirectory(prefix=__name__) as d:
             meta_file = Path(d) / "metadata.jwt"
             # NOTE: do not use cache when fetching metadata
-            metadata_jwt_url = urljoin(f"{url_base.rstrip('/')}/", "metadata.jwt")
+            metadata_jwt_url = urljoin_ensure_base(url_base, "metadata.jwt")
             self._downloader.download(
                 metadata_jwt_url,
                 meta_file,
@@ -165,7 +165,7 @@ class _OTAUpdater:
             cert_fname, cert_hash = cert_info.file, cert_info.hash
             cert_file: Path = Path(d) / cert_fname
             self._downloader.download(
-                urljoin(f"{url_base.rstrip('/')}/", cert_fname),
+                urljoin_ensure_base(url_base, cert_fname),
                 cert_file,
                 digest=cert_hash,
                 cookies=cookies,

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -290,7 +290,7 @@ class OTAMetadata:
         if getattr(self, "_data_url", None) is None:
             _base_url = f"{base_url.rstrip('/')}/"  # ensure base_url ends with /
             self._data_url = urljoin(_base_url, self.rootfs_directory.lstrip("/"))
-        return self._data_url
+        return f"{self._data_url.rstrip('/')}/"
 
     def get_image_compressed_data_url(self, base_url: str) -> str:
         if getattr(self, "_compressed_data_url", None) is None:
@@ -298,7 +298,7 @@ class OTAMetadata:
             self._compressed_data_url = urljoin(
                 _base_url, self.compressed_rootfs_directory.lstrip("/")
             )
-        return self._compressed_data_url
+        return f"{self._compressed_data_url.rstrip('/')}/"
 
     def get_download_url(
         self, reg_inf: RegularInf, *, base_url: str

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -306,25 +306,24 @@ class OTAMetadata:
 
     def get_download_url(
         self, reg_inf: RegularInf, *, base_url: str
-    ) -> Tuple[str, bool]:
+    ) -> Tuple[str, Optional[str]]:
         """
         NOTE: compressed file is located under another OTA image remote folder
 
         Returns:
             A tuple of download url and zstd_compression enable flag.
         """
-        # v2 OTA image, with zst compression enabled
-        # example: http://example.com/base_url/data.zstd/a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3.zst
+        # v2 OTA image, with compression enabled
+        # example: http://example.com/base_url/data.zstd/a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3.<compression_alg>
         if (
-            reg_inf.compressed_alg
-            and reg_inf.compressed_alg in cfg.SUPPORTED_COMPRESS_ALG
-        ):
+            compress_alg := reg_inf.compressed_alg
+        ) and compress_alg in cfg.SUPPORTED_COMPRESS_ALG:
             return (
                 urljoin_ensure_base(
                     self.get_image_compressed_data_url(base_url),
                     quote(f"{reg_inf.sha256hash}.{reg_inf.compressed_alg}"),
                 ),
-                True,
+                compress_alg,
             )
         # v1 OTA image, uncompressed and use full path as URL path
         # example: http://example.com/base_url/data/rootfs/full/path/file
@@ -334,7 +333,7 @@ class OTAMetadata:
                     self.get_image_data_url(base_url),
                     quote(str(reg_inf.path.relative_to("/"))),
                 ),
-                False,
+                None,
             )
 
 

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -143,7 +143,7 @@ class ParseMetadataHelper:
         logger.debug(f"metadata={self.ota_metadata!r}")
 
     def _verify_metadata_cert(self, metadata_cert: bytes) -> None:
-        """Verify the metadata's sign cert against local pinned CA.
+        """Verify the metadata's sign certificate against local pinned CA.
 
         Raises:
             Raise ValueError on verification failed.
@@ -186,11 +186,14 @@ class ParseMetadataHelper:
             except crypto.X509StoreContextError as e:
                 logger.info(f"verify against {ca_prefix} failed: {e}")
 
-        logger.error(f"certificate {metadata_cert} could not be verified")
-        raise ValueError(f"certificate {metadata_cert} could not be verified")
+        logger.error(f"metadata sign certificate {metadata_cert} could not be verified")
+        raise ValueError(
+            f"metadata sign certificate {metadata_cert} could not be verified"
+        )
 
     def _verify_metadata(self, metadata_cert: bytes):
-        """
+        """Verify metadata against sign certificate.
+
         Raises:
             Raise ValueError on validation failed.
         """
@@ -203,9 +206,10 @@ class ParseMetadataHelper:
                 self.metadata_bytes,
                 self.HASH_ALG,
             )
-        except Exception as e:
-            logger.exception("verify")
-            raise ValueError(e)
+        except crypto.Error as e:
+            msg = f"failed to verify metadata against sign cert: {e!r}"
+            logger.error(msg)
+            raise ValueError(msg) from None
 
     def get_otametadata(self) -> "OTAMetadata":
         """Get parsed OTAMetaData.

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -28,6 +28,7 @@ from typing import (
     ClassVar,
     Dict,
     Generic,
+    Iterator,
     List,
     Optional,
     TypeVar,
@@ -117,7 +118,7 @@ class MetaFieldDescriptor(Generic[FV]):
 class ParseMetadataHelper:
     HASH_ALG = "sha256"
 
-    def __init__(self, metadata_jwt: str, *, certs_dir: str):
+    def __init__(self, metadata_jwt: str, *, certs_dir: Union[str, Path]):
         self.cert_dir = Path(certs_dir)
 
         # pre_parse metadata_jwt
@@ -273,6 +274,15 @@ class OTAMetadata:
                 if (fn := f.name) in entry:
                     setattr(res, fn, entry)
         return res
+
+    def get_metafiles(self) -> Iterator[MetaFile]:
+        for f in fields(self):
+            if (
+                (fd := getattr(self.__class__, f.name))
+                and isinstance(fd, MetaFieldDescriptor)
+                and fd.field_type is MetaFile
+            ):
+                yield getattr(self, f.name)
 
 
 # meta files entry classes

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -32,6 +32,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Tuple,
     TypeVar,
     Union,
     overload,
@@ -299,9 +300,14 @@ class OTAMetadata:
             )
         return self._compressed_data_url
 
-    def get_download_url(self, reg_inf: RegularInf, *, base_url: str) -> str:
+    def get_download_url(
+        self, reg_inf: RegularInf, *, base_url: str
+    ) -> Tuple[str, bool]:
         """
         NOTE: compressed file is located under another OTA image remote folder
+
+        Returns:
+            A tuple of download url and zstd_compression enable flag.
         """
         # v2 OTA image, with zst compression enabled
         # example: http://example.com/base_url/data.zstd/a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3.zst
@@ -309,16 +315,22 @@ class OTAMetadata:
             reg_inf.compressed_alg
             and reg_inf.compressed_alg in cfg.SUPPORTED_COMPRESS_ALG
         ):
-            return urljoin(
-                self.get_image_compressed_data_url(base_url),
-                quote(f"{reg_inf.sha256hash}.{reg_inf.compressed_alg}"),
+            return (
+                urljoin(
+                    self.get_image_compressed_data_url(base_url),
+                    quote(f"{reg_inf.sha256hash}.{reg_inf.compressed_alg}"),
+                ),
+                True,
             )
         # v1 OTA image, uncompressed and use full path as URL path
         # example: http://example.com/base_url/data/rootfs/full/path/file
         else:
-            return urljoin(
-                self.get_image_data_url(base_url),
-                quote(str(reg_inf.path.relative_to("/"))),
+            return (
+                urljoin(
+                    self.get_image_data_url(base_url),
+                    quote(str(reg_inf.path.relative_to("/"))),
+                ),
+                False,
             )
 
 

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -20,6 +20,7 @@ import os
 import re
 import shutil
 from dataclasses import asdict, dataclass, field, fields
+from urllib.parse import urljoin
 from OpenSSL import crypto
 from pathlib import Path
 from functools import partial
@@ -283,6 +284,20 @@ class OTAMetadata:
                 and fd.field_type is MetaFile
             ):
                 yield getattr(self, f.name)
+
+    def get_image_data_url(self, base_url: str) -> str:
+        if getattr(self, "_data_url", None) is None:
+            _base_url = f"{base_url.rstrip('/')}/"  # ensure base_url ends with /
+            self._data_url = urljoin(_base_url, self.rootfs_directory.lstrip("/"))
+        return self._data_url
+
+    def get_image_compressed_data_url(self, base_url: str) -> str:
+        if getattr(self, "_compressed_data_url", None) is None:
+            _base_url = f"{base_url.rstrip('/')}/"  # ensure base_url ends with /
+            self._compressed_data_url = urljoin(
+                _base_url, self.compressed_rootfs_directory.lstrip("/")
+            )
+        return self._compressed_data_url
 
 
 # meta files entry classes

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -475,7 +475,7 @@ class RegularInf:
     _reginf_pa: ClassVar[re.Pattern] = re.compile(
         r"(?P<mode>\d+),(?P<uid>\d+),(?P<gid>\d+)"
         r",(?P<nlink>\d+),(?P<hash>\w+),'(?P<path>.+)'"
-        r"(,(?P<size>\d+)(,(?P<inode>\d+)(,(?P<compressed_alg>\w+))?)?)?"
+        r"(,(?P<size>\d+)?(,(?P<inode>\d+)?(,(?P<compressed_alg>\w+)?)?)?)?"
     )
 
     @classmethod

--- a/otaclient/requirements.txt
+++ b/otaclient/requirements.txt
@@ -12,7 +12,6 @@ boto3==1.17.112
 retrying==1.3.3
 urllib3>=1.26.8, <2.0.0
 uvicorn==0.18.3
-urllib3>=1.26.8
 aiohttp>=3.8.1
 aiofiles==0.8.0
 zstandard==0.18.0

--- a/otaclient/requirements.txt
+++ b/otaclient/requirements.txt
@@ -11,6 +11,7 @@ botocore==1.20.112
 boto3==1.17.112
 retrying==1.3.3
 uvicorn>=0.16.0
-urllib3>=1.26.8
+urllib3>=1.26.8, <2.0.0
 aiohttp>=3.8.1
 aiofiles==0.8.0
+zstandard==0.18.0

--- a/tests/test_create_standby.py
+++ b/tests/test_create_standby.py
@@ -21,7 +21,7 @@ from pytest_mock import MockerFixture
 from otaclient.app.create_standby.interface import UpdateMeta
 from otaclient.app.create_standby.legacy_mode import LegacyMode
 from otaclient.app.create_standby.rebuild_mode import RebuildMode
-from otaclient.app.ota_metadata import OtaMetadata
+from otaclient.app.ota_metadata import ParseMetadataHelper
 from otaclient.app.proto import wrapper
 from otaclient.app.update_stats import OTAUpdateStatsCollector
 
@@ -58,10 +58,15 @@ class _Common:
         finally:
             _collector.stop()
 
+    @pytest.fixture
+    def prepare_certsdir(self):
+        _test_dir = Path(__file__).parent
+        self.certs_dir = str(_test_dir / "keys")
+
 
 class Test_RebuildMode(_Common):
     @pytest.fixture(autouse=True)
-    def prepare_mock(self, mocker: MockerFixture, prepare_ab_slots):
+    def prepare_mock(self, mocker: MockerFixture, prepare_certsdir, prepare_ab_slots):
         cfg_path = f"{cfg.CREATE_STANDBY_MODULE_PATH}.rebuild_mode.cfg"
         proxy_cfg_path = f"{cfg.CREATE_STANDBY_MODULE_PATH}.rebuild_mode.proxy_cfg"
         mocker.patch(f"{cfg_path}.PASSWD_FILE", f"{self.slot_a}/etc/passwd")
@@ -77,11 +82,14 @@ class Test_RebuildMode(_Common):
         mocker.patch(f"{rebuild_mode_cls}._process_persistents")
 
         # prepare update meta
+        _parser = ParseMetadataHelper(
+            (Path(cfg.OTA_IMAGE_DIR) / "metadata.jwt").read_text(),
+            certs_dir=self.certs_dir,
+        )
+        ota_meta = _parser.get_otametadata()
         self.update_meta = UpdateMeta(
             cookies={},
-            metadata=OtaMetadata(
-                (Path(cfg.OTA_IMAGE_DIR) / "metadata.jwt").read_text()
-            ),
+            metadata=ota_meta,
             url_base=f"http://{cfg.OTA_IMAGE_SERVER_ADDR}:{cfg.OTA_IMAGE_SERVER_PORT}",
             boot_dir=str(self.slot_b_boot_dir),
             standby_slot_mount_point=str(self.slot_b),
@@ -123,7 +131,7 @@ class Test_RebuildMode(_Common):
 
 class Test_LegacyMode(_Common):
     @pytest.fixture(autouse=True)
-    def prepare_mock(self, prepare_ab_slots, mocker: MockerFixture):
+    def prepare_mock(self, mocker: MockerFixture, prepare_certsdir, prepare_ab_slots):
         module_root = f"{cfg.CREATE_STANDBY_MODULE_PATH}.legacy_mode"
 
         cfg_path = f"{module_root}.cfg"
@@ -140,11 +148,14 @@ class Test_LegacyMode(_Common):
         mocker.patch(f"{legacy_mode_cls}._process_persistent")
 
         # prepare update meta
+        _parser = ParseMetadataHelper(
+            (Path(cfg.OTA_IMAGE_DIR) / "metadata.jwt").read_text(),
+            certs_dir=self.certs_dir,
+        )
+        ota_meta = _parser.get_otametadata()
         self.update_meta = UpdateMeta(
             cookies={},
-            metadata=OtaMetadata(
-                (Path(cfg.OTA_IMAGE_DIR) / "metadata.jwt").read_text()
-            ),
+            metadata=ota_meta,
             url_base=f"http://{cfg.OTA_IMAGE_SERVER_ADDR}:{cfg.OTA_IMAGE_SERVER_PORT}",
             boot_dir=str(self.slot_b_boot_dir),
             standby_slot_mount_point=str(self.slot_b),

--- a/tests/test_create_standby.py
+++ b/tests/test_create_standby.py
@@ -21,6 +21,7 @@ from pytest_mock import MockerFixture
 from otaclient.app.create_standby.interface import UpdateMeta
 from otaclient.app.create_standby.legacy_mode import LegacyMode
 from otaclient.app.create_standby.rebuild_mode import RebuildMode
+from otaclient.app.downloader import Downloader
 from otaclient.app.ota_metadata import ParseMetadataHelper
 from otaclient.app.proto import wrapper
 from otaclient.app.update_stats import OTAUpdateStatsCollector
@@ -57,6 +58,14 @@ class _Common:
             yield
         finally:
             _collector.stop()
+
+    @pytest.fixture(autouse=True)
+    def prepare_downloader(self):
+        try:
+            self._downloader = Downloader()
+            yield
+        finally:
+            self._downloader.shutdown()
 
     @pytest.fixture
     def prepare_certsdir(self):
@@ -103,6 +112,7 @@ class Test_RebuildMode(_Common):
             update_meta=self.update_meta,
             stats_collector=self._collector,
             update_phase_tracker=update_phase_tracker,
+            downloader=self._downloader,
         )
         builder.create_standby_slot()
 
@@ -169,6 +179,7 @@ class Test_LegacyMode(_Common):
             update_meta=self.update_meta,
             stats_collector=self._collector,
             update_phase_tracker=update_phase_tracker,
+            downloader=self._downloader,
         )
         builder.create_standby_slot()
 

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -13,21 +13,86 @@
 # limitations under the License.
 
 
+import asyncio
+import logging
+import threading
 import pytest
 import pytest_mock
 import requests
 import requests_mock
-import typing
 from pathlib import Path
+from urllib.parse import urlsplit, urljoin
+
 
 from otaclient.app.common import file_sha256
 from otaclient.app.downloader import (
+    Downloader,
+    DestinationNotAvailableError,
     ChunkStreamingError,
     ExceedMaxRetryError,
     HashVerificaitonError,
+    UnhandledHTTPError,
 )
 
 from tests.conftest import TestConfiguration as cfg
+
+
+logger = logging.getLogger(__name__)
+
+
+class _SimpleDummyApp:
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] != "http" or scope["method"] != "GET":
+            return
+
+        url = urlsplit(scope["path"])
+        _input_status_code = url.path.strip("/")
+        # send a request with the http code indicated by URL path
+        await send(
+            {
+                "type": "http.response.start",
+                "status": int(_input_status_code),
+                "headers": [
+                    [b"content-type", b"text/html;charset=UTF-8"],
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": _input_status_code.encode()})
+
+
+@pytest.fixture
+def launch_dummy_server(host: str = "127.0.0.1", port: int = 9999):
+    _should_exit = threading.Event()
+
+    async def _launcher():
+        import uvicorn
+
+        _config = uvicorn.Config(
+            _SimpleDummyApp(),
+            host=host,
+            port=port,
+        )
+        server = uvicorn.Server(_config)
+        config = server.config
+        if not config.loaded:
+            config.load()
+        server.lifespan = config.lifespan_class(config)
+        await server.startup()
+        logger.info("dummy server started")
+        while True:
+            if _should_exit.is_set():
+                await server.shutdown()
+                break
+            await asyncio.sleep(2)
+
+    try:
+        _t = threading.Thread(target=asyncio.run, args=(_launcher(),))
+        _t.start()
+        yield
+    finally:
+        logger.info("dummy server shutdown")
+        _should_exit.set()
+        _t.join()
 
 
 class TestDownloader:
@@ -38,66 +103,63 @@ class TestDownloader:
     TEST_FILE_SHA256 = file_sha256(TEST_FILE_PATH)
     TEST_FILE_SIZE = len(TEST_FILE_PATH.read_bytes())
 
-    DOWNLOADER_MODULE_PATH = "app.downloader"
-
     @pytest.fixture(autouse=True)
-    def mock_setup(self, mocker: pytest_mock.MockerFixture):
-        _cfg_path = f"{self.DOWNLOADER_MODULE_PATH}.cfg"
-        mocker.patch(f"{_cfg_path}.DOWNLOAD_BACKOFF_MAX", 2)
+    def launch_downloader(self, mocker: pytest_mock.MockerFixture):
+        mocker.patch.object(Downloader, "BACKOFF_MAX", 0.1)
+        mocker.patch.object(Downloader, "RETRY_COUNT", 3)
+        try:
+            self.downloader = Downloader()
+            yield
+        finally:
+            self.downloader.shutdown()
 
     def test_normal_download(self, tmp_path: Path):
-        from otaclient.app.downloader import Downloader
-
-        _downloader = Downloader()
         _target_path = tmp_path / self.TEST_FILE
 
-        _downloader.cleanup_proxy()
-        _error = _downloader.download(
-            self.TEST_FILE,
+        url = urljoin(f"{cfg.OTA_IMAGE_URL.rstrip('/')}/", self.TEST_FILE)
+        _error = self.downloader.download(
+            url,
             _target_path,
-            self.TEST_FILE_SHA256,
-            url_base=cfg.OTA_IMAGE_URL,
+            digest=self.TEST_FILE_SHA256,
+            size=self.TEST_FILE_SIZE,
         )
 
         assert _error == 0
         assert file_sha256(_target_path) == self.TEST_FILE_SHA256
 
     def test_download_mismatch_sha256(self, tmp_path: Path):
-        from otaclient.app.downloader import Downloader
-
-        _downloader = Downloader()
         _target_path = tmp_path / self.TEST_FILE
 
-        _downloader.cleanup_proxy()
+        url = urljoin(f"{cfg.OTA_IMAGE_URL.rstrip('/')}/", self.TEST_FILE)
         with pytest.raises(HashVerificaitonError):
-            _downloader.download(
-                self.TEST_FILE,
+            self.downloader.download(
+                url,
                 _target_path,
-                "wrong_sha256_value",
-                url_base=cfg.OTA_IMAGE_URL,
+                digest="wrong_sha256hash",
+                size=self.TEST_FILE_SIZE,
             )
 
     @pytest.mark.parametrize(
         "inject_requests_err, expected_ota_download_err",
         (
-            (requests.exceptions.ConnectTimeout, ExceedMaxRetryError),
-            (
-                requests.exceptions.HTTPError,
-                ExceedMaxRetryError,
-            ),  # arbitrary HTTP error
+            (requests.exceptions.ChunkedEncodingError, ChunkStreamingError),
+            (requests.exceptions.ConnectionError, ChunkStreamingError),
+            (requests.exceptions.HTTPError, UnhandledHTTPError),
+            (FileNotFoundError, DestinationNotAvailableError),
+            (requests.exceptions.RequestException, ExceedMaxRetryError),
         ),
     )
-    def test_download_server_error(
+    def test_download_errors_handling(
         self,
         tmp_path: Path,
         inject_requests_err,
         expected_ota_download_err,
+        mocker: pytest_mock.MockerFixture,
     ):
+        import requests
         from otaclient.app.downloader import Downloader
 
-        _downloader = Downloader()
-        _target_path = tmp_path / self.TEST_FILE
-
+        _mocked_session = requests.Session()
         _mock_adapter = requests_mock.Adapter()
         _mock_adapter.register_uri(
             requests_mock.ANY,
@@ -105,109 +167,91 @@ class TestDownloader:
             exc=inject_requests_err,
         )
 
-        # directly load the mocker adapter to the Downloader session
-        _downloader.session.mount(cfg.OTA_IMAGE_URL, _mock_adapter)
-        with pytest.raises(expected_ota_download_err) as e:
-            _downloader.download(
-                self.TEST_FILE,
-                _target_path,
-                self.TEST_FILE_SHA256,
-                url_base=cfg.OTA_IMAGE_URL,
-            )
-        # assert exception catched
-        assert isinstance(e.value.__cause__, inject_requests_err)
-
-    def test_raise_streaming_error_on_incompleted_download(self, tmp_path: Path):
-        from otaclient.app.downloader import Downloader
+        # load the mocker adapter to the Downloader session
+        _mocked_session.mount(cfg.OTA_IMAGE_URL, _mock_adapter)
+        # patch the mocked session to the downloader module
+        mocker.patch(
+            "app.downloader.requests.Session",
+            return_value=_mocked_session,
+        )
 
         _downloader = Downloader()
         _target_path = tmp_path / self.TEST_FILE
-
-        with pytest.raises(ChunkStreamingError) as e:
+        url = urljoin(f"{cfg.OTA_IMAGE_URL.rstrip('/')}/", self.TEST_FILE)
+        with pytest.raises(expected_ota_download_err):
             _downloader.download(
-                self.TEST_FILE,
+                url,
                 _target_path,
+                size=self.TEST_FILE_SIZE,
                 digest=self.TEST_FILE_SHA256,
-                # input wrong size to simulate incomplete download
-                size=self.TEST_FILE_SIZE // 2,
-                url_base=cfg.OTA_IMAGE_URL,
             )
-
-        assert isinstance(e.value.__cause__, ValueError)
+        _downloader.shutdown()
 
     @pytest.mark.parametrize(
-        "inject_requests_err, expected_ota_download_err",
+        "status_code, expected_ota_download_err",
         (
-            (requests.exceptions.ChunkedEncodingError, ChunkStreamingError),
-            (requests.exceptions.ConnectionError, ChunkStreamingError),
-            (requests.exceptions.StreamConsumedError, ChunkStreamingError),
+            # handled by urllib3.Retry
+            (413, ExceedMaxRetryError),
+            (429, ExceedMaxRetryError),
+            (500, ExceedMaxRetryError),
+            (502, ExceedMaxRetryError),
+            (503, ExceedMaxRetryError),
+            (504, ExceedMaxRetryError),
+            # target file unavailabe
+            (403, UnhandledHTTPError),
+            (404, UnhandledHTTPError),
         ),
     )
-    def test_download_streaming_error(
+    def test_download_server_with_http_error(
         self,
         tmp_path: Path,
-        mocker: pytest_mock.MockerFixture,
-        inject_requests_err,
+        status_code,
         expected_ota_download_err,
+        launch_dummy_server,
     ):
-        from otaclient.app.downloader import Downloader
-
-        _downloader = Downloader()
+        url = urljoin("http://127.0.0.1:9999/", str(status_code))
         _target_path = tmp_path / self.TEST_FILE
-
-        # mock the session.get method to return a mock as resp
-        _mock_resp = typing.cast(requests.Response, mocker.MagicMock())
-        _mock_resp.raw.retries = None
-        _mock_resp.iter_content.side_effect = inject_requests_err
-        mocker.patch.object(_downloader.session, "get", return_value=_mock_resp)
-
-        with pytest.raises(expected_ota_download_err) as e:
-            _downloader.download(
-                self.TEST_FILE,
+        with pytest.raises(expected_ota_download_err):
+            self.downloader.download(
+                url,
                 _target_path,
-                self.TEST_FILE_SHA256,
-                url_base=cfg.OTA_IMAGE_URL,
+                size=self.TEST_FILE_SIZE,
+                digest=self.TEST_FILE_SHA256,
             )
-        # assert exception catched
-        assert isinstance(e.value.__cause__, inject_requests_err)
 
     def test_retry_headers_injection(
         self, tmp_path: Path, mocker: pytest_mock.MockerFixture
     ):
-        from otaclient.app.downloader import Downloader
+        from otaclient.app import downloader
 
-        _downloader = Downloader()
+        _session_cls = downloader.requests.Session
         _target_path = tmp_path / self.TEST_FILE
 
-        # directly mock the response.iter_content method to return a HashVerificationError
+        # directly mock the Session.get method to return a HashVerificationError
         # for test convenience(it won't happen in the real world!)
-        _mock_resp = typing.cast(requests.Response, mocker.MagicMock())
-        _mock_resp.raw.retries = None
-        _mock_resp.iter_content.side_effect = HashVerificaitonError(
-            url="", dst=""
-        )  # NOTE: url and dst are not important in this test
-        _mock_get = mocker.MagicMock(return_value=_mock_resp)
-        mocker.patch.object(_downloader.session, "get", _mock_get)
+        _mock_get = mocker.MagicMock(side_effect=HashVerificaitonError(url="", dst=""))
+        mocker.patch.object(_session_cls, "get", _mock_get)
+        mocker.patch.object(downloader.requests, "Session", _session_cls)
 
+        _downloader = downloader.Downloader()
+        url = urljoin("http://127.0.0.1:9999/", "anything")
         with pytest.raises(HashVerificaitonError):
-            _downloader.download(
-                self.TEST_FILE,
-                _target_path,
-                self.TEST_FILE_SHA256,
-                url_base=cfg.OTA_IMAGE_URL,
-            )
+            _downloader.download(url, _target_path)
+        _downloader.shutdown()
 
         # one normal get call
         _mock_get.assert_any_call(
-            f"{cfg.OTA_IMAGE_URL}/{self.TEST_FILE}",
+            url,
             stream=True,
-            cookies={},
-            headers={},
+            proxies=None,
+            cookies=None,
+            headers=None,
         )
         # following at least one get call with ota-cache retry header
         _mock_get.assert_any_call(
-            f"{cfg.OTA_IMAGE_URL}/{self.TEST_FILE}",
+            url,
             stream=True,
-            cookies={},
+            proxies=None,
+            cookies=None,
             headers={"ota-file-cache-control": "retry_caching"},
         )

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from urllib.parse import urlsplit, urljoin
 
 
-from otaclient.app.common import file_sha256
+from otaclient.app.common import file_sha256, urljoin_ensure_base
 from otaclient.app.downloader import (
     Downloader,
     DestinationNotAvailableError,
@@ -116,7 +116,7 @@ class TestDownloader:
     def test_normal_download(self, tmp_path: Path):
         _target_path = tmp_path / self.TEST_FILE
 
-        url = urljoin(f"{cfg.OTA_IMAGE_URL.rstrip('/')}/", self.TEST_FILE)
+        url = urljoin_ensure_base(cfg.OTA_IMAGE_URL, self.TEST_FILE)
         _error = self.downloader.download(
             url,
             _target_path,
@@ -130,7 +130,7 @@ class TestDownloader:
     def test_download_mismatch_sha256(self, tmp_path: Path):
         _target_path = tmp_path / self.TEST_FILE
 
-        url = urljoin(f"{cfg.OTA_IMAGE_URL.rstrip('/')}/", self.TEST_FILE)
+        url = urljoin_ensure_base(cfg.OTA_IMAGE_URL, self.TEST_FILE)
         with pytest.raises(HashVerificaitonError):
             self.downloader.download(
                 url,
@@ -177,7 +177,7 @@ class TestDownloader:
 
         _downloader = Downloader()
         _target_path = tmp_path / self.TEST_FILE
-        url = urljoin(f"{cfg.OTA_IMAGE_URL.rstrip('/')}/", self.TEST_FILE)
+        url = urljoin_ensure_base(cfg.OTA_IMAGE_URL, self.TEST_FILE)
         with pytest.raises(expected_ota_download_err):
             _downloader.download(
                 url,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,8 +17,10 @@ import asyncio
 import os
 import time
 import http.server as http_server
+import zstandard
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from typing import Union
 from functools import partial
 from pathlib import Path
 
@@ -173,3 +175,9 @@ class DummySubECU:
             available_ecu_ids=[self.ecu_id],
         )
         return res
+
+
+def zstd_compress_file(src: Union[str, Path], dst: Union[str, Path]):
+    cctx = zstandard.ZstdCompressor()
+    with open(src, "rb") as src_f, open(dst, "wb") as dst_f:
+        cctx.copy_stream(src_f, dst_f)


### PR DESCRIPTION
## Introduction
This PR introduces the support for compressed OTA image on OTAclient, refinement and refactor for related OTAclient modules, and update/add test files.

## Changes
1. ota_metadata: new implementation of OTAMetadata, now ota_metadata class can be defined pragmatically with `MetaFieldDescriptor`, without hard-coding field names,
2. ota_metadata: implement `ParseMetadataHelper`, split the verification logics from old `OTAMetadata` class and move to this helper class,
3. ota_metadata: implement many helper methods for `OTAMetadata`,
4. downloader: major refactor, now `Downloader` is self-contained and multi-threaded generic downloader with concurrent download limitation configured,
5. downloader: refinement over error handling,
6. downloader: introduce `DecompressionAdapterProtocol`, now transparent decompression support is introduced into `Downloader` by registering adapter, and `ZstdDecompressor` is introduced for zstd compression support,
7. create_standby, ota_client: integration for updated downloader module and ota_metadata module, now one update session will only have one downloader instance,
8. common: introduce `urljoin_ensure_base` helper function,
9. test_base/Dockerfile: enable OTA image compression,
10. test_downloader: updated according to downloader module's changes, implement test for zstd decompression support,
11. test_ota_metadata: updated accordingly, implement extra cases for backward-compatibility for previous ota_metadata format revision,
12. other minor fix and update.

## Tests

- [x] test via test files
- [ ] VM test

## Ticket
[T4PB-20716](https://tier4.atlassian.net/browse/T4PB-20716)