### PR TITLE
[Security] bump cryptography to 39.0.1, pyopenssl to 23.0.0

### DIFF
--- a/otaclient/requirements.txt
+++ b/otaclient/requirements.txt
@@ -1,6 +1,5 @@
-pyOpenSSL==20.0.1
-jwt==1.2.0
-cryptography==3.4.8
+pyOpenSSL==23.0.0
+cryptography>=39.0.1, <40.0.0
 grpcio==1.48.2
 protobuf==3.20.3
 PyYAML>=3.12


### PR DESCRIPTION
## Introduction
Bump cryptography to 39.0.1 and pyopenssl to 23.0.0 due to security concerns, check #197 for details. 
Also remove the deps to `jwt` package as not in use and caused the deps conflicts.

NOTE: pyopenssl version bump is required for cryptography version bump. 