### PR TITLE
[Refactor] re-implement RetryTaskMap

### DIFF
--- a/otaclient/app/create_standby/rebuild_mode.py
+++ b/otaclient/app/create_standby/rebuild_mode.py
@@ -123,13 +123,14 @@ class RebuildMode(StandbySlotCreatorProtocol):
                 ),
                 executor=pool,
             )
-            for _is_successful, _entry, _fut in _mapper.map(
+            for _, task_result in _mapper.map(
                 self._process_regular,
                 self.delta_bundle.new_delta.items(),
             ):
-                if not _is_successful:
+                is_successful, entry, fut = task_result
+                if not is_successful:
                     logger.error(
-                        f"[process_regular] failed to process {_entry=}: {_fut=}"
+                        f"[process_regular] failed to process {entry=}: {fut=}"
                     )
             self.stats_collector.wait_staging()
 

--- a/otaclient/app/ota_client.py
+++ b/otaclient/app/ota_client.py
@@ -18,6 +18,7 @@ import json
 import time
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from json.decoder import JSONDecodeError
 from pathlib import Path
 from typing import Optional, Type, Iterator
@@ -34,7 +35,7 @@ from .errors import (
     OTAUpdateError,
 )
 from .boot_control import BootControllerProtocol
-from .common import RetryTaskMap
+from .common import RetryTaskMap, wait_with_backoff
 from .configs import config as cfg
 from .create_standby import StandbySlotCreatorProtocol
 from .downloader import (
@@ -207,18 +208,22 @@ class _OTAUpdater:
         _keep_failing_timer = time.time()
         with ThreadPoolExecutor(thread_name_prefix="downloading") as _executor:
             _mapper = RetryTaskMap(
-                _download_file,
-                download_list,
                 title="downloading_ota_files",
                 max_concurrent=cfg.MAX_CONCURRENT_DOWNLOAD_TASKS,
-                backoff_max=cfg.DOWNLOAD_GROUP_BACKOFF_MAX,
-                backoff_factor=cfg.DOWNLOAD_GROUP_BACKOFF_FACTOR,
+                retry_interval_f=partial(
+                    wait_with_backoff,
+                    _backoff_factor=cfg.DOWNLOAD_GROUP_BACKOFF_FACTOR,
+                    _backoff_max=cfg.DOWNLOAD_GROUP_BACKOFF_MAX,
+                ),
                 max_retry=0,  # NOTE: we use another strategy below
                 executor=_executor,
             )
-            for _exp, _entry, _stats in _mapper.execute():
+            for _is_successful, _entry, _fut in _mapper.map(
+                _download_file, download_list
+            ):
                 # task successfully finished
-                if not isinstance(_exp, Exception) and _stats:
+                if _is_successful:
+                    _stats = _fut.result()
                     self._update_stats_collector.report(_stats)
                     # reset the failing timer on one succeeded task
                     _keep_failing_timer = time.time()
@@ -227,7 +232,7 @@ class _OTAUpdater:
                 # task failed
                 # NOTE: for failed task, it must has retried <DOWNLOAD_RETRY>
                 #       time, so we manually create one download report
-                logger.debug(f"failed to download {_entry=}: {_exp!r}")
+                logger.debug(f"failed to download {_entry=}: {_fut}")
                 self._update_stats_collector.report(
                     RegInfProcessedStats(
                         op=RegProcessOperation.DOWNLOAD_ERROR_REPORT,

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -596,15 +596,16 @@ class OTAMetadata:
                 max_retry=0,  # NOTE: we use another strategy below
                 executor=_executor,
             )
-            for _is_successful, _entry, _fut in _mapper.map(
+            for _, task_result in _mapper.map(
                 _process_text_base_otameta_file,
                 self._ota_metadata.get_img_metafiles(),
             ):
-                if _is_successful:
+                is_successful, entry, fut = task_result
+                if is_successful:
                     _keep_failing_timer = time.time()
                     continue
 
-                logger.debug(f"metafile downloading failed: {_entry=}, {_fut=}")
+                logger.debug(f"metafile downloading failed: {entry=}, {fut=}")
                 if (
                     time.time() - _keep_failing_timer
                     > cfg.DOWNLOAD_GROUP_NO_SUCCESS_RETRY_TIMEOUT

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -309,11 +309,12 @@ class TestRetryTaskMap:
                     ),
                     max_retry=0,  # we are testing keep failing timeout here
                 )
-                for _is_successful, _, _ in _mapper.map(
+                for retry_round, task_result in _mapper.map(
                     self.workload_aways_failed, range(self.TASKS_COUNT)
                 ):
+                    is_successful, _, _ = task_result
                     # task successfully finished
-                    if _is_successful:
+                    if is_successful:
                         # reset the failing timer on one succeeded task
                         _keep_failing_timer = time.time()
                         continue
@@ -337,11 +338,12 @@ class TestRetryTaskMap:
                 ),
                 max_retry=0,  # we are testing keep failing timeout here
             )
-            for _is_successful, _, _ in _mapper.map(
+            for retry_round, task_result in _mapper.map(
                 self.workload_failed_and_then_succeed, range(self.TASKS_COUNT)
             ):
                 # task successfully finished
-                if _is_successful:
+                is_successful, _, _ = task_result
+                if is_successful:
                     # reset the failing timer on one succeeded task
                     _keep_failing_timer = time.time()
                     continue
@@ -363,11 +365,12 @@ class TestRetryTaskMap:
                 ),
                 max_retry=0,  # we are testing keep failing timeout here
             )
-            for _is_successful, _, _ in _mapper.map(
+            for retry_round, task_result in _mapper.map(
                 self.workload_succeed, range(self.TASKS_COUNT)
             ):
+                is_successful, _, _ = task_result
                 # task successfully finished
-                if _is_successful:
+                if is_successful:
                     # reset the failing timer on one succeeded task
                     _keep_failing_timer = time.time()
                     continue

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+from functools import partial
 import os
 import subprocess
 import time
@@ -26,7 +27,7 @@ from typing import Tuple
 
 from otaclient.app.common import (
     RetryTaskMap,
-    _RetryTaskMapErr,
+    RetryTaskMapInterrupted,
     copytree_identical,
     file_sha256,
     re_symlink_atomic,
@@ -34,6 +35,7 @@ from otaclient.app.common import (
     subprocess_call,
     subprocess_check_output,
     verify_file,
+    wait_with_backoff,
     write_str_to_file_sync,
 )
 from tests.utils import compare_dir
@@ -265,8 +267,8 @@ class _RetryTaskMapTestErr(Exception):
 
 class TestRetryTaskMap:
     WAIT_CONST = 100_000_000
-    TASKS_COUNT = 1000
-    MAX_CONCURRENT = 60
+    TASKS_COUNT = 2000
+    MAX_CONCURRENT = 128
     DOWNLOAD_GROUP_NO_SUCCESS_RETRY_TIMEOUT = 6  # seconds
     MAX_WAIT_BEFORE_SUCCESS = 10
 
@@ -297,20 +299,21 @@ class TestRetryTaskMap:
 
     def test_retry_keep_failing_timeout(self):
         _keep_failing_timer = time.time()
-        with pytest.raises(_RetryTaskMapErr):
+        with pytest.raises(RetryTaskMapInterrupted):
             with ThreadPoolExecutor() as pool:
                 _mapper = RetryTaskMap(
-                    self.workload_aways_failed,
-                    range(self.TASKS_COUNT),
                     max_concurrent=self.MAX_CONCURRENT,
                     executor=pool,
-                    backoff_max=1,
-                    backoff_factor=0.01,
+                    retry_interval_f=partial(
+                        wait_with_backoff, _backoff_factor=0.01, _backoff_max=1
+                    ),
                     max_retry=0,  # we are testing keep failing timeout here
                 )
-                for _exp, _, _ in _mapper.execute():
+                for _is_successful, _, _ in _mapper.map(
+                    self.workload_aways_failed, range(self.TASKS_COUNT)
+                ):
                     # task successfully finished
-                    if not isinstance(_exp, Exception):
+                    if _is_successful:
                         # reset the failing timer on one succeeded task
                         _keep_failing_timer = time.time()
                         continue
@@ -327,17 +330,18 @@ class TestRetryTaskMap:
         _keep_failing_timer = time.time()
         with ThreadPoolExecutor() as pool:
             _mapper = RetryTaskMap(
-                self.workload_failed_and_then_succeed,
-                range(self.TASKS_COUNT),
                 max_concurrent=self.MAX_CONCURRENT,
                 executor=pool,
-                backoff_max=1,
-                backoff_factor=0.1,
+                retry_interval_f=partial(
+                    wait_with_backoff, _backoff_factor=0.01, _backoff_max=1
+                ),
                 max_retry=0,  # we are testing keep failing timeout here
             )
-            for _exp, _, _ in _mapper.execute():
+            for _is_successful, _, _ in _mapper.map(
+                self.workload_failed_and_then_succeed, range(self.TASKS_COUNT)
+            ):
                 # task successfully finished
-                if not isinstance(_exp, Exception):
+                if _is_successful:
                     # reset the failing timer on one succeeded task
                     _keep_failing_timer = time.time()
                     continue
@@ -352,17 +356,18 @@ class TestRetryTaskMap:
         _keep_failing_timer = time.time()
         with ThreadPoolExecutor() as pool:
             _mapper = RetryTaskMap(
-                self.workload_succeed,
-                range(self.TASKS_COUNT),
                 max_concurrent=self.MAX_CONCURRENT,
                 executor=pool,
-                backoff_max=1,
-                backoff_factor=0.1,
+                retry_interval_f=partial(
+                    wait_with_backoff, _backoff_factor=0.01, _backoff_max=1
+                ),
                 max_retry=0,  # we are testing keep failing timeout here
             )
-            for _exp, _, _ in _mapper.execute():
+            for _is_successful, _, _ in _mapper.map(
+                self.workload_succeed, range(self.TASKS_COUNT)
+            ):
                 # task successfully finished
-                if not isinstance(_exp, Exception):
+                if _is_successful:
                     # reset the failing timer on one succeeded task
                     _keep_failing_timer = time.time()
                     continue


### PR DESCRIPTION
## Introduction
Previous implementation has a problem, it will hold all the resources related to failed task, even that retry round is finished, due to unexpected reference cycle.
This PR re-implements the `RetryTaskMap` to resolve the following issues & requirements:
- simplify the internal design and implementation.
- better memory efficiency, not consume all input iterable at first retry round.
- resolve memory leak due to reference cycle.
- better error handling on interruption/shutdown.
- caller has more control over the executing tasks.

NOTE: this PR is based on #205 .

## Example
```python
        with ThreadPoolExecutor() as pool:
            _mapper = RetryTaskMap(
                max_concurrent=<max_conccurent_tasks>,
                executor=pool,
                retry_interval_f=<Callable[[int], Any]>,
                max_retry=<max_retry>, 
            )
           # a tuple of bool indicates the task finished without exception or not, 
           # processed entry and Future of processed task will be returned.
            for retry_round, task_result in _mapper.map(
                <func>, <iterable>
            ):
                # task successfully finished
                _is_successful, _entry, _fut = task_result
                if _is_successful:
                    ... # logic on successful finished task
                else:
                    # logic on failed task
                    _fut: Future
                    _entry: Any
                    ...

                if <interrupt_condition>:
                    _mapper.shutdown() # force interrupt the running RetryTaskMap instance and raise RetryTaskMapInterrupted
```

## TODO

- [x] test files passed
- [x] confirm improvement comparing to previous implementation
- [x] VM test