### PR TITLE
[bugfix/refinement] bugfix for cache_tracker, refactor otaproxy based on asyncio+async generator 

### DIFF
--- a/otaclient/ota_proxy/config.py
+++ b/otaclient/ota_proxy/config.py
@@ -47,8 +47,9 @@ class Config:
 
     # cache streaming behavior
     STREAMING_WAIT_FOR_FIRST_BYTE = 3  # second
-    STREAMING_TIMEOUT = 10  # seconds
-    STREAMING_BACKOFF_FACTOR = 0.001  # second
+    STREAMING_TIMEOUT = 6  # seconds
+    STREAMING_CACHED_TMP_TIMEOUT = 1  # second
+    STREAMING_BACKOFF_FACTOR = 0.01  # second
 
 
 config = Config()

--- a/otaclient/ota_proxy/config.py
+++ b/otaclient/ota_proxy/config.py
@@ -46,10 +46,10 @@ class Config:
     TABLE_NAME = f"ota_cache_{TABLE_DEFINITION_VERSION}"
 
     # cache streaming behavior
-    STREAMING_WAIT_FOR_FIRST_BYTE = 8  # second
-    STREAMING_TIMEOUT = 8  # seconds
+    AIOHTTP_SOCKET_READ_TIMEOUT = 60  # second
+    STREAMING_TIMEOUT = 60  # seconds
     STREAMING_CACHED_TMP_TIMEOUT = 1  # second
-    STREAMING_BACKOFF_FACTOR = 0.01  # second
+    STREAMING_BACKOFF_FACTOR = 1  # second
 
 
 config = Config()

--- a/otaclient/ota_proxy/config.py
+++ b/otaclient/ota_proxy/config.py
@@ -46,8 +46,8 @@ class Config:
     TABLE_NAME = f"ota_cache_{TABLE_DEFINITION_VERSION}"
 
     # cache streaming behavior
-    STREAMING_WAIT_FOR_FIRST_BYTE = 3  # second
-    STREAMING_TIMEOUT = 6  # seconds
+    STREAMING_WAIT_FOR_FIRST_BYTE = 8  # second
+    STREAMING_TIMEOUT = 8  # seconds
     STREAMING_CACHED_TMP_TIMEOUT = 1  # second
     STREAMING_BACKOFF_FACTOR = 0.01  # second
 

--- a/otaclient/ota_proxy/config.py
+++ b/otaclient/ota_proxy/config.py
@@ -47,9 +47,9 @@ class Config:
 
     # cache streaming behavior
     AIOHTTP_SOCKET_READ_TIMEOUT = 60  # second
-    STREAMING_TIMEOUT = 60  # seconds
+    STREAMING_BACKOFF_MAX = 30  # seconds
+    STREAMING_BACKOFF_FACTOR = 0.1  # second
     STREAMING_CACHED_TMP_TIMEOUT = 1  # second
-    STREAMING_BACKOFF_FACTOR = 1  # second
 
 
 config = Config()

--- a/otaclient/ota_proxy/config.py
+++ b/otaclient/ota_proxy/config.py
@@ -48,8 +48,8 @@ class Config:
     # cache streaming behavior
     AIOHTTP_SOCKET_READ_TIMEOUT = 60  # second
     STREAMING_BACKOFF_MAX = 30  # seconds
-    STREAMING_BACKOFF_FACTOR = 0.1  # second
-    STREAMING_CACHED_TMP_TIMEOUT = 1  # second
+    STREAMING_BACKOFF_FACTOR = 0.01  # second
+    STREAMING_CACHED_TMP_TIMEOUT = 10  # second
 
 
 config = Config()

--- a/otaclient/ota_proxy/errors.py
+++ b/otaclient/ota_proxy/errors.py
@@ -8,3 +8,11 @@ class CacheMultiStreamingFailed(BaseOTACacheError):
 
 class CacheStreamingFailed(BaseOTACacheError):
     ...
+
+
+class StorageReachHardLimit(BaseOTACacheError):
+    ...
+
+
+class CacheStreamingInterrupt(BaseOTACacheError):
+    ...

--- a/otaclient/ota_proxy/ota_cache.py
+++ b/otaclient/ota_proxy/ota_cache.py
@@ -119,8 +119,8 @@ class OngoingCacheTracker(Generic[_WEAKREF]):
         self.fpath = Path(base_dir) / fn
         self.meta = None
         self._writer_ready = asyncio.Event()
-        self._writer_finished = threading.Event()
-        self._writer_failed = threading.Event()
+        self._writer_finished = asyncio.Event()
+        self._writer_failed = asyncio.Event()
         self._ref = ref_holder
         self._subscriber_ref_holder: List[_WEAKREF] = []
         self._executor = executor

--- a/otaclient/ota_proxy/ota_cache.py
+++ b/otaclient/ota_proxy/ota_cache.py
@@ -189,11 +189,10 @@ class CacheTracker(Generic[_WEAKREF]):
                     logger.warning(f"reach storage hard limit, abort: {self.meta=}")
                     raise StorageReachHardLimit
                 _sha256hash_f.update(_data)
-                self._bytes_written += (_written := await f.write(_data))
-        self.meta.size, self.meta.sha256hash = (  # type: ignore
-            self._bytes_written,
-            _sha256hash_f.hexdigest(),
-        )
+                _written = await f.write(_data)
+                self._bytes_written += _written
+        self.meta.size = self._bytes_written  # type: ignore
+        self.meta.sha256hash = _sha256hash_f.hexdigest()  # type: ignore
         logger.debug(
             "cache write finished, total bytes written"
             f"({self._bytes_written}) for {self.meta=}"

--- a/otaclient/ota_proxy/ota_cache.py
+++ b/otaclient/ota_proxy/ota_cache.py
@@ -1056,19 +1056,10 @@ class OTACache:
                     ),
                     _tracker.meta,
                 )
-            # bad tracker detected, directly open remote again
+            # bad tracker detected, let otaclient retry
             else:
                 logger.warning(
-                    f"failed tracker detected, directly open_remote: {raw_url=}"
+                    "failed tracker detected(might caused by "
+                    f"network interruption or space limitation): {raw_url=}"
                 )
-                meta = CacheMeta(url=raw_url)
-                fd = _FileDescriptorHelper.open_remote(
-                    self._process_raw_url(raw_url),
-                    meta,  # updated when remote response is received
-                    cookies,
-                    extra_headers,
-                    session=self._session,
-                    upper_proxy=self._upper_proxy,
-                )
-                await fd.__anext__()  # open remote connection
-                return fd, meta
+                return None

--- a/otaclient/ota_proxy/ota_cache.py
+++ b/otaclient/ota_proxy/ota_cache.py
@@ -822,10 +822,11 @@ class OTACache:
                     self._storage_below_hard_limit_event.clear()
             except FileNotFoundError:
                 logger.error(
-                    "background free space check failed as cache folder disappeared"
+                    "background free space check interrupted as cache folder disappeared"
                 )
                 self._storage_below_soft_limit_event.clear()
                 self._storage_below_hard_limit_event.clear()
+                break
 
             time.sleep(cfg.DISK_USE_PULL_INTERVAL)
 

--- a/otaclient/ota_proxy/server_app.py
+++ b/otaclient/ota_proxy/server_app.py
@@ -212,8 +212,8 @@ class App:
 
         except aiohttp.ClientResponseError as e:
             await self._respond_with_error(e.status, e.message, send)
-            logger.exception(f"request for {url=} failed")
-        except aiohttp.ClientConnectionError:
+            logger.warning(f"request for {url=} failed: {e!r}")
+        except aiohttp.ClientConnectionError as e:
             # terminate the transmission
             if respond_started:
                 await send({"type": "http.response.body", "body": b""})
@@ -223,7 +223,7 @@ class App:
                     "failed to connect to remote server",
                     send,
                 )
-            logger.exception(f"request for {url=} failed")
+            logger.warning(f"request for {url=} failed: {e!r}")
         except aiohttp.ClientError as e:
             # terminate the transmission
             if respond_started:
@@ -232,10 +232,10 @@ class App:
                 await self._respond_with_error(
                     HTTPStatus.INTERNAL_SERVER_ERROR, f"client error: {e!r}", send
                 )
-            logger.exception(f"request for {url=} failed")
+            logger.warning(f"request for {url=} failed: {e!r}")
         except BaseOTACacheError as e:
             logger.exception(
-                f"request for {url=} failed due to handled ota_cache internal error"
+                f"request for {url=} failed due to handled ota_cache internal error: {e!r}"
             )
             # terminate the transmission
             if respond_started:
@@ -248,7 +248,7 @@ class App:
             # exceptions rather than aiohttp error indicates
             # internal errors of ota_cache
             logger.exception(
-                f"request for {url=} failed due to unhandled ota_cache internal error"
+                f"request for {url=} failed due to unhandled ota_cache internal error: {e!r}"
             )
 
             # terminate the transmission

--- a/otaclient/ota_proxy/server_app.py
+++ b/otaclient/ota_proxy/server_app.py
@@ -233,7 +233,7 @@ class App:
                     HTTPStatus.INTERNAL_SERVER_ERROR, f"client error: {e!r}", send
                 )
             logger.warning(f"request for {url=} failed: {e!r}")
-        except BaseOTACacheError as e:
+        except (BaseOTACacheError, StopAsyncIteration) as e:
             logger.exception(
                 f"request for {url=} failed due to handled ota_cache internal error: {e!r}"
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,6 +180,9 @@ class ThreadpoolExecutorFixtureMixin:
                 f"{self.THTREADPOOL_EXECUTOR_PATCH_PATH}.ThreadPoolExecutor",
                 return_value=self._executor,
             )
+            logger.info(
+                f"ThreadpoolExecutor is patched at {self.THTREADPOOL_EXECUTOR_PATCH_PATH}"
+            )
             yield
         finally:
             self._executor.shutdown()

--- a/tests/test_ota_proxy/test_ota_cache.py
+++ b/tests/test_ota_proxy/test_ota_cache.py
@@ -135,7 +135,7 @@ class TestOngoingCachingRegister:
         # simulate multiple works subscribing the register
         await self.sync_event.wait()
         await asyncio.sleep(random.randrange(100, 200) // 100)
-        _tracker, _is_writer = await self.register.get_or_subscribe_tracker(self.URL)
+        _tracker, _is_writer = await self.register.get_tracker(self.URL)
         await self.register_finish.acquire()
         if _is_writer and _tracker is not None:
             logger.info(f"#{idx} is provider")

--- a/tests/test_ota_proxy/test_ota_cache.py
+++ b/tests/test_ota_proxy/test_ota_cache.py
@@ -147,13 +147,14 @@ class TestOngoingCachingRegister:
             return True, _tracker.meta  # type: ignore
         elif _tracker is not None:  # subscriber
             logger.debug(f"#{idx} is subscriber")
+            while not _tracker.cache_done:  # simulating cache streaming
+                await asyncio.sleep(0.1)
             _tracker.reader_on_done()
             return False, _tracker.meta  # type: ignore
         else:
             # edge condition when subscriber on multi cache streaming
             # subscribes a just closed tracker.
-            # it will not be a problem, a retry on otaclient side can
-            # handle this edge condition.
+            logger.error(f"edge condition: {idx=}")
             return False, None
 
     async def test_OngoingCachingRegister(self):

--- a/tests/test_ota_proxy/test_ota_cache.py
+++ b/tests/test_ota_proxy/test_ota_cache.py
@@ -24,7 +24,7 @@ from typing import Dict, List, Optional, Tuple, Coroutine
 
 from otaclient.ota_proxy.db import CacheMeta
 from otaclient.ota_proxy import config as cfg
-from otaclient.ota_proxy.ota_cache import LRUCacheHelper, OngoingCachingRegister
+from otaclient.ota_proxy.ota_cache import LRUCacheHelper, CachingRegister
 
 logger = logging.getLogger(__name__)
 
@@ -115,7 +115,7 @@ class TestOngoingCachingRegister:
     def setup_test(self, tmp_path: Path):
         self.base_dir = tmp_path / "base_dir"
         self.base_dir.mkdir(parents=True, exist_ok=True)
-        self.register = OngoingCachingRegister(self.base_dir)
+        self.register = CachingRegister(self.base_dir)
 
         # events
         # NOTE: we don't have Barrier in asyncio lib, so

--- a/tests/test_ota_proxy/test_ota_proxy_server.py
+++ b/tests/test_ota_proxy/test_ota_proxy_server.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import List
 
 from otaclient.app.ota_metadata import RegularInf
-from tests.conftest import cfg
+from tests.conftest import ThreadpoolExecutorFixtureMixin, cfg
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +51,8 @@ async def _start_uvicorn_server(server: uvicorn.Server):
     await server.startup()
 
 
-class TestOTAProxyServer:
+class TestOTAProxyServer(ThreadpoolExecutorFixtureMixin):
+    THTREADPOOL_EXECUTOR_PATCH_PATH = f"{cfg.OTAPROXY_MODULE_PATH}.otacache"
     OTA_IMAGE_URL = f"http://{cfg.OTA_IMAGE_SERVER_ADDR}:{cfg.OTA_IMAGE_SERVER_PORT}"
     OTA_PROXY_URL = f"http://{cfg.OTA_PROXY_SERVER_ADDR}:{cfg.OTA_PROXY_SERVER_PORT}"
     REGULARS_TXT_PATH = f"{cfg.OTA_IMAGE_DIR}/regulars.txt"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,7 +16,6 @@
 import asyncio
 import os
 import time
-import http.server as http_server
 import zstandard
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -69,6 +68,13 @@ async def run_otaclient_server(otaclient_service_v2, listen_addr):
 
 
 def run_http_server(addr: str, port: int, *, directory: str):
+    import http.server as http_server
+
+    def _dummy_logger(*args, **kwargs):
+        return
+
+    http_server.SimpleHTTPRequestHandler.log_message = _dummy_logger
+
     handler_class = partial(http_server.SimpleHTTPRequestHandler, directory=directory)
     with http_server.ThreadingHTTPServer((addr, port), handler_class) as httpd:
         httpd.serve_forever()


### PR DESCRIPTION
## Introduction
This PR fixes a bug on cache_tracker implementation, which might fail the multiple cache streaming even the cache is successfully finished, also introduces a refactoring to otaproxy, which changes the implementation from multithreading+queue to asyncio+async_generator.
In result this PR improves the performance in all network environment, while significatntly reduce/stabilize the memory usage and CPU usage, and stabilize the overall otaproxy running. 

## Local test
###  Test setup
1. one ota-proxy instance on VM, 5 clients on host machine
2. network: tc controlled network(43ms latency, 5ms jitter, 0.01% packet loss rate, 120Mbit bandwidth)
3. disk IO for ota-proxy VM: 500M

### Test result
1. 147340 files, ~10G,
2. time cost: 2274s,
3. finished without errors,

### differences comparing to #183 
1. memory usage is much more stable, starts from using 34M mem, in the end the otaproxy only takes 100M mem, 
2. CPU usage is slightly lease than previous,
3. overall timecost reduced from 2313s to 2274s,

### Other test cases
1. large latency network(100ms+20ms jitter, 8Mbit bandwidth, 1% packet loss rate), test for 10mins, the average network speed is 500KB/s+, no errors occurred. However, previously in such network, the otaproxy will be too slow and many errors occured.
2. without tc network control, performance is much better than before.
3. long run test(40ms, 5ms jitter, 8Mbit bandwidth, 0.1% packet loss rate), long run test for 9360s, 8490MB+ size of files are downloaded, mem usage=160M~, no errors occurred.

## Ticket
[T4PB-24233: bug related to cache_tracker](https://tier4.atlassian.net/browse/T4PB-24233)