### PR TITLE
proxy_info: align default proxy_info settings as v2.5.4

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -169,56 +169,77 @@ See [OTA proxy](../ota_proxy/README.md) more details.
 
 ##### Entries
 
-- enable_local_ota_proxy (boolean, optional)
+- enable_local_ota_proxy (boolean, default=**true**)
 
   This field specifies whether OTA client uses local OTA proxy or not.
-  If this field is not specified, OTA client doesn't use local OTA proxy, it means OTA client connects to OTA server directly. If the local OTA proxy is enabled, the OTA client requests the local OTA proxy.
+  If this field is set to **true**, OTA client will not download remote OTA files using local OTA proxy, it means OTA client connects to remote OTA server directly. If the local OTA proxy is enabled, the OTA client requests the remote OTA files via the local OTA proxy.
 
-- upper_ota_proxy (string, optional)
+- upper_ota_proxy (string, default=**""**)
 
-  This field specifies the upper OTA proxy address to be accessed by the OTA client or local OTA proxy.
+  This field specifies the upper OTA proxy address to be use by the OTA client or local OTA proxy server. Only **HTTP** proxy is supported, like `http://192.168.20.11:8082`. If not set or set to `""`, not upper_ota_proxy will be used.
 
-  | `enable_local_ota_proxy` | `upper_ota_proxy` | who accesses    | where?              |
-  | :---:                    | :---:             | :---:           | :---:               |
-  | true                     | set               | local OTA proxy | `upper_ota_proxy`   |
-  | true                     | not set           | local OTA proxy | OTA server directly |
-  | false                    | set               | OTA client      | `upper_ota_proxy`   |
-  | false                    | not set           | OTA client      | OTA server directly |
+- gateway (boolean, default=**false**)
 
-  To specify the upper OTA proxy address, `http://192.168.20.11:8082` notation is used.
+  When the `enable_local_ota_proxy` field is true, this field specifies whether the **local OTA proxy** requests the remote OTA server directly with HTTPS or HTTP. If it is true or this config entry is not presented, HTTPS is used otherwise HTTP is used.  
+  Note that if the ECU can't access to the remote OTA server directly, the value **MUST** be set to false, `enable_local_ota_proxy` **MUST** be set to true to enable local OTA proxy server, and a valid `upper_ota_proxy` **MUST** be set for local OTA proxy server to connect to parent ECU's OTA proxy server.
 
-The configuration for local OTA proxy are as follows.
+- enable_local_ota_proxy_cache (boolean, default=**true**)
 
-- gateway (boolean, optional if `enable_local_ota_proxy` is true otherwise not required)
+  When the `enable_local_ota_proxy` field is true, this field specifies whether the local OTA proxy caches the requests and uses the local caches to satisify the requests or not. If it is true or this config entry is not set, the local cache is used otherwise not used.
 
-  When the `enable_local_ota_proxy` field is true, this field specifies whether the **local OTA proxy** requests the OTA server directly with HTTPS or HTTP. If it is true, HTTPS is used otherwise HTTP is used.  
-  If this field is not specified, HTTP is used.  
-  Note that if the ECU can't access to the OTA server directly, the value should be set to false.
+- local_ota_proxy_listen_addr (string, default=**"0.0.0.0"**)
 
-- enable_local_ota_proxy_cache (boolean, optional if `enable_local_ota_proxy` is true otherwise not required)
+  When the `enable_local_ota_proxy` field is true, this field specifies the listen address for local OTA proxy. If not specified, local OTA proxy will listen on **"0.0.0.0"**.
 
-  When the `enable_local_ota_proxy` field is true, this field specifies whether the local OTA proxy uses the local cache or not. If it is true, the local cache is used otherwise not used.  
-  If this field is not specified, the local cache is used.
+- local_ota_proxy_listen_port (integer, default=**8082**)
 
-- local_ota_proxy_listen_addr (string, optional if `enable_local_ota_proxy` is true otherwise not required)
+  When the `enable_local_ota_proxy` field is true, this field specifies the listen port for local OTA proxy. If not specified, port **8082** will be used.
 
-  When the `enable_local_ota_proxy` field is true, this field specifies the listen address for local OTA proxy.  
-  If this field is not specified, "0.0.0.0" is used.
+##### NOTE about OTA client behavior under different combination of `enable_local_ota_proxy` and `upper_ota_proxy` setting
 
-- local_ota_proxy_listen_port (integer, optional if `enable_local_ota_proxy` is true otherwise not required)
+The behavior of OTA client under different `enable_local_ota_proxy` and `upper_ota_proxy` setting is as follow:
 
-  When the `enable_local_ota_proxy` field is true, this field specifies the listen port for local OTA proxy.  
-  If this field is not specified, 8082 is used.
+| `enable_local_ota_proxy` | `upper_ota_proxy`   | `behavior`                          |
+| ---:                     | ---:                | ---                                 |
+| (unset, default=false)   | (unset, default="") | OTA client directly connects to remote without any proxy |
+| true                     | set                 | OTA client connects to remote via OTA proxy, and local OTA proxy itself also uses `upper_ota_proxy` to connect to remote |
+| true                     | (unset, default="") | OTA client connects to remote via OTA proxy, and local OTA proxy OTA connects to remote directly |
+| false                    | set                 | OTA client connects to remote via `upper_ota_proxy`, local OTA proxy is not enabled and not used |
+| false                    | not set             | OTA client directly connects to remote without any proxy |
 
-##### The default setting
+##### Note about the behavior when no `proxy_info.yaml` is presented
 
-If proxy_info.yaml doesn't exist, the default setting is used as follows:
+If proxy_info.yaml doesn't exist, the default `proxy_info.yaml` will be used as follow:
 
-- enable_local_ota_proxy
-  - true
+```yaml
+enable_local_ota_proxy: true
+gateway: true
+```
 
-- gateway
-  - true
+#### Example default `proxy_info.yaml` for main ECU
+
+The main ECU defined here is responsible to provide OTA proxy for all child and sub child ECUs to connect to the remote OTA server.
+
+```yaml
+# local OTA proxy for main ECU also provides proxy service for all child/sub child ECUs
+enable_local_ota_proxy: true
+# for main ECU that directly connects to the Internet, HTTPS should be used, so set gateway=true
+gateway: true
+```
+
+#### Example default `proxy_info.yaml` for sub ECU
+
+The sub ECU defines here is which has at least one parent ECU and cannot connect the Internet directly.
+
+```yaml
+# local OTA proxy MUST be enabled to serve local OTA client(or together with the child ECUs)
+enable_local_ota_proxy: true
+# a valid upper_ota_proxy MUST be set for local OTA proxy to connect to remote as sub ECU cannot
+# directly connect the Internet
+upper_ota_proxy: "http://192.168.20.11:8082"
+# optional: if the sub ECU's disk is not so fast(like USB device), local OTA proxy cache can be disabled
+# enable_local_ota_proxy_cache: false
+```
 
 ### python packages installation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,14 @@ OTA client is licensed under the Apache License, Version 2.0.
   - pip
   - setuptools
 
+### Dependency installation
+
+```bash
+sudo python3.8 -m pip install -r otaclient/requirements.txt
+```
+
+Note that OTA client is run with super user privileges so `sudo` is required for the above command.
+
 ### Partitioning
 
 For the GRUB system, the disk is partitioned as follows:
@@ -69,7 +77,7 @@ In this example, A(=active) partition is sda2 and B(=standby) partition is sda3.
 And `/boot` partition is shared by A/B partitions.
 Note that the disk and the sector size depend on the system, but the size of A and B should be the same, basically.
 
-### Configurations
+## OTA client Configurations
 
 OTA client can update a single ECU or multiple ECUs and is installed for each ECU.
 There are two types of ECU, Main ECU - receives user request, Secondary ECUs - receive request from Main ECU. One or multiple Secondary ECUs can also have Secondary ECUs.
@@ -98,15 +106,15 @@ Secondary ECU A, B and C are connected to Main ECU, and D, E, F are connected to
 +------------------------------------------------------------------+
 ```
 
-#### ecu\_info.yaml
+### ecu\_info.yaml
 
 ecu_info.yaml is the setting file for ECU configuration.
 
-##### File path
+#### File path
 
 /boot/ota/ecu_info.yaml
 
-##### Entries
+#### Entries
 
 - format_version (string, required)
 
@@ -144,7 +152,7 @@ ecu_info.yaml is the setting file for ECU configuration.
 
   `secondaries` lists the directly connected children ECUs, available_ecu_ids consists of all children ECU ids(including directly connected, indirectly connected and itself).
 
-##### The default setting
+#### The default setting
 
 If ecu_info.yaml doesn't exist, the default setting is used as follows:
 
@@ -154,7 +162,7 @@ If ecu_info.yaml doesn't exist, the default setting is used as follows:
 - ecu_id
   - "autoware"
 
-#### proxy\_info.yaml
+### proxy\_info.yaml
 
 proxy_info.yaml is the setting file for OTA proxy configuration.
 
@@ -163,11 +171,11 @@ Whether OTA proxy access the OTA server directly or indirectly depends on the co
 
 See [OTA proxy](../ota_proxy/README.md) more details.
 
-##### File path
+#### File path
 
 /boot/ota/proxy_info.yaml
 
-##### Entries
+#### Entries
 
 - enable_local_ota_proxy (boolean, default=**true**)
 
@@ -195,28 +203,19 @@ See [OTA proxy](../ota_proxy/README.md) more details.
 
   When the `enable_local_ota_proxy` field is true, this field specifies the listen port for local OTA proxy. If not specified, port **8082** will be used.
 
-##### NOTE about OTA client behavior under different combination of `enable_local_ota_proxy` and `upper_ota_proxy` setting
+#### NOTE about OTA client behavior under different combination of `enable_local_ota_proxy` and `upper_ota_proxy` setting
 
 The behavior of OTA client under different `enable_local_ota_proxy` and `upper_ota_proxy` setting is as follow:
 
 | `enable_local_ota_proxy` | `upper_ota_proxy`   | `behavior`                          |
-| ---:                     | ---:                | ---                                 |
+| :---:                     | :---:                | ---                                 |
 | (unset, default=false)   | (unset, default="") | OTA client directly connects to remote without any proxy |
 | true                     | set                 | OTA client connects to remote via OTA proxy, and local OTA proxy itself also uses `upper_ota_proxy` to connect to remote |
 | true                     | (unset, default="") | OTA client connects to remote via OTA proxy, and local OTA proxy connects to remote directly |
 | false                    | set                 | OTA client connects to remote via `upper_ota_proxy`, local OTA proxy is not enabled and not used |
 | false                    | not set             | OTA client directly connects to remote without any proxy |
 
-##### Note about the behavior when no `proxy_info.yaml` is presented
-
-If proxy_info.yaml doesn't exist, OTA client is expected to running on main ECU(or equivalent that directly connects to the Internet), the default `proxy_info.yaml` will be used as follow:
-
-```yaml
-enable_local_ota_proxy: true
-gateway: true
-```
-
-#### Example default `proxy_info.yaml` for main ECU
+#### Example `proxy_info.yaml` for main ECU
 
 The main ECU defined here is responsible to provide OTA proxy for all child and sub child ECUs to connect to the remote OTA server.
 
@@ -227,7 +226,7 @@ enable_local_ota_proxy: true
 gateway: true
 ```
 
-#### Example default `proxy_info.yaml` for sub ECU
+#### Example `proxy_info.yaml` for sub ECU
 
 The sub ECU defines here is which has at least one parent ECU and cannot connect the Internet directly. The sub ECU requires at least one upper OTA client that provides OTA proxy, and download OTA files via this upper proxy.
 
@@ -244,13 +243,14 @@ upper_ota_proxy: "http://192.168.20.11:8082"
 # enable_local_ota_proxy_cache: false
 ```
 
-### python packages installation
+### Note about the behavior when `proxy_info.yaml` is missing
 
-```bash
-sudo python3.8 -m pip install -r app/requirements.txt
+If `proxy_info.yaml` file is missing/not found, OTA client is expected to running on main ECU(or equivalent that directly connects to the Internet), a pre-defined `proxy_info.yaml` will be used as follow:
+
+```yaml
+enable_local_ota_proxy: true
+gateway: true
 ```
-
-Note that OTA client is run with super user privileges so `sudo` is required for the above command.
 
 ## OTA image generation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -203,13 +203,13 @@ The behavior of OTA client under different `enable_local_ota_proxy` and `upper_o
 | ---:                     | ---:                | ---                                 |
 | (unset, default=false)   | (unset, default="") | OTA client directly connects to remote without any proxy |
 | true                     | set                 | OTA client connects to remote via OTA proxy, and local OTA proxy itself also uses `upper_ota_proxy` to connect to remote |
-| true                     | (unset, default="") | OTA client connects to remote via OTA proxy, and local OTA proxy OTA connects to remote directly |
+| true                     | (unset, default="") | OTA client connects to remote via OTA proxy, and local OTA proxy connects to remote directly |
 | false                    | set                 | OTA client connects to remote via `upper_ota_proxy`, local OTA proxy is not enabled and not used |
 | false                    | not set             | OTA client directly connects to remote without any proxy |
 
 ##### Note about the behavior when no `proxy_info.yaml` is presented
 
-If proxy_info.yaml doesn't exist, the default `proxy_info.yaml` will be used as follow:
+If proxy_info.yaml doesn't exist, OTA client is expected to running on main ECU(or equivalent that directly connects to the Internet), the default `proxy_info.yaml` will be used as follow:
 
 ```yaml
 enable_local_ota_proxy: true
@@ -229,10 +229,13 @@ gateway: true
 
 #### Example default `proxy_info.yaml` for sub ECU
 
-The sub ECU defines here is which has at least one parent ECU and cannot connect the Internet directly.
+The sub ECU defines here is which has at least one parent ECU and cannot connect the Internet directly. The sub ECU requires at least one upper OTA client that provides OTA proxy, and download OTA files via this upper proxy.
+
+If this sub ECU also serves sub ECUs, the OTA proxy for this sub ECU MUST be enabled to provide OTA proxy for its sub ECUs(and subsub ECUs if any).
 
 ```yaml
-# local OTA proxy MUST be enabled to serve local OTA client(or together with the child ECUs)
+# local OTA proxy Must be enabled if the sub ECU also serves child ECUs, 
+# should be enabled if local OTA files cache is needed.
 enable_local_ota_proxy: true
 # a valid upper_ota_proxy MUST be set for local OTA proxy to connect to remote as sub ECU cannot
 # directly connect the Internet

--- a/otaclient/app/proxy_info.py
+++ b/otaclient/app/proxy_info.py
@@ -52,7 +52,7 @@ enable_local_ota_proxy: true
 enable_local_ota_proxy_cache: true
 
 # the listen_addr of local_ota_proxy, if not presented, default to 0.0.0.0:8082
-# optional, default: "0.0.0.0", 8082 
+# optional, default: "0.0.0.0", 8082
 local_ota_proxy_listen_addr: "0.0.0.0"
 local_ota_proxy_listen_port: 8082
 """
@@ -94,8 +94,8 @@ class ProxyInfo:
 
     # NOTE(20221216): gateway=False is default setting for subECUs
     gateway: bool = False
-    # NOTE(20221216): only main ECU can not set this value,
-    #                 for subECU, this value should be set
+    # NOTE(20221216): only main ECU can ignore this field,
+    #                 for subECU, this value MUST be set
     upper_ota_proxy: str = ""
 
     # common default settings for both main ECU and sub ECUs

--- a/otaclient/app/proxy_info.py
+++ b/otaclient/app/proxy_info.py
@@ -14,47 +14,8 @@
 
 
 """Proxy setting parsing.
-###### Example proxy_info.yaml for different scenario ######
-## --------------------- mainecu --------------------- ##
-# for mainecu, proxy_info.yaml is not needed, the following
-# DEFAULT_PROXY_INFO will be used.
-# we should treat the ecu with no proxy_info.yaml
-# as main ecu(as gateway), and enable ota_proxy without upper proxy.
 
-enable_local_ota_proxy: true
-gateway: true
-enable_local_ota_proxy_cache: true
-
-
-## --------------------- internal ecu --------------------- ##
-# for internal ecu, that doesn't have direct internet connection,
-# proxy_info.yaml must be presented.
-# the following is the default configuration for it.
-
-# for internal ECU, upper_ota_proxy is required,
-# internal ECU will use this proxy to request for ota update.
-# upper ota proxy must be an HTTP URL.
-# required if internal ECU cannot directly connect to the Internet.
-upper_ota_proxy: <upper_ota_proxy_URL: str>
-
-# internal ecu is not the gateway for the local network,
-# MUST BE SET TO false or NOT SET IT.
-# optional, default: false
-gateway: false
-
-# enable the local otaproxy, should be true for sub ECU to connect
-# to the Internet via main ECU.
-# optional, default: true
-enable_local_ota_proxy: true
-
-# enable ota cache, otaproxy will cache the requested files.
-# optional, default: true
-enable_local_ota_proxy_cache: true
-
-# the listen_addr of local_ota_proxy, if not presented, default to 0.0.0.0:8082
-# optional, default: "0.0.0.0", 8082
-local_ota_proxy_listen_addr: "0.0.0.0"
-local_ota_proxy_listen_port: 8082
+check docs/README.md for more details.
 """
 import yaml
 import warnings
@@ -83,26 +44,25 @@ class ProxyInfo:
     NOTE(20221216): for mainECU, if proxy_info.yaml is not presented,
                     a default _DEFAULT_MAIN_ECU_PROXY_INFO will be used!
     Attributes:
-        enable_local_ota_proxy: whether to launch a local ota_proxy server, default is True.
-        gateway: (only valid when enable_local_ota_proxy==true) whether to enforce HTTPS when local ota_proxy
-            sends out the requests, default is False.
-        enable_local_ota_proxy_cache: enable cache mechanism on ota-proxy, default is True.
-        local_ota_proxy_listen_addr: default is "0.0.0.0".
-        local_ota_proxy_listen_port: default is 8082.
-        upper_ota_proxy: the upper proxy used by local ota_proxy(proxy chain), default is None.
+        enable_local_ota_proxy: whether to launch a local ota_proxy server.
+        enable_local_ota_proxy_cache: enable cache mechanism on ota-proxy.
+        gateway: whether to use HTTPS when local ota_proxy connects to remote.
+        local_ota_proxy_listen_addr: ipaddr ota_proxy listens on.
+        local_ota_proxy_listen_port: port ota_proxy used.
+        upper_ota_proxy: the upper proxy used by local ota_proxy(proxy chain).
     """
 
-    # NOTE(20221216): gateway=False is default setting for subECUs
+    # NOTE(20221219): the default values for the following settings
+    #                 now align with v2.5.4
     gateway: bool = False
-    # NOTE(20221216): only main ECU can ignore this field,
-    #                 for subECU, this value MUST be set
     upper_ota_proxy: str = ""
-
-    # common default settings for both main ECU and sub ECUs
-    enable_local_ota_proxy: bool = True
-    enable_local_ota_proxy_cache: bool = True
+    enable_local_ota_proxy: bool = False
     local_ota_proxy_listen_addr: str = server_cfg.OTA_PROXY_LISTEN_ADDRESS
     local_ota_proxy_listen_port: int = server_cfg.OTA_PROXY_LISTEN_PORT
+    # NOTE: this field not presented in v2.5.4,
+    #       for current implementation, it should be default to True.
+    #       This field doesn't take effect if enable_local_ota_proxy is False
+    enable_local_ota_proxy_cache: bool = True
 
     # for maintaining compatibility, will be removed in the future
     # Dict[str, str]: <old_option_name> -> <new_option_name>

--- a/otaclient/app/proxy_info.py
+++ b/otaclient/app/proxy_info.py
@@ -34,7 +34,7 @@ enable_local_ota_proxy_cache: true
 # for internal ECU, upper_ota_proxy is required,
 # internal ECU will use this proxy to request for ota update.
 # upper ota proxy must be an HTTP URL.
-# required
+# required if internal ECU cannot directly connect to the Internet.
 upper_ota_proxy: <upper_ota_proxy_URL: str>
 
 # internal ecu is not the gateway for the local network,
@@ -42,13 +42,14 @@ upper_ota_proxy: <upper_ota_proxy_URL: str>
 # optional, default: false
 gateway: false
 
-# set to false if internal ECU doesn't have child ECU to serve.
-# optional, default: false
-enable_local_ota_proxy: false
+# enable the local otaproxy, should be true for sub ECU to connect
+# to the Internet via main ECU.
+# optional, default: true
+enable_local_ota_proxy: true
 
-# generally, we can only enable ota cache on the gateway ECU.
-# optional, default: false
-enable_local_ota_proxy_cache: false
+# enable ota cache, otaproxy will cache the requested files.
+# optional, default: true
+enable_local_ota_proxy_cache: true
 
 # the listen_addr of local_ota_proxy, if not presented, default to 0.0.0.0:8082
 # optional, default: "0.0.0.0", 8082 
@@ -88,16 +89,18 @@ class ProxyInfo:
         enable_local_ota_proxy_cache: enable cache mechanism on ota-proxy, default is True.
         local_ota_proxy_listen_addr: default is "0.0.0.0".
         local_ota_proxy_listen_port: default is 8082.
-        upper_ota_proxy: the upper proxy used by local ota_proxy(proxy chain), default is None(no upper proxy).
+        upper_ota_proxy: the upper proxy used by local ota_proxy(proxy chain), default is None.
     """
 
     # NOTE(20221216): gateway=False is default setting for subECUs
     gateway: bool = False
+    # NOTE(20221216): only main ECU can not set this value,
+    #                 for subECU, this value should be set
+    upper_ota_proxy: str = ""
 
     # common default settings for both main ECU and sub ECUs
     enable_local_ota_proxy: bool = True
     enable_local_ota_proxy_cache: bool = True
-    upper_ota_proxy: str = ""
     local_ota_proxy_listen_addr: str = server_cfg.OTA_PROXY_LISTEN_ADDRESS
     local_ota_proxy_listen_port: int = server_cfg.OTA_PROXY_LISTEN_PORT
 

--- a/otaclient/app/proxy_info.py
+++ b/otaclient/app/proxy_info.py
@@ -31,7 +31,8 @@ logger = log_setting.get_logger(
     __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)
 )
 
-DEFAULT_MAIN_ECU_PROXY_INFO = """
+
+PRE_DEFINED_PROXY_INFO_YAML = """
 enable_local_ota_proxy: true
 gateway: true
 """
@@ -41,8 +42,11 @@ gateway: true
 class ProxyInfo:
     """OTA-proxy configuration.
 
-    NOTE(20221216): for mainECU, if proxy_info.yaml is not presented,
-                    a default _DEFAULT_MAIN_ECU_PROXY_INFO will be used!
+    NOTE 1(20221220): when proxy_info.yaml is missing/not a valid yaml,
+                      a pre_defined proxy_info.yaml as follow will be used.
+    NOTE 2(20221220): when a config field is missing/assigned with invalid value,
+                      default value will be applied.
+
     Attributes:
         enable_local_ota_proxy: whether to launch a local ota_proxy server.
         enable_local_ota_proxy_cache: enable cache mechanism on ota-proxy.
@@ -93,7 +97,7 @@ def parse_proxy_info(proxy_info_file: str = cfg.PROXY_INFO_FILE) -> ProxyInfo:
             f"failed to load {proxy_info_file=} or config file corrupted, "
             "use default main ECU config"
         )
-        _loaded = yaml.safe_load(DEFAULT_MAIN_ECU_PROXY_INFO)
+        _loaded = yaml.safe_load(PRE_DEFINED_PROXY_INFO_YAML)
 
     # load options
     # NOTE: if option is not presented,

--- a/tests/test_proxy_info.py
+++ b/tests/test_proxy_info.py
@@ -21,22 +21,22 @@ from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
 
-MAINECU_PROXY_INFO: str = """
+DEFAULT_MAINECU_PROXY_INFO = """
 enable_local_ota_proxy: true
 gateway: true
 """
-PERCEPTION_ECU_PROXY_INFO: str = """
+
+PERCEPTION_ECU_PROXY_INFO = """
 gateway: false
 enable_local_ota_proxy: true
 upper_ota_proxy: "http://10.0.0.1:8082"
 enable_local_ota_proxy_cache: true
 """
-EMPTY_PROXY_INFO: str = ""
 
 # corrupted yaml files that contains invalid value
 # all fields are asigned with invalid value,
 # invalid field should be replaced by default value.
-CORRUPTED_PROXY_INFO: str = """
+CORRUPTED_PROXY_INFO = """
 enable_local_ota_proxy: dafef
 gateway: 123
 upper_ota_proxy: true
@@ -45,17 +45,14 @@ local_ota_proxy_listen_addr: 123
 local_ota_proxy_listen_port: "2808"
 """
 
-# check ProxyInfo for detail
-_COMMON_DEFAULT_PARSED_CONFIGS: Dict[str, Any] = {
-    "enable_local_ota_proxy": True,
+# NOTE: check docs/README.md for details
+DEFAULT_SETTINGS_FOR_PROXY_INFO = {
+    "gateway": False,
+    "upper_ota_proxy": "",
+    "enable_local_ota_proxy": False,
     "enable_local_ota_proxy_cache": True,
     "local_ota_proxy_listen_addr": "0.0.0.0",
     "local_ota_proxy_listen_port": 8082,
-}
-_DEFAULT_PARSED_MAIN_ECU_CONFIGS: Dict[str, Any] = {
-    "enable_local_ota_proxy": True,
-    "gateway": True,
-    "upper_ota_proxy": "",
 }
 
 
@@ -64,32 +61,38 @@ _DEFAULT_PARSED_MAIN_ECU_CONFIGS: Dict[str, Any] = {
     (
         # case 1: testing minimun main ECU proxy_info
         (
-            MAINECU_PROXY_INFO,
+            DEFAULT_MAINECU_PROXY_INFO,
             {
-                **_COMMON_DEFAULT_PARSED_CONFIGS,
-                **{
-                    "gateway": True,
-                    "upper_ota_proxy": "",
-                },
+                "gateway": True,
+                "upper_ota_proxy": "",
+                "enable_local_ota_proxy": True,
+                "enable_local_ota_proxy_cache": True,
+                "local_ota_proxy_listen_addr": "0.0.0.0",
+                "local_ota_proxy_listen_port": 8082,
             },
         ),
         # case 2: tesing typical sub ECU setting
         (
             PERCEPTION_ECU_PROXY_INFO,
             {
-                **_COMMON_DEFAULT_PARSED_CONFIGS,
-                **{
-                    "gateway": False,
-                    "upper_ota_proxy": "http://10.0.0.1:8082",
-                },
+                "gateway": False,
+                "upper_ota_proxy": "http://10.0.0.1:8082",
+                "enable_local_ota_proxy": True,
+                "enable_local_ota_proxy_cache": True,
+                "local_ota_proxy_listen_addr": "0.0.0.0",
+                "local_ota_proxy_listen_port": 8082,
             },
         ),
         # case 3: testing missing/invalid proxy_info.yaml
         (
             "not a valid proxy_info.yaml",
             {
-                **_COMMON_DEFAULT_PARSED_CONFIGS,
-                **_DEFAULT_PARSED_MAIN_ECU_CONFIGS,
+                "gateway": True,
+                "upper_ota_proxy": "",
+                "enable_local_ota_proxy": True,
+                "enable_local_ota_proxy_cache": True,
+                "local_ota_proxy_listen_addr": "0.0.0.0",
+                "local_ota_proxy_listen_port": 8082,
             },
         ),
         # case 4: testing default settings against invalid fields
@@ -98,10 +101,7 @@ _DEFAULT_PARSED_MAIN_ECU_CONFIGS: Dict[str, Any] = {
         # NOTE 2: default value settings are for sub ECU
         (
             CORRUPTED_PROXY_INFO,
-            {
-                **_COMMON_DEFAULT_PARSED_CONFIGS,
-                **{"gateway": False, "upper_ota_proxy": ""},
-            },
+            DEFAULT_SETTINGS_FOR_PROXY_INFO,
         ),
     ),
 )


### PR DESCRIPTION
## Introduction
This PR aligns the default `proxy_info` settings as v2.5.4 as follow:
1. for missing `proxy_info.yaml`, a `PRE_DEFINED_PROXY_INFO_YAML` will be used:
      ```
      enable_local_ota_proxy: true
      gateway: true
      ```
2. the default settings for each field also aligned v2.5.4 as follow: 
    ```
    gateway: false
    enable_local_ota_proxy: false
    local_ota_proxy_listen_addr: "0.0.0.0"
    local_ota_proxy_listen_port: 8082
    upper_ota_proxy: "" # None, not set
    ```
3. Update the document related to `proxy_info.yaml`.
4. clearly distinguish the terminologies of `proxy_info.yaml missing/corrupted/invalid` and `default setting`.

## Changes
1. proxy_info.py: aligns the behavior as v2.5.4
2. docs/README.md: update the documents related to proxy_info.yaml, update section about config entries, add new section for special treatment when `proxy_info.yaml` not presented, add new sections that provide example `proxy_info.yaml` for main ECU and sub ECU.