### PR TITLE
[Refine] otaproxy: make ota_cache fully async, resolving blocking

### DIFF
--- a/otaclient/ota_proxy/db.py
+++ b/otaclient/ota_proxy/db.py
@@ -14,6 +14,7 @@
 
 
 from __future__ import annotations
+import asyncio
 import functools
 import sqlite3
 import threading
@@ -274,44 +275,33 @@ class _ProxyBase:
         self._executor.shutdown(wait=True)
 
 
-def _proxy_wrapper(func: Callable) -> Callable:
-    """NOTE: this wrapper should only be used for _ProxyBase"""
-    func_name = func.__name__
-
-    @functools.wraps(func)
-    def _wrapped(self, *args, **kwargs):
-        # get the handler from underlaying db connector
+class AioOTACacheDBProxy(_ProxyBase):
+    async def insert_entry(self, *cache_meta: CacheMeta) -> int:
         def _inner():
             _db: OTACacheDB = self._thread_local.db
-            return getattr(_db, func_name)(*args, **kwargs)
+            return _db.insert_entry(*cache_meta)
 
-        # inner is dispatched to the db connection threadpool
-        return self._executor.submit(_inner).result()
+        return await asyncio.get_running_loop().run_in_executor(self._executor, _inner)
 
-    return _wrapped
+    async def lookup_entry(
+        self, fd: ColumnDescriptor, _input: Any
+    ) -> Optional[CacheMeta]:
+        def _inner():
+            _db: OTACacheDB = self._thread_local.db
+            return _db.lookup_entry(fd, _input)
 
+        return await asyncio.get_running_loop().run_in_executor(self._executor, _inner)
 
-def create_db_proxy(name: str, *, source_cls: Type) -> Type:
-    """Class factory for creating a proxy class for OTACacheDB.
+    async def remove_entries(self, fd: ColumnDescriptor, *_inputs: Any) -> int:
+        def _inner():
+            _db: OTACacheDB = self._thread_local.db
+            return _db.remove_entries(fd, *_inputs)
 
-    All methods of OTACacheDB will be proxied to corresponding wrapper methods,
-    the wrapper will proxy the request to the thread pool.
-    """
-    _new_cls = type(name, (_ProxyBase,), {})
-    for attr_n, attr in source_cls.__dict__.items():
-        # NOTE: not proxy the close method as we should call the proxy's close method
-        if not attr_n.startswith("_") and callable(attr) and attr_n != "close":
-            # assigned wrapped method to the proxy cls
-            setattr(
-                _new_cls,
-                attr_n,
-                _proxy_wrapper(attr),
-            )
-    return _new_cls
+        return await asyncio.get_running_loop().run_in_executor(self._executor, _inner)
 
+    async def rotate_cache(self, bucket_idx: int, num: int) -> Optional[List[str]]:
+        def _inner():
+            _db: OTACacheDB = self._thread_local.db
+            return _db.rotate_cache(bucket_idx, num)
 
-# expose OTACacheDB classs
-OTACacheDBProxy = cast(
-    Type[OTACacheDB], create_db_proxy("OTACacheDBProxy", source_cls=OTACacheDB)
-)
-del create_db_proxy  # cleanup namespace
+        return await asyncio.get_running_loop().run_in_executor(self._executor, _inner)

--- a/otaclient/ota_proxy/db.py
+++ b/otaclient/ota_proxy/db.py
@@ -15,13 +15,12 @@
 
 from __future__ import annotations
 import asyncio
-import functools
 import sqlite3
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pathlib import Path
-from typing import Any, List, Optional, Type, Callable, Union, cast
+from typing import Any, List, Optional, Union
 
 from .config import config as cfg
 from .orm import ColumnDescriptor, ORMBase
@@ -275,7 +274,7 @@ class _ProxyBase:
         self._executor.shutdown(wait=True)
 
 
-class AioOTACacheDBProxy(_ProxyBase):
+class AIO_OTACacheDBProxy(_ProxyBase):
     async def insert_entry(self, *cache_meta: CacheMeta) -> int:
         def _inner():
             _db: OTACacheDB = self._thread_local.db

--- a/otaclient/ota_proxy/ota_cache.py
+++ b/otaclient/ota_proxy/ota_cache.py
@@ -47,7 +47,7 @@ from typing import (
 from urllib.parse import SplitResult, quote, urlsplit
 
 from .cache_control import OTAFileCacheControl
-from .db import CacheMeta, OTACacheDB, AioOTACacheDBProxy
+from .db import CacheMeta, OTACacheDB, AIO_OTACacheDBProxy
 from .errors import (
     BaseOTACacheError,
     CacheStreamingFailed,
@@ -56,7 +56,7 @@ from .errors import (
     StorageReachHardLimit,
 )
 from .config import config as cfg
-from .utils import wait_with_backoff, AioSHA256Hasher
+from .utils import wait_with_backoff, AIOSHA256Hasher
 
 if TYPE_CHECKING:
     import multiprocessing
@@ -161,7 +161,7 @@ class CacheTracker(Generic[_WEAKREF]):
             The exception from upper caller via throw() will also be re-raised directly.
         """
         logger.debug(f"start to cache for {self.meta=}...")
-        _sha256hash_f = AioSHA256Hasher(executor=self._executor)
+        _sha256hash_f = AIOSHA256Hasher(executor=self._executor)
         async with aiofiles.open(self.fpath, "wb", executor=self._executor) as f:
             _written = 0
             while _data := (yield _written):
@@ -406,7 +406,7 @@ class LRUCacheHelper:
     BSIZE_DICT = cfg.BUCKET_FILE_SIZE_DICT
 
     def __init__(self, db_f: Union[str, Path]):
-        self._db = AioOTACacheDBProxy(db_f)
+        self._db = AIO_OTACacheDBProxy(db_f)
         self._closed = False
 
     def close(self):

--- a/otaclient/ota_proxy/utils.py
+++ b/otaclient/ota_proxy/utils.py
@@ -1,0 +1,41 @@
+import asyncio
+from concurrent.futures import Executor
+from hashlib import sha256
+
+
+def get_backoff(n: int, factor: float, _max: float) -> float:
+    return min(_max, factor * (2 ** (n - 1)))
+
+
+async def wait_with_backoff(
+    _retry_cnt: int, *, _backoff_factor: float, _backoff_max: float
+) -> bool:
+    """
+    Returns:
+        A bool indicates whether upper caller should keep retry.
+    """
+    _timeout = get_backoff(
+        _retry_cnt,
+        _backoff_factor,
+        _backoff_max,
+    )
+    if _timeout <= _backoff_max:
+        await asyncio.sleep(_timeout)
+        return True
+    return False
+
+
+class AioSHA256Hasher:
+    def __init__(self, *, executor: Executor) -> None:
+        self._executor = executor
+        self._hashf = sha256()
+
+    async def update(self, data: bytes):
+        await asyncio.get_running_loop().run_in_executor(
+            self._executor, self._hashf.update, data
+        )
+
+    async def hexdigest(self) -> str:
+        return await asyncio.get_running_loop().run_in_executor(
+            self._executor, self._hashf.hexdigest
+        )

--- a/otaclient/ota_proxy/utils.py
+++ b/otaclient/ota_proxy/utils.py
@@ -25,7 +25,7 @@ async def wait_with_backoff(
     return False
 
 
-class AioSHA256Hasher:
+class AIOSHA256Hasher:
     def __init__(self, *, executor: Executor) -> None:
         self._executor = executor
         self._hashf = sha256()


### PR DESCRIPTION
## Introduction
This PR follows #184 , in #184 ota_cache is switching to asyncio+async generator model, and this PR further improve the implementation, resolving blocking code in asyncio workflow, including sha256 hashing and cache_db accessing. Now sha256 hashing and cache_db accessing are wrapped into a proxy class which provides async interface to resolve blocking.

## Motivation
I have done some small scale test, and found that sha256 blocks the async workflow obviously, especailly when there are many small files. In #184 although cache writing is implemented in async, but `_hash.update()` is still being directly called, which introduces blocking in async.

## Test result
I try 2 tests in different settings as follow.
NOTE: the average download speed is hard to reach the full bandwidth because we have many small files,
but it will reach max bandwidth during downloading large file.
### Test 1(5clients, 43ms, 5ms jitter, 0.1% packet loss, 120Mbit)
1. downloaded files: 147339, ~10.4G,
2. timecost: **1865s**(average 44Mbps, 79 files/s),
3. memory usage: **126M**,
4. finished without errors.

### Test 2(5clients, 43ms, 10ms jitter, 1% packet loss, 8Mbit)
1. downloaded files: 147339, ~10.4G,
2. timecost: **12613s**(average 6.6Mbps, 12 files/s),
3. memory usage: **156M**,
4. finished without errors.

The memory usage is almost the same as in #184, and both way better than before #184. And with this PR, the performance is further better than #184 (2274s), and way better than before #184 (2313s). 