### PR TITLE
[Fix] elapsed_download_time recording

### DIFF
--- a/otaclient/app/create_standby/rebuild_mode.py
+++ b/otaclient/app/create_standby/rebuild_mode.py
@@ -237,7 +237,7 @@ class RebuildMode(StandbySlotCreatorProtocol):
 
         for is_last, entry in _regs_set.iter_entries():
             cur_stat = RegInfProcessedStats()
-            _start = time.thread_time_ns()
+            _start_time, _download_time = time.thread_time_ns(), 0
 
             # prepare first copy for the hash group
             if not _local_copy_available:
@@ -259,7 +259,6 @@ class RebuildMode(StandbySlotCreatorProtocol):
                     compression_alg=compression_alg,
                 )
                 _local_copy_available = True
-                cur_stat.elapsed_ns = _download_time
 
             # record the size of this entry(by query the local copy)
             cur_stat.size = _local_copy.stat().st_size
@@ -306,9 +305,7 @@ class RebuildMode(StandbySlotCreatorProtocol):
                     _local_copy.unlink(missing_ok=True)
 
             # create stat
-            # NOTE: for download op, the download is already recorded
-            if cur_stat.op != RegProcessOperation.OP_DOWNLOAD:
-                cur_stat.elapsed_ns = time.thread_time_ns() - _start
+            cur_stat.elapsed_ns = time.thread_time_ns() - _start_time + _download_time
             stats_list.append(cur_stat)
 
         # report the stats to the stats_collector

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -129,7 +129,7 @@ class TestDownloader:
         _target_path = tmp_path / self.TEST_FILE
 
         url = urljoin_ensure_base(cfg.OTA_IMAGE_URL, self.TEST_FILE)
-        _error, _read_download_size = self.downloader.download(
+        _error, _read_download_size, _ = self.downloader.download(
             url,
             _target_path,
             digest=self.TEST_FILE_SHA256,
@@ -147,12 +147,12 @@ class TestDownloader:
 
         url = urljoin_ensure_base(cfg.OTA_IMAGE_URL, f"{self.TEST_FILE}.zst")
         # first test directly download without decompression
-        _error, _read_download_bytes_a = self.downloader.download(url, _target_path)
+        _error, _read_download_bytes_a, _ = self.downloader.download(url, _target_path)
         assert _error == 0
         assert file_sha256(_target_path) == file_sha256(self.zstd_compressed)
 
         # second, test dwonloader with transparent zstd decompression
-        _error, _real_download_bytes_b = self.downloader.download(
+        _error, _real_download_bytes_b, _ = self.downloader.download(
             url,
             _target_path,
             digest=self.TEST_FILE_SHA256,


### PR DESCRIPTION
## Introduce
Previously the download time recording is done by otaclient, using `time.time_thread_ns`, but due to the downloading now is done by the `downloader` module, and the downloading is done by another thread than the thread otaclient running on, so the download time recording is incorrect.
This PR fixes this issues by recording the downloading time in the downloader.

## Ticket
[T4PB-25099](https://tier4.atlassian.net/browse/T4PB-25099)

[T4PB-25099]: https://tier4.atlassian.net/browse/T4PB-25099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ