### PR TITLE
[Refine] otaproxy: only return 500 in unhandled unexpected otaproxy internal error

### DIFF
--- a/otaclient/ota_proxy/ota_cache.py
+++ b/otaclient/ota_proxy/ota_cache.py
@@ -1090,7 +1090,7 @@ class OTACache:
                 )
             except Exception as e:
                 _err_msg = f"failed to open remote connection for {raw_url=}: {e!r}"
-                logger.error(_err_msg)
+                logger.debug(_err_msg)
                 await _tracker.provider_on_failed()
                 raise CacheStreamingFailed(_err_msg) from e
 


### PR DESCRIPTION
## Introduction
Previously otaproxy will return 500 on any unsatisfied request except 4xx(currently 403 and 404) error. This behavior is not proper, and confusing the otaclient.

This PR fixes this behavior as follow:
1. return 500 on internal otaproxy error only.
2. return 502(BAD_GATEWAY) on any connection related error.
3. return 503(SERVICE_UNAVAILABLE) on any aiohttp client error except connection error.