### PR TITLE
[Bugfix/refinement] ota-proxy timeout issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   pytest_with_coverage:
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout commit
         uses: actions/checkout@v2

--- a/otaclient/app/configs.py
+++ b/otaclient/app/configs.py
@@ -94,7 +94,7 @@ class BaseConfig:
     DOWNLOAD_RETRY: int = 10
     DOWNLOAD_BACKOFF_MAX: int = 3  # seconds
     MAX_CONCURRENT_TASKS: int = 128
-    MAX_DOWNLOAD_THREAD: int = 8
+    MAX_DOWNLOAD_THREAD = 3
     DOWNLOADER_CONNPOOL_SIZE_PER_THREAD: int = 8
     STATS_COLLECT_INTERVAL: int = 1  # second
     ## standby creation mode, default to rebuild now

--- a/otaclient/app/ota_client_stub.py
+++ b/otaclient/app/ota_client_stub.py
@@ -54,15 +54,16 @@ class OtaProxyWrapper:
 
         NOTE: logging needs to be configured again.
         """
+        import uvloop
+        import uvicorn
+        from otaclient.ota_proxy import App, OTACache
+
         # configure logging for ota_proxy process
         log_setting.configure_logging(
             loglevel=cfg.DEFAULT_LOG_LEVEL, http_logging_url="ota_proxy"
         )
 
         async def _start_uvicorn(init_cache: bool, *, scrub_cache_event):
-            import uvicorn
-            from otaclient.ota_proxy import App, OTACache
-
             _ota_cache = OTACache(
                 cache_enabled=proxy_cfg.enable_local_ota_proxy_cache,
                 upper_proxy=proxy_cfg.upper_ota_proxy,
@@ -86,6 +87,7 @@ class OtaProxyWrapper:
             server = uvicorn.Server(config)
             await server.serve()
 
+        uvloop.install()
         asyncio.run(_start_uvicorn(init_cache, scrub_cache_event=scrub_cache_event))
 
     def is_running(self) -> bool:

--- a/otaclient/ota_proxy/__main__.py
+++ b/otaclient/ota_proxy/__main__.py
@@ -16,6 +16,7 @@
 import argparse
 import asyncio
 import logging
+import uvloop
 
 logger = logging.getLogger(__name__)
 
@@ -68,11 +69,12 @@ if __name__ == "__main__":
             port=args.port,
             log_level="error",
             lifespan="on",
-            loop="asyncio",
+            loop="uvloop",
             http="h11",
         )
         _server = uvicorn.Server(_config)
         await _server.serve()
 
     logger.info(f"launch ota_proxy at {args.host}:{args.port}")
+    uvloop.install()
     asyncio.run(_launch_server())

--- a/otaclient/ota_proxy/config.py
+++ b/otaclient/ota_proxy/config.py
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
 
-
-@dataclass
 class Config:
-    BASE_DIR: str = "/ota-cache"
-    CHUNK_SIZE: int = 4 * 1024 * 1024  # 4MB
+    BASE_DIR = "/ota-cache"
+    CHUNK_SIZE = 4 * 1024 * 1024  # 4MB
     DISK_USE_LIMIT_SOFT_P = 70  # in p%
     DISK_USE_LIMIT_HARD_P = 80  # in p%
     DISK_USE_PULL_INTERVAL = 2  # in seconds
@@ -45,8 +42,9 @@ class Config:
     # DB configuration/setup
     # ota-cache table
     # NOTE: use table name to keep track of table scheme version
+    DB_THREAD_POOL_SIZE = 1
     TABLE_DEFINITION_VERSION = "v3"
-    TABLE_NAME: str = f"ota_cache_{TABLE_DEFINITION_VERSION}"
+    TABLE_NAME = f"ota_cache_{TABLE_DEFINITION_VERSION}"
 
     # cache streaming behavior
     STREAMING_WAIT_FOR_FIRST_BYTE = 1  # second

--- a/otaclient/ota_proxy/config.py
+++ b/otaclient/ota_proxy/config.py
@@ -42,14 +42,15 @@ class Config:
     # DB configuration/setup
     # ota-cache table
     # NOTE: use table name to keep track of table scheme version
-    DB_THREAD_POOL_SIZE = 1
+    DB_THREAD_POOL_SIZE = 2
     TABLE_DEFINITION_VERSION = "v3"
     TABLE_NAME = f"ota_cache_{TABLE_DEFINITION_VERSION}"
 
     # cache streaming behavior
     STREAMING_WAIT_FOR_FIRST_BYTE = 3  # second
     STREAMING_TIMEOUT = 10  # seconds
-    STREAMING_BACOFF_FACTOR = 0.01  # second
+    STREAMING_BACOFF_FACTOR = 0.1  # second
+    STREAMING_WAIT_FOR_WRITER = 0.1  # second
 
 
 config = Config()

--- a/otaclient/ota_proxy/config.py
+++ b/otaclient/ota_proxy/config.py
@@ -47,7 +47,7 @@ class Config:
     TABLE_NAME = f"ota_cache_{TABLE_DEFINITION_VERSION}"
 
     # cache streaming behavior
-    STREAMING_WAIT_FOR_FIRST_BYTE = 1  # second
+    STREAMING_WAIT_FOR_FIRST_BYTE = 3  # second
     STREAMING_TIMEOUT = 10  # seconds
     STREAMING_BACOFF_FACTOR = 0.01  # second
 

--- a/otaclient/ota_proxy/config.py
+++ b/otaclient/ota_proxy/config.py
@@ -41,7 +41,6 @@ class Config:
 
     # DB configuration/setup
     # ota-cache table
-    DB_THREAD_POOL_SIZE = 1
     # NOTE: use table name to keep track of table scheme version
     TABLE_DEFINITION_VERSION = "v3"
     TABLE_NAME = f"ota_cache_{TABLE_DEFINITION_VERSION}"

--- a/otaclient/ota_proxy/config.py
+++ b/otaclient/ota_proxy/config.py
@@ -15,7 +15,7 @@
 
 class Config:
     BASE_DIR = "/ota-cache"
-    CHUNK_SIZE = 4 * 1024 * 1024  # 4MB
+    CHUNK_SIZE = 1 * 1024 * 1024  # 4MB
     DISK_USE_LIMIT_SOFT_P = 70  # in p%
     DISK_USE_LIMIT_HARD_P = 80  # in p%
     DISK_USE_PULL_INTERVAL = 2  # in seconds
@@ -42,15 +42,15 @@ class Config:
     # DB configuration/setup
     # ota-cache table
     # NOTE: use table name to keep track of table scheme version
-    DB_THREAD_POOL_SIZE = 2
+    DB_THREAD_POOL_SIZE = 3
     TABLE_DEFINITION_VERSION = "v3"
     TABLE_NAME = f"ota_cache_{TABLE_DEFINITION_VERSION}"
 
     # cache streaming behavior
     STREAMING_WAIT_FOR_FIRST_BYTE = 3  # second
     STREAMING_TIMEOUT = 10  # seconds
-    STREAMING_BACOFF_FACTOR = 0.1  # second
-    STREAMING_WAIT_FOR_WRITER = 0.1  # second
+    STREAMING_BACOFF_FACTOR = 0.01  # second
+    STREAMING_WAIT_FOR_WRITER = 0  # second
 
 
 config = Config()

--- a/otaclient/ota_proxy/config.py
+++ b/otaclient/ota_proxy/config.py
@@ -48,5 +48,10 @@ class Config:
     TABLE_DEFINITION_VERSION = "v3"
     TABLE_NAME: str = f"ota_cache_{TABLE_DEFINITION_VERSION}"
 
+    # cache streaming behavior
+    STREAMING_WAIT_FOR_FIRST_BYTE = 1  # second
+    STREAMING_TIMEOUT = 10  # seconds
+    STREAMING_BACOFF_FACTOR = 0.01  # second
+
 
 config = Config()

--- a/otaclient/ota_proxy/config.py
+++ b/otaclient/ota_proxy/config.py
@@ -50,7 +50,6 @@ class Config:
     STREAMING_WAIT_FOR_FIRST_BYTE = 3  # second
     STREAMING_TIMEOUT = 10  # seconds
     STREAMING_BACKOFF_FACTOR = 0.001  # second
-    STREAMING_WAIT_FOR_WRITER = 0  # second
 
 
 config = Config()

--- a/otaclient/ota_proxy/config.py
+++ b/otaclient/ota_proxy/config.py
@@ -49,7 +49,7 @@ class Config:
     # cache streaming behavior
     STREAMING_WAIT_FOR_FIRST_BYTE = 3  # second
     STREAMING_TIMEOUT = 10  # seconds
-    STREAMING_BACOFF_FACTOR = 0.01  # second
+    STREAMING_BACKOFF_FACTOR = 0.001  # second
     STREAMING_WAIT_FOR_WRITER = 0  # second
 
 

--- a/otaclient/ota_proxy/config.py
+++ b/otaclient/ota_proxy/config.py
@@ -41,8 +41,8 @@ class Config:
 
     # DB configuration/setup
     # ota-cache table
+    DB_THREAD_POOL_SIZE = 1
     # NOTE: use table name to keep track of table scheme version
-    DB_THREAD_POOL_SIZE = 3
     TABLE_DEFINITION_VERSION = "v3"
     TABLE_NAME = f"ota_cache_{TABLE_DEFINITION_VERSION}"
 

--- a/otaclient/ota_proxy/db.py
+++ b/otaclient/ota_proxy/db.py
@@ -252,6 +252,8 @@ class OTACacheDB:
 class _ProxyBase:
     """A proxy class base for OTACacheDB that dispatches all requests into a threadpool."""
 
+    DB_THREAD_POOL_SIZE = 1
+
     def _thread_initializer(self, db_f):
         """Init a db connection for each thread worker"""
         # NOTE: set init to False always as we only operate db when using proxy
@@ -260,8 +262,10 @@ class _ProxyBase:
     def __init__(self, db_f: Union[str, Path], *, init=False):
         """Init the database connecting thread pool."""
         self._thread_local = threading.local()
+        # set thread_pool_size to 1 to make the db access
+        # to make it totally concurrent.
         self._executor = ThreadPoolExecutor(
-            max_workers=cfg.DB_THREAD_POOL_SIZE,
+            max_workers=self.DB_THREAD_POOL_SIZE,
             initializer=self._thread_initializer,
             initargs=(db_f,),
         )

--- a/otaclient/ota_proxy/db.py
+++ b/otaclient/ota_proxy/db.py
@@ -261,7 +261,7 @@ class _ProxyBase:
         """Init the database connecting thread pool."""
         self._thread_local = threading.local()
         self._executor = ThreadPoolExecutor(
-            max_workers=3,
+            max_workers=cfg.DB_THREAD_POOL_SIZE,
             initializer=self._thread_initializer,
             initargs=(db_f,),
         )

--- a/otaclient/ota_proxy/ota_cache.py
+++ b/otaclient/ota_proxy/ota_cache.py
@@ -368,13 +368,14 @@ class RemoteOTAFile:
                             # signal streamer to stop streaming
                             raise ValueError(_err_msg)
 
-            # caching succeeded, try to commit cache
-            self._tracker.writer_on_done(success=True)
-            commit_cache_entry_callback(self._tracker)
-
+            # cache successfully
+            # update meta
             _hash = _sha256hash_f.hexdigest()
             self.meta.sha256hash = _hash
             self.meta.size = _size
+            # commit cache entry
+            self._tracker.writer_on_done(success=True)
+            commit_cache_entry_callback(self._tracker)
             # for 0 size file, register the entry only
             # but if the 0 size file doesn't exist, create one
             if _size > 0 or not (self._base_dir / _hash).is_file():

--- a/otaclient/ota_proxy/ota_cache.py
+++ b/otaclient/ota_proxy/ota_cache.py
@@ -327,9 +327,6 @@ class RemoteOTAFile:
             tracker: an OngoingCacheTracker to sync status with subscriber.
             callback: a callback function to do post-caching jobs.
         """
-        # wait sometime for the streamer to put data chunk into queue
-        time.sleep(cfg.STREAMING_WAIT_FOR_WRITER)
-
         # populate these 2 properties of CacheMeta in this method
         _hash, _size = "", 0
         _sha256hash_f = sha256()
@@ -601,8 +598,6 @@ class _FileDescriptorHelper:
         base_dir: Union[str, Path],
         executor: Executor,
     ) -> AsyncIterator[bytes]:
-        # wait for writer to write some data chunks
-        await asyncio.sleep(cfg.STREAMING_WAIT_FOR_WRITER)
         _bytes_streamed = 0
         try:
             async with aiofiles.open(

--- a/otaclient/requirements.txt
+++ b/otaclient/requirements.txt
@@ -11,8 +11,8 @@ botocore==1.20.112
 boto3==1.17.112
 retrying==1.3.3
 urllib3>=1.26.8, <2.0.0
-uvicorn==0.18.3
-aiohttp>=3.8.1
-aiofiles==0.8.0
+uvicorn==0.20.0
+aiohttp==3.8.1
+aiofiles==22.1.0
 zstandard==0.18.0
 pycurl==7.45.1

--- a/otaclient/requirements.txt
+++ b/otaclient/requirements.txt
@@ -11,7 +11,7 @@ botocore==1.20.112
 boto3==1.17.112
 retrying==1.3.3
 urllib3>=1.26.8, <2.0.0
-uvicorn==0.20.0
+uvicorn[standard]==0.20.0
 aiohttp==3.8.1
 aiofiles==22.1.0
 zstandard==0.18.0

--- a/tests/test_ota_proxy/test_ota_cache.py
+++ b/tests/test_ota_proxy/test_ota_cache.py
@@ -149,7 +149,11 @@ class TestOngoingCachingRegister:
             logger.debug(f"#{idx} is subscriber")
             _tracker.reader_on_done()
             return False, _tracker.meta  # type: ignore
-        else:  # edge condition
+        else:
+            # edge condition when subscriber on multi cache streaming
+            # subscribes a just closed tracker.
+            # it will not be a problem, a retry on otaclient side can
+            # handle this edge condition.
             return False, None
 
     async def test_OngoingCachingRegister(self):

--- a/tests/test_ota_proxy/test_ota_cache.py
+++ b/tests/test_ota_proxy/test_ota_cache.py
@@ -20,7 +20,7 @@ import random
 from concurrent.futures import ThreadPoolExecutor
 from hashlib import sha256
 from pathlib import Path
-from typing import Dict, List, Tuple, Coroutine
+from typing import Dict, List, Optional, Tuple, Coroutine
 
 from otaclient.ota_proxy.db import CacheMeta
 from otaclient.ota_proxy import config as cfg
@@ -127,7 +127,7 @@ class TestOngoingCachingRegister:
     async def _worker(
         self,
         idx: int,
-    ) -> Tuple[bool, CacheMeta]:
+    ) -> Tuple[bool, Optional[CacheMeta]]:
         """
         Returns tuple of bool indicates whether the worker is writter, and CacheMeta
         from tracker.
@@ -135,22 +135,22 @@ class TestOngoingCachingRegister:
         # simulate multiple works subscribing the register
         await self.sync_event.wait()
         await asyncio.sleep(random.randrange(100, 200) // 100)
-        _tracker, _is_writer = await self.register.get_tracker(self.URL)
+        _tracker, _is_writer = await self.register.get_or_subscribe_tracker(self.URL)
         await self.register_finish.acquire()
-        if _is_writer:
+        if _is_writer and _tracker is not None:
             logger.info(f"#{idx} is provider")
             # NOTE: use last_access field to store worker index
             await _tracker.writer_on_ready(CacheMeta(last_access=idx))
             # simulate waiting for writer finished downloading
             await self.writer_done_event.wait()
-            _tracker.writer_on_finish()
+            _tracker.writer_on_done(success=True)
             return True, _tracker.meta  # type: ignore
-        else:
+        elif _tracker is not None:  # subscriber
             logger.debug(f"#{idx} is subscriber")
-            # wait for writter become ready
-            await _tracker.reader_subscribe(None)
             _tracker.reader_on_done()
             return False, _tracker.meta  # type: ignore
+        else:  # edge condition
+            return False, None
 
     async def test_OngoingCachingRegister(self):
         coros: List[Coroutine] = []
@@ -169,6 +169,12 @@ class TestOngoingCachingRegister:
         ###### check the test result ######
         meta_set, writer_meta = set(), None
         for is_writer, meta in await asyncio.gather(*tasks):
+            if meta is None:
+                logger.warning(
+                    "encount edge condition that subscriber subscribes "
+                    "on closed tracker, ignored"
+                )
+                continue
             meta_set.add(meta)
             if is_writer:
                 writer_meta = meta


### PR DESCRIPTION
## Introduction
This PR fixes the issue caused by unwanted timeout implemented in previous PR for ota-proxy, and optimizes some implementation.

## Changes
1. fix and refine `OngoingCacheTracker`, resolve the unwanted timeout issue, resolve the edge condition that subscriber subscribes on closed tracker,
2. move more configuration to `ota_proxy.config` instead of hard-coded,
3. fix and refine the `RemoteOTAFile`, simplify the background_cache_writing logic and cache commit logic,
4. refine `OTACache.retrieve_file`,
5. deps: bump uvicorn==0.20.0, aiofiles==22.1.0, and pin aiohttp==3.8.1,
6. optimize ota_proxy configuration according to test result,
7. test files updates,
8. other minor updates.

## Optimization comes with this PR
1. `MAX_DOWNLOAD_THREAD` reduces from 8 to 3, as the benefit is not significant,
2. use `uvloop` for `ota-proxy`, which results in around 10%~ or more performance improved,
3. reduce `CHUNK_SIZE` to 1MB, tests reveal that this setting has better performance,
4. reduce `STREAMING_BACKOFF_FACTOR` to 0.001 to reduce blocking

## Ticket
[T4PB-24098](https://tier4.atlassian.net/browse/T4PB-24098)

## Test
- [x] single ECU: real network
- [x] single ECU: local test
- [x] multiple ECUs: local test
- [x] multiple ECUs: real network
- [x] test files