### PR TITLE
fix: log-group for ota-proxy

### DIFF
--- a/otaclient/app/ota_client_stub.py
+++ b/otaclient/app/ota_client_stub.py
@@ -60,7 +60,7 @@ class OtaProxyWrapper:
 
         # configure logging for ota_proxy process
         log_setting.configure_logging(
-            loglevel=cfg.DEFAULT_LOG_LEVEL, http_logging_url="ota_proxy"
+            loglevel=cfg.DEFAULT_LOG_LEVEL, http_logging_url=log_setting.get_ecu_id()
         )
 
         async def _start_uvicorn(init_cache: bool, *, scrub_cache_event):


### PR DESCRIPTION
# About this PR
This PR fixes cloudwatch log group for ota-proxy.
Current implementation stores ota-proxy log to the single `ota-proxy` log group even multiple ecu are targeted.
By this change, ota-proxy log is saved with each ecu's log-group.

current:
all ecus logs in the vehicle for ota-proxy are saved in the same `ota-proxy` log group.
![image](https://user-images.githubusercontent.com/58019445/209275646-724676a0-d497-4e52-b229-d1160e56ffd0.png)

by this change:
ota-client and ota-proxy logs are saved in the same log group.
![image](https://user-images.githubusercontent.com/58019445/209275821-84946092-e0a6-4314-a865-8d0842a3ee36.png)