### PR TITLE
[Bugfix] otaproxy: fix AsyncStopIteration errors spamming

### DIFF
--- a/otaclient/ota_proxy/ota_cache.py
+++ b/otaclient/ota_proxy/ota_cache.py
@@ -696,7 +696,8 @@ class _FileDescriptorHelper:
                 # open the connection and update the CacheMeta
                 yield b""
                 async for data, _ in response.content.iter_chunks():
-                    yield data
+                    if data:  # only yield non-empty data chunk
+                        yield data
 
         # open remote connection
         await (_remote_fd := _inner()).__anext__()


### PR DESCRIPTION
## Introduction
This PR fixes otaproxy spams `cache write failed: AsyncStopIteration` logs caused by `_cache_streamer` doesn't skip empty chunk.
When HTTP chunk encoding is enabled, a empty chunk will be sent to indicate the end of chunk streaming, previously the otaproxy will not skip this empty chunk and also send it to client and the caching generator. And when multiple otaproxy chained together, multiple empty chunks will be sent to the client(one more empty chunk for passing one more otaproxy), causing the problem.

## Changes
1. _cache_streamer: skip the empty chunk