### PR TITLE
[Refinement] increase MAX_DOWNLOAD_THREAD and DOWNLOADER_CONNPOOL_SIZE_PER_THREAD

### DIFF
--- a/otaclient/app/configs.py
+++ b/otaclient/app/configs.py
@@ -104,8 +104,8 @@ class BaseConfig:
     DOWNLOAD_RETRY: int = 10
     DOWNLOAD_BACKOFF_MAX: int = 3  # seconds
     MAX_CONCURRENT_TASKS: int = 128
-    MAX_DOWNLOAD_THREAD = 3
-    DOWNLOADER_CONNPOOL_SIZE_PER_THREAD: int = 8
+    MAX_DOWNLOAD_THREAD = 7
+    DOWNLOADER_CONNPOOL_SIZE_PER_THREAD: int = 10
     STATS_COLLECT_INTERVAL: int = 1  # second
     ## standby creation mode, default to rebuild now
     STANDBY_CREATION_MODE = CreateStandbyMechanism.REBUILD


### PR DESCRIPTION
# Introduction
In #183, the MAX_DOWNLOAD_THREAD is decreased from 8 to 3 due to otaproxy and otaclient seem to be not so stable under large amount of connections. 
At that time it seems that this change doesn't reduce too much performance. But it turns out this change does degrade the performance significantly(nearly double the time cost under the same environment). 
But since #186, the otaproxy becomes much more stable and efficient than before. And the local test(check the following comment for details) shows that MAX_DOWNLOAD_THREAD==3 doesn't max out the otaclient's efficiency, and change the MAX_DOWNLOAD_THREAD back to 7 does resume the performance as before #183, meanwhile doesn't increase CPU usage and Memory Usage footprint thanks to optimization over otaproxy and otaclient.
So this PR change the MAX_DOWNLOAD_THREAD of otaclient back to 7.

# Changes
1. increase `MAX_DOWNLOAD_THREAD` back to 7
2. increase `DOWNLOADER_CONNPOOL_SIZE_PER_THREAD` to 10

# Ticket
[T4PB-25078](https://tier4.atlassian.net/browse/T4PB-25078)

[T4PB-25078]: https://tier4.atlassian.net/browse/T4PB-25078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ