### PR TITLE
Add new field in ecu_info.yaml and support new bootloader specification mechanism

### DIFF
--- a/otaclient/app/boot_control/configs.py
+++ b/otaclient/app/boot_control/configs.py
@@ -28,17 +28,30 @@ class BootloaderType(Enum):
     rpi_boot: raspberry pi 4 with eeprom version newer than 2020-10-28
     """
 
-    UNSUPPORTED = "unsupported"
+    UNSPECIFIED = "unspecified"
     GRUB = "grub"
     CBOOT = "cboot"
     RPI_BOOT = "rpi_boot"
+
+    @classmethod
+    def parse_str(cls, _input: str) -> "BootloaderType":
+        res = cls.UNSPECIFIED
+        try:  # input is enum key(capitalized)
+            res = BootloaderType[_input]
+        except KeyError:
+            pass
+        try:  # input is enum value(uncapitalized)
+            res = BootloaderType(_input)
+        except ValueError:
+            pass
+        return res
 
 
 @dataclass
 class GrubControlConfig(BaseConfig):
     """x86-64 platform, with grub as bootloader."""
 
-    BOOTLOADER: str = "grub"
+    BOOTLOADER: BootloaderType = BootloaderType.GRUB
     FSTAB_FILE_PATH: str = "/etc/fstab"
     GRUB_DIR: str = "/boot/grub"
     GRUB_CFG_PATH: str = "/boot/grub/grub.cfg"
@@ -53,7 +66,7 @@ class CBootControlConfig(BaseConfig):
     NOTE: only for tegraid:0x19, roscube-x platform(jetson-xavier-agx series)
     """
 
-    BOOTLOADER: str = "cboot"
+    BOOTLOADER: BootloaderType = BootloaderType.CBOOT
     TEGRA_CHIP_ID_PATH: str = "/sys/module/tegra_fuse/parameters/tegra_chip_id"
     CHIP_ID_MODEL_MAP: Dict[int, str] = field(default_factory=lambda: {0x19: "rqx_580"})
     OTA_STATUS_DIR: str = "/boot/ota-status"
@@ -63,6 +76,7 @@ class CBootControlConfig(BaseConfig):
 
 @dataclass
 class RPIBootControlConfig(BaseConfig):
+    BBOOTLOADER: BootloaderType = BootloaderType.RPI_BOOT
     RPI_MODEL_FILE: str = "/proc/device-tree/model"
     RPI_MODEL_HINT: str = r"Raspberry Pi"
 

--- a/otaclient/app/boot_control/selecter.py
+++ b/otaclient/app/boot_control/selecter.py
@@ -60,7 +60,7 @@ def detect_bootloader(raise_on_unknown=True) -> BootloaderType:
     # failed to detect bootloader
     if raise_on_unknown:
         raise ValueError(f"unsupported platform({machine=}, {arch=}) detected, abort")
-    return BootloaderType.UNSUPPORTED
+    return BootloaderType.UNSPECIFIED
 
 
 def get_boot_controller(

--- a/otaclient/app/ecu_info.py
+++ b/otaclient/app/ecu_info.py
@@ -11,46 +11,74 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+r"""ECU metadatas definition.
 
+Version 1 scheme example:
+format_vesrion: 1
+ecu_id: "autoware"
+ip_addr: "0.0.0.0"
+# available options: grub, cboot, rpi_boot
+bootloader: "grub"
+secondaries:
+    - ecu_id: "p1"
+      ip_addr: "0.0.0.0"
+available_ecu_ids:
+    - "autoware"
+    - "p1"
+"""
 
 import yaml
+from pathlib import Path
+from typing import Iterator, Union, Dict, List, Tuple
 
 from . import log_util
 from .configs import config as cfg
+from .boot_control import BootloaderType
 
 logger = log_util.get_logger(
     __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)
 )
 
 
-class EcuInfo:
-    ECU_INFO_FILE = cfg.ECU_INFO_FILE
-    DEFAULT_ECU_INFO = {
-        "format_version": 1,  # current version is 1
-        "ecu_id": "autoware",  # should be unique for each ECU in vehicle
-    }
+DEFAULT_ECU_INFO = {
+    "format_version": 1,  # current version is 1
+    "ecu_id": "autoware",  # should be unique for each ECU in vehicle
+}
 
-    def __init__(self):
-        ecu_info_file = EcuInfo.ECU_INFO_FILE
-        self._ecu_info = self._load_ecu_info(ecu_info_file)
-        logger.info(f"ecu_info={self._ecu_info}")
 
-    def get_secondary_ecus(self):
-        return self._ecu_info.get("secondaries", [])
-
-    def get_ecu_id(self):
-        return self._ecu_info["ecu_id"]
-
-    def get_ecu_ip_addr(self):
-        return self._ecu_info.get("ip_addr", "localhost")
-
-    def get_available_ecu_ids(self):
-        return self._ecu_info.get("available_ecu_ids", [self.get_ecu_id()])
-
-    def _load_ecu_info(self, path: str):
+class ECUInfo:
+    def __init__(self, ecu_info_file: Union[str, Path]):
+        ecu_info = DEFAULT_ECU_INFO
         try:
-            with open(path) as f:
+            with open(ecu_info_file) as f:
                 ecu_info = yaml.safe_load(f)
         except Exception:
-            return EcuInfo.DEFAULT_ECU_INFO
-        return ecu_info
+            pass
+        logger.info(f"ecu_info={ecu_info}")
+        # required field
+        self.ecu_id = ecu_info["ecu_id"]
+        # optional fields
+        self.ip_addr = ecu_info.get("ip_addr", "127.0.0.1")
+        self.bootloader_type = BootloaderType.parse_str(
+            ecu_info.get("bootloader", "unspecified")
+        )
+        self.secondaries: List[Dict[str, str]] = ecu_info.get("secondaries", [])
+        self.available_ecu_id: List[str] = ecu_info.get(
+            "available_ecu_ids", [self.ecu_id]
+        )
+
+    def iter_secondary_ecus(self) -> Iterator[Tuple[str, str]]:
+        """
+        Return a tuple contains ecu_id and ip_addr in str.
+        """
+        for subecu in self.secondaries:
+            yield subecu["ecu_id"], subecu.get("ip_addr", "127.0.0.1")
+
+    def get_ecu_id(self) -> str:
+        return self.ecu_id
+
+    def get_ecu_ip_addr(self) -> str:
+        return self.ip_addr
+
+    def get_available_ecu_ids(self) -> List[str]:
+        return self.available_ecu_id.copy()

--- a/otaclient/app/ecu_info.py
+++ b/otaclient/app/ecu_info.py
@@ -59,7 +59,7 @@ class ECUInfo:
         self.ecu_id = ecu_info["ecu_id"]
         # optional fields
         self.ip_addr = ecu_info.get("ip_addr", "127.0.0.1")
-        self.bootloader_type = BootloaderType.parse_str(
+        self.bootloader = BootloaderType.parse_str(
             ecu_info.get("bootloader", "unspecified")
         )
         self.secondaries: List[Dict[str, str]] = ecu_info.get("secondaries", [])

--- a/otaclient/app/ecu_info.py
+++ b/otaclient/app/ecu_info.py
@@ -11,25 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r"""ECU metadatas definition.
-
-Version 1 scheme example:
-format_vesrion: 1
-ecu_id: "autoware"
-ip_addr: "0.0.0.0"
-# available options: grub, cboot, rpi_boot
-bootloader: "grub"
-secondaries:
-    - ecu_id: "p1"
-      ip_addr: "0.0.0.0"
-available_ecu_ids:
-    - "autoware"
-    - "p1"
-"""
+r"""ECU metadatas definition."""
 
 import yaml
+from dataclasses import dataclass, field, fields, MISSING
 from pathlib import Path
-from typing import Iterator, Union, Dict, List, Tuple
+from typing import Iterator, Union, Dict, List, Tuple, Any
 
 from . import log_util
 from .configs import config as cfg
@@ -46,26 +33,66 @@ DEFAULT_ECU_INFO = {
 }
 
 
+@dataclass
 class ECUInfo:
-    def __init__(self, ecu_info_file: Union[str, Path]):
-        ecu_info = DEFAULT_ECU_INFO
+    """
+    Version 1 scheme example:
+        format_vesrion: 1
+        ecu_id: "autoware"
+        ip_addr: "0.0.0.0"
+        bootloader: "grub"
+        secondaries:
+            - ecu_id: "p1"
+              ip_addr: "0.0.0.0"
+        available_ecu_ids:
+            - "autoware"
+            - "p1
+    """
+
+    ecu_id: str
+    ip_addr: str = "127.0.0.1"
+    bootloader: str = BootloaderType.UNSPECIFIED.value
+    available_ecu_id: List[str] = field(default_factory=list)
+    secondaries: List[Dict[str, str]] = field(default_factory=list)
+    format_version: int = 1
+
+    @classmethod
+    def parse_ecu_info(cls, ecu_info_file: Union[str, Path]) -> "ECUInfo":
+        ecu_info = DEFAULT_ECU_INFO.copy()
         try:
-            with open(ecu_info_file) as f:
-                ecu_info = yaml.safe_load(f)
+            ecu_info = yaml.safe_load(Path(ecu_info_file).read_text())
+            assert isinstance(ecu_info, Dict)
         except Exception:
-            pass
+            logger.warning(
+                f"failed to load {ecu_info_file=} or config file corrupted, use default config"
+            )
         logger.info(f"ecu_info={ecu_info}")
-        # required field
-        self.ecu_id = ecu_info["ecu_id"]
-        # optional fields
-        self.ip_addr = ecu_info.get("ip_addr", "127.0.0.1")
-        self.bootloader = BootloaderType.parse_str(
-            ecu_info.get("bootloader", "unspecified")
-        )
-        self.secondaries: List[Dict[str, str]] = ecu_info.get("secondaries", [])
-        self.available_ecu_id: List[str] = ecu_info.get(
-            "available_ecu_ids", [self.ecu_id]
-        )
+
+        # load options
+        # NOTE: if option is not presented,
+        #       this option will be set to the default value
+        _ecu_info_dict: Dict[str, Any] = dict()
+        for _field in fields(cls):
+            _option = ecu_info.get(_field.name)
+            if not isinstance(_option, _field.type):
+                if _option is not None:
+                    logger.warning(
+                        f"{_field.name} contains invalid value={_option}, "
+                        "ignored and set to default={_field.default}"
+                    )
+                if _field.default is MISSING:
+                    raise ValueError(
+                        f"required field {_field.name} is not presented, abort"
+                    )
+                _ecu_info_dict[_field.name] = _field.default
+                continue
+            if isinstance(_option, (list, dict)):
+                _ecu_info_dict[_field.name] = _option.copy()
+            else:
+                _ecu_info_dict[_field.name] = _option
+
+        # initialize ECUInfo inst
+        return cls(**_ecu_info_dict)
 
     def iter_secondary_ecus(self) -> Iterator[Tuple[str, str]]:
         """
@@ -79,6 +106,9 @@ class ECUInfo:
 
     def get_ecu_ip_addr(self) -> str:
         return self.ip_addr
+
+    def get_bootloader(self) -> BootloaderType:
+        return BootloaderType.parse_str(self.bootloader)
 
     def get_available_ecu_ids(self) -> List[str]:
         return self.available_ecu_id.copy()

--- a/otaclient/app/ota_client_stub.py
+++ b/otaclient/app/ota_client_stub.py
@@ -355,7 +355,7 @@ class OtaClientStub:
         # dispatch the requested operations to threadpool
         self._executor = ThreadPoolExecutor(thread_name_prefix="ota_client_stub")
 
-        self._ecu_info = ECUInfo(cfg.ECU_INFO_FILE)
+        self._ecu_info = ECUInfo.parse_ecu_info(cfg.ECU_INFO_FILE)
         self.my_ecu_id = self._ecu_info.get_ecu_id()
         self.subecus_dict: Dict[str, str] = {
             ecu_id: ecu_ip_addr
@@ -364,7 +364,9 @@ class OtaClientStub:
 
         # read ecu_info to get the booloader type,
         # if not specified, use detect_bootloader
-        if (bootloader_type := self._ecu_info.bootloader) == BootloaderType.UNSPECIFIED:
+        if (
+            bootloader_type := self._ecu_info.get_bootloader()
+        ) == BootloaderType.UNSPECIFIED:
             bootloader_type = detect_bootloader()
         # NOTE: inject bootloader and create_standby into otaclient
         self._ota_client = OTAClient(

--- a/otaclient/app/ota_client_stub.py
+++ b/otaclient/app/ota_client_stub.py
@@ -26,7 +26,7 @@ from typing import Coroutine, Dict, List, Optional
 
 from .boot_control import get_boot_controller, detect_bootloader
 from .create_standby import get_standby_slot_creator
-from .ecu_info import EcuInfo
+from .ecu_info import ECUInfo
 from .ota_client import OTAClient, OTAUpdateFSM
 from .ota_client_call import OtaClientCall
 from .proto import wrapper
@@ -355,10 +355,11 @@ class OtaClientStub:
         # dispatch the requested operations to threadpool
         self._executor = ThreadPoolExecutor(thread_name_prefix="ota_client_stub")
 
-        self._ecu_info = EcuInfo()
+        self._ecu_info = ECUInfo(cfg.ECU_INFO_FILE)
         self.my_ecu_id = self._ecu_info.get_ecu_id()
         self.subecus_dict: Dict[str, str] = {
-            e["ecu_id"]: e["ip_addr"] for e in self._ecu_info.get_secondary_ecus()
+            ecu_id: ecu_ip_addr
+            for ecu_id, ecu_ip_addr in self._ecu_info.iter_secondary_ecus()
         }
 
         # NOTE: explicitly specific which mechanism to use

--- a/tests/test_ecu_info.py
+++ b/tests/test_ecu_info.py
@@ -22,12 +22,12 @@ import yaml
 @pytest.mark.parametrize(
     "ecu_info_dict, secondary_ecus, ecu_id, ip_addr, available_ecu_ids",
     (
-        (None, [], "autoware", "localhost", ["autoware"]),
+        (None, [], "autoware", "127.0.0.1", ["autoware"]),
         (
             {"format_version": 1, "ecu_id": "autoware"},
             [],
             "autoware",
-            "localhost",
+            "127.0.0.1",
             ["autoware"],
         ),
         (
@@ -52,13 +52,12 @@ import yaml
                 {"ecu_id": "perception2", "ip_addr": "192.168.0.12"},
             ],
             "autoware",
-            "localhost",
+            "127.0.0.1",
             ["autoware", "perception1", "perception2"],
         ),
     ),
 )
 def test_ecu_info(
-    mocker: MockerFixture,
     tmp_path: Path,
     ecu_info_dict,
     secondary_ecus,
@@ -66,7 +65,7 @@ def test_ecu_info(
     ip_addr,
     available_ecu_ids,
 ):
-    from otaclient.app.ecu_info import EcuInfo
+    from otaclient.app.ecu_info import ECUInfo
 
     boot_dir = tmp_path / "boot"
     boot_dir.mkdir()
@@ -75,9 +74,8 @@ def test_ecu_info(
     if ecu_info_dict is not None:
         ecu_info_file.write_text(yaml.dump(ecu_info_dict))
 
-    mocker.patch.object(EcuInfo, "ECU_INFO_FILE", ecu_info_file)
-    ecu_info = EcuInfo()
-    assert ecu_info.get_secondary_ecus() == secondary_ecus
+    ecu_info = ECUInfo(ecu_info_file)
+    assert ecu_info.secondaries == secondary_ecus
     assert ecu_info.get_ecu_id() == ecu_id
     assert ecu_info.get_ecu_ip_addr() == ip_addr
     assert ecu_info.get_available_ecu_ids() == available_ecu_ids

--- a/tests/test_ecu_info.py
+++ b/tests/test_ecu_info.py
@@ -13,22 +13,31 @@
 # limitations under the License.
 
 
-from pathlib import Path
-import pytest
-from pytest_mock import MockerFixture
 import yaml
+import pytest
+from pathlib import Path
+from otaclient.app.boot_control import BootloaderType
+from typing import Any, List, Dict
 
 
 @pytest.mark.parametrize(
-    "ecu_info_dict, secondary_ecus, ecu_id, ip_addr, available_ecu_ids",
+    "ecu_info_dict, secondary_ecus, ecu_id, ip_addr, available_ecu_ids, bootloader",
     (
-        (None, [], "autoware", "127.0.0.1", ["autoware"]),
+        (
+            None,
+            [],
+            "autoware",
+            "127.0.0.1",
+            ["autoware"],
+            BootloaderType.UNSPECIFIED,
+        ),
         (
             {"format_version": 1, "ecu_id": "autoware"},
             [],
             "autoware",
             "127.0.0.1",
             ["autoware"],
+            BootloaderType.UNSPECIFIED,
         ),
         (
             {"format_version": 2, "ecu_id": "autoware", "ip_addr": "192.168.1.1"},
@@ -36,6 +45,7 @@ import yaml
             "autoware",
             "192.168.1.1",
             ["autoware"],
+            BootloaderType.UNSPECIFIED,
         ),
         (
             {
@@ -54,16 +64,38 @@ import yaml
             "autoware",
             "127.0.0.1",
             ["autoware", "perception1", "perception2"],
+            BootloaderType.UNSPECIFIED,
+        ),
+        (
+            {
+                "format_version": 1,
+                "bootloader": "grub",
+                "ecu_id": "autoware",
+                "secondaries": [
+                    {"ecu_id": "perception1", "ip_addr": "192.168.0.11"},
+                    {"ecu_id": "perception2", "ip_addr": "192.168.0.12"},
+                ],
+                "available_ecu_ids": ["autoware", "perception1", "perception2"],
+            },
+            [
+                {"ecu_id": "perception1", "ip_addr": "192.168.0.11"},
+                {"ecu_id": "perception2", "ip_addr": "192.168.0.12"},
+            ],
+            "autoware",
+            "127.0.0.1",
+            ["autoware", "perception1", "perception2"],
+            BootloaderType.GRUB,
         ),
     ),
 )
 def test_ecu_info(
     tmp_path: Path,
-    ecu_info_dict,
-    secondary_ecus,
-    ecu_id,
-    ip_addr,
-    available_ecu_ids,
+    ecu_info_dict: Dict[str, Any],
+    secondary_ecus: List[Dict[str, Any]],
+    ecu_id: str,
+    ip_addr: str,
+    available_ecu_ids: List[str],
+    bootloader: BootloaderType,
 ):
     from otaclient.app.ecu_info import ECUInfo
 
@@ -74,8 +106,9 @@ def test_ecu_info(
     if ecu_info_dict is not None:
         ecu_info_file.write_text(yaml.dump(ecu_info_dict))
 
-    ecu_info = ECUInfo(ecu_info_file)
+    ecu_info = ECUInfo.parse_ecu_info(ecu_info_file)
     assert ecu_info.secondaries == secondary_ecus
     assert ecu_info.get_ecu_id() == ecu_id
     assert ecu_info.get_ecu_ip_addr() == ip_addr
     assert ecu_info.get_available_ecu_ids() == available_ecu_ids
+    assert ecu_info.get_bootloader() == bootloader

--- a/tests/test_ota_client_stub.py
+++ b/tests/test_ota_client_stub.py
@@ -14,6 +14,7 @@
 
 
 import asyncio
+import json
 import pytest
 import pytest_mock
 import time
@@ -210,7 +211,7 @@ class TestOtaClientStub(ThreadpoolExecutorFixtureMixin):
     # TODO: status
 
     @pytest.fixture
-    def setup_ecus(self):
+    def setup_ecus(self, tmp_path: Path):
         self._my_ecuid = "autoware"
         self._subecu_dict = {"p1": "", "p2": ""}
         self._subecs = _DummySubECUsGroup(list(self._subecu_dict.keys()))
@@ -225,10 +226,24 @@ class TestOtaClientStub(ThreadpoolExecutorFixtureMixin):
                 {"ecu_id": "p2"},
             ]
         )
+        # prepare ecu info
+        ecu_info = {
+            "ecu_id": "autoware",
+            "secondaries": [{"ecu_id": "p1"}, {"ecu_id": "p2"}],
+            "available_ecu_ids": ["autoware", "p1", "p2"],
+            "bootloader": "grub",
+        }
+        self.ecu_info_file = tmp_path / "ecu_info_file"
+        self.ecu_info_file.write_text(json.dumps(ecu_info))
 
     @pytest.fixture(autouse=True)
-    def mock_setup(self, mocker: pytest_mock.MockerFixture, setup_ecus, setup_executor):
-        from otaclient.app.ecu_info import EcuInfo
+    def mock_setup(
+        self,
+        mocker: pytest_mock.MockerFixture,
+        tmp_path: Path,
+        setup_ecus,
+        setup_executor,
+    ):
         from otaclient.app.ota_client import OTAClient, OTAUpdateFSM
         from otaclient.app.ota_client_call import OtaClientCall
 
@@ -260,14 +275,6 @@ class TestOtaClientStub(ThreadpoolExecutorFixtureMixin):
         self._fsm = _ota_update_fsm
         self._wait_for_update_finished = _wait_for_update_finished
 
-        ###### mock ecu_info ######
-        _ecu_info_mock = typing.cast(EcuInfo, mocker.MagicMock(spec=EcuInfo))
-        _ecu_info_mock.get_ecu_id.return_value = self._my_ecuid
-        _ecu_info_mock.get_available_ecu_ids.return_value = list(
-            self._subecu_dict.keys()
-        ) + [self._my_ecuid]
-        _ecu_info_mock.get_secondary_ecus.return_value = self._subecu_list_ecu_info
-
         ###### mock otaclient ######
         self._ota_client_mock = typing.cast(OTAClient, mocker.MagicMock())
         self._ota_client_mock.live_ota_status.request_update.return_value = True
@@ -279,7 +286,8 @@ class TestOtaClientStub(ThreadpoolExecutorFixtureMixin):
 
         ###### patch ######
         mocker.patch(
-            f"{cfg.OTACLIENT_STUB_MODULE_PATH}.EcuInfo", return_value=_ecu_info_mock
+            f"{cfg.OTACLIENT_STUB_MODULE_PATH}.cfg.ECU_INFO_FILE",
+            str(self.ecu_info_file),
         )
         mocker.patch(
             f"{cfg.OTACLIENT_STUB_MODULE_PATH}.OTAClient",


### PR DESCRIPTION
## Introduction
This PR follows #178 , add support for a new field `bootloader` in `ecu_info.yaml` which specifies the bootloader running with, and finishes up the support for new bootloader specification mechanism.

**NOTE: this PR is the 2nd PR of a total 3 PRs that introduces raspberry pi support for otaclient.**

## Changes
1. use dataclass to refactor `ECUInfo` class, now `ecu_info.yaml` definition/parsing is using the same mechanism as `ota_metadata` definition/parsing, fields are defined programmaticly,
2. ota_client_stub now first queries `ECUInfo` to get bootloader information, if not specified, then fallback to use `detect_bootloader` function from `boot_control` module,
3. update test files, other related updates.