### PR TITLE
[BugFix] fix RetryTaskMap not working on py3.8.0

### DIFF
--- a/otaclient/app/common.py
+++ b/otaclient/app/common.py
@@ -483,8 +483,8 @@ class RetryTaskMap(Generic[_T, _RES]):
 
             def _done_cb(_fut, /):
                 _se.release()  # make sure the se is released first
-                self._futs.discard(_fut)
                 if self._status is _RetryTaskMapStatus.RUNNING:
+                    self._futs.discard(_fut)
                     try:
                         self._task_collector_gen.send(_fut)
                     except StopIteration:

--- a/otaclient/app/common.py
+++ b/otaclient/app/common.py
@@ -481,7 +481,7 @@ class RetryTaskMap(Generic[_T, _RES]):
         for _total_retry_count in self._max_retry_iter:
             _se = Semaphore(self.max_concurrent)  # each retry round has its own se
 
-            def _done_cb(_fut: Future, /):
+            def _done_cb(_fut, /):
                 _se.release()  # make sure the se is released first
                 if self._status is not _RetryTaskMapStatus.RUNNING:
                     return

--- a/otaclient/app/common.py
+++ b/otaclient/app/common.py
@@ -483,10 +483,12 @@ class RetryTaskMap(Generic[_T, _RES]):
 
             def _done_cb(_fut, /):
                 _se.release()  # make sure the se is released first
-                if self._status is not _RetryTaskMapStatus.RUNNING:
-                    return
                 self._futs.discard(_fut)
-                self._task_collector_gen.send(_fut)
+                if self._status is _RetryTaskMapStatus.RUNNING:
+                    try:
+                        self._task_collector_gen.send(_fut)
+                    except StopIteration:
+                        pass
 
             for _entry in self._tasks_list:
                 if self._status is not _RetryTaskMapStatus.RUNNING:

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -494,10 +494,16 @@ class OTAMetadata:
         self.image_rootfs_url = urljoin_ensure_base(
             self.url_base, f"{self._ota_metadata.rootfs_directory.strip('/')}/"
         )
-        self.image_compressed_rootfs_url = urljoin_ensure_base(
-            self.url_base,
-            f"{self._ota_metadata.compressed_rootfs_directory.strip('/')}/",
+        # NOTE: remember to handle old image that doesn't have compression
+        self.image_compressed_rootfs_url = (
+            urljoin_ensure_base(
+                self.url_base,
+                f"{self._ota_metadata.compressed_rootfs_directory.strip('/')}/",
+            )
+            if self._ota_metadata.compressed_rootfs_directory
+            else None
         )
+
         self.total_regular_size = self._ota_metadata.total_regular_size
         # download, parse and store ota metatfiles
         self._process_text_base_otameta_files()
@@ -615,7 +621,8 @@ class OTAMetadata:
         # v2 OTA image, with compression enabled
         # example: http://example.com/base_url/data.zstd/a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3.<compression_alg>
         if (
-            reg_inf.compressed_alg
+            self.image_compressed_rootfs_url
+            and reg_inf.compressed_alg
             and reg_inf.compressed_alg in cfg.SUPPORTED_COMPRESS_ALG
         ):
             return (


### PR DESCRIPTION
## Introduction
Perception ECU using BSP32.5 will have ubuntu 18.04.5, which have python3.8 in version 3.8.0. This version of python has a bug(https://bugs.python.org/issue39215), causing RetryTaskMap unable to work properly.
```
[2023-03-10 18:42:54,036][ERROR]-otaclient.app.common:_task_dispatcher:528,dispatcher failed! SystemError("no locals when loading 'Future'")
Traceback (most recent call last):
  File "/home/autoware/ota-client/otaclient/app/common.py", line 486, in _task_dispatcher
    def _done_cb(_fut: Future, /):
SystemError: no locals when loading 'Future'
```
This PR handles otaclient running on py3.8.0.

## Changes
1. remove type hint in `RetryTaskMap._task_dispatcher._done_cb`, minor update.
2. ota_metadata: minor fix to backward compatible with ota image without compression.