### PR TITLE
[Fix&refine] new way to collect downloader stats, resolve edge condition on downloading breakout condition

### DIFF
--- a/otaclient/app/configs.py
+++ b/otaclient/app/configs.py
@@ -131,7 +131,7 @@ class BaseConfig(_InternalSettings):
     # DOWNLOAD_GROUP_NO_SUCCESS_RETRY_TIMEOUT time, failed the whole
     # download task group and raise NETWORK OTA error.
     MAX_CONCURRENT_DOWNLOAD_TASKS = 128
-    DOWNLOAD_GROUP_NO_SUCCESS_RETRY_TIMEOUT = 5 * 60  # seconds
+    DOWNLOAD_GROUP_INACTIVE_TIMEOUT = 5 * 60  # seconds
     DOWNLOAD_GROUP_BACKOFF_MAX = 12  # seconds
     DOWNLOAD_GROUP_BACKOFF_FACTOR = 1  # seconds
 

--- a/otaclient/app/configs.py
+++ b/otaclient/app/configs.py
@@ -133,7 +133,7 @@ class BaseConfig(_InternalSettings):
     MAX_CONCURRENT_DOWNLOAD_TASKS = 128
     DOWNLOAD_GROUP_NO_SUCCESS_RETRY_TIMEOUT = 5 * 60  # seconds
     DOWNLOAD_GROUP_BACKOFF_MAX = 12  # seconds
-    DOWNLOAD_GROUP_BACKOFF_FACTOR = 0.1  # seconds
+    DOWNLOAD_GROUP_BACKOFF_FACTOR = 1  # seconds
 
     # --- stats collector setting --- #
     STATS_COLLECT_INTERVAL = 1  # second

--- a/otaclient/app/downloader.py
+++ b/otaclient/app/downloader.py
@@ -291,6 +291,8 @@ class Downloader:
             except Empty:
                 pass
             self._downloaded_bytes += traffic_bytes
+        # force clear downloader_active flag
+        self._downloader_active.clear()
 
     def configure_proxies(self, _proxies: Dict[str, str], /):
         self._proxies = _proxies.copy()

--- a/otaclient/app/downloader.py
+++ b/otaclient/app/downloader.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import errno
 import os
 import requests
@@ -298,6 +299,7 @@ class Downloader:
         self._cookies = _cookies.copy()
 
     def shutdown(self):
+        """NOTE: the downloader instance cannot be reused after shutdown."""
         if not self.shutdowned.is_set():
             self.shutdowned.set()
             self._executor.shutdown()
@@ -445,6 +447,9 @@ class Downloader:
             A tuple of ints, which are error counts, real downloaded bytes and
                 the download time cost.
         """
+        if self.shutdowned.is_set():
+            raise ValueError("downloader already shutdowned.")
+
         return self._executor.submit(
             self._download_task,
             url,

--- a/otaclient/app/downloader.py
+++ b/otaclient/app/downloader.py
@@ -23,7 +23,7 @@ import requests.exceptions
 import urllib3.exceptions
 from abc import abstractmethod
 from concurrent.futures import ThreadPoolExecutor
-from queue import Empty, Full, Queue
+from queue import Empty, Queue
 from functools import partial
 from hashlib import sha256
 from pathlib import Path

--- a/otaclient/app/downloader.py
+++ b/otaclient/app/downloader.py
@@ -322,8 +322,6 @@ class Downloader:
         compression_alg: Optional[str] = None,
         use_http_if_proxy_set: bool = True,
     ) -> Tuple[int, int, int]:
-        _start_time = time.thread_time_ns()
-
         # special treatment for empty file
         if digest == self.EMPTY_STR_SHA256:
             if not (dst_p := Path(dst)).is_file():
@@ -427,8 +425,7 @@ class Downloader:
             logger.error(msg)
             raise HashVerificaitonError(url, dst, msg)
 
-        _end_time = time.thread_time_ns()
-        return _err_count, traffic_on_wire, _end_time - _start_time
+        return _err_count, traffic_on_wire, 0
 
     def download(
         self,
@@ -446,8 +443,8 @@ class Downloader:
         """Dispatcher for download tasks.
 
         Returns:
-            A tuple of ints, which are error counts, real downloaded bytes and
-                the download time cost.
+            A tuple of ints, which are error counts, real downloaded bytes
+                and a const 0.
         """
         if self.shutdowned.is_set():
             raise ValueError("downloader already shutdowned.")

--- a/otaclient/app/ota_client.py
+++ b/otaclient/app/ota_client.py
@@ -299,6 +299,9 @@ class _OTAUpdater:
             logger.error(f"failed to finish downloading files: {e!r}")
             raise NetworkError from e
 
+        # shutdown downloader on download finished
+        self._downloader.shutdown()
+
         # ------ in_update ------ #
         logger.info("start to apply changes to standby slot...")
         self.update_phase = UpdatePhase.APPLYING_UPDATE
@@ -435,6 +438,9 @@ class _OTAUpdater:
         update_progress.total_download_files_num = self.total_download_files_num
         update_progress.total_download_files_size = self.total_download_fiies_size
         update_progress.total_remove_files_num = self.total_remove_files_num
+        # downloaded bytes
+        update_progress.downloaded_bytes = self._downloader.downloaded_bytes
+
         # update other information
         update_progress.phase = self.update_phase
         update_progress.total_elapsed_time = wrapper.Duration.from_nanoseconds(

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -583,7 +583,6 @@ class OTAMetadata:
                 if _metafile.file == MetafilesV1.REGULAR_FNAME:
                     self.total_files_num = _count
 
-        keep_failing_timer = time.time()
         with ThreadPoolExecutor(thread_name_prefix="process_metafiles") as _executor:
             _mapper = RetryTaskMap(
                 title="process_metafiles",
@@ -601,17 +600,19 @@ class OTAMetadata:
                 self._ota_metadata.get_img_metafiles(),
             ):
                 is_successful, entry, fut = task_result
-                if is_successful or self._downloader.is_downloader_active:
-                    keep_failing_timer = time.time()
-                else:
-                    if (
-                        time.time() - keep_failing_timer
-                        > cfg.DOWNLOAD_GROUP_NO_SUCCESS_RETRY_TIMEOUT
-                    ):
-                        _mapper.shutdown()
+                if is_successful:
+                    continue
 
-                if not is_successful:
-                    logger.debug(f"metafile downloading failed: {entry=}, {fut=}")
+                # on task failed
+                logger.debug(f"metafile downloading failed: {entry=}, {fut=}")
+                if (
+                    int(time.time()) - self._downloader.last_active_timestamp
+                    > cfg.DOWNLOAD_GROUP_INACTIVE_TIMEOUT
+                ):
+                    logger.error(
+                        f"downloader becomes stuck for {cfg.DOWNLOAD_GROUP_INACTIVE_TIMEOUT=} seconds, abort"
+                    )
+                    _mapper.shutdown()
 
     # APIs
 

--- a/otaclient/app/update_stats.py
+++ b/otaclient/app/update_stats.py
@@ -157,9 +157,9 @@ class OTAUpdateStatsCollector:
                             staging_storage.downloaded_files_num += 1
                             staging_storage.downloaded_files_size += st.size
                             staging_storage.downloading_errors += st.download_errors
-                            staging_storage.downloading_elapsed_time.add_nanoseconds(
-                                st.elapsed_ns
-                            )
+                            # staging_storage.downloading_elapsed_time.add_nanoseconds(
+                            #     st.elapsed_ns
+                            # )
                             # as remote_delta, update processed_files_*
                             staging_storage.processed_files_num += 1
                             staging_storage.processed_files_size += st.size

--- a/otaclient/app/update_stats.py
+++ b/otaclient/app/update_stats.py
@@ -153,7 +153,7 @@ class OTAUpdateStatsCollector:
                         _op = st.op
                         if _op == RegProcessOperation.DOWNLOAD_REMOTE_COPY:
                             # update download specific fields
-                            staging_storage.downloaded_bytes += st.downloaded_bytes
+                            # staging_storage.downloaded_bytes += st.downloaded_bytes
                             staging_storage.downloaded_files_num += 1
                             staging_storage.downloaded_files_size += st.size
                             staging_storage.downloading_errors += st.download_errors

--- a/otaclient/app/update_stats.py
+++ b/otaclient/app/update_stats.py
@@ -94,23 +94,18 @@ class OTAUpdateStatsCollector:
             self.stop()
 
         with self._lock:
-            if self.terminated.is_set():
-                self.terminated.clear()
-                self._collector_thread = Thread(target=self.collector)
-                self._collector_thread.start()
-            else:
-                logger.warning("detect active collector, abort lauching new collector")
+            self.terminated.clear()
+            self._clear()
+            self._collector_thread = Thread(target=self.collector)
+            self._collector_thread.start()
 
     def stop(self):
         with self._lock:
-            if not self.terminated.is_set():
-                self.terminated.set()
-                if self._collector_thread is not None:
-                    # wait for the collector thread to stop
-                    self._collector_thread.join()
-                    self._collector_thread = None
-                # cleanup stats storage
-                self._clear()
+            self.terminated.set()
+            if self._collector_thread is not None:
+                # wait for the collector thread to stop
+                self._collector_thread.join()
+                self._collector_thread = None
 
     def get_snapshot(self) -> UpdateStatus:
         """Return a copy of statistics storage."""

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -305,7 +305,7 @@ class TestRetryTaskMap:
                     max_concurrent=self.MAX_CONCURRENT,
                     executor=pool,
                     retry_interval_f=partial(
-                        wait_with_backoff, _backoff_factor=0.01, _backoff_max=1
+                        wait_with_backoff, _backoff_factor=0.1, _backoff_max=1
                     ),
                     max_retry=0,  # we are testing keep failing timeout here
                 )
@@ -334,7 +334,7 @@ class TestRetryTaskMap:
                 max_concurrent=self.MAX_CONCURRENT,
                 executor=pool,
                 retry_interval_f=partial(
-                    wait_with_backoff, _backoff_factor=0.01, _backoff_max=1
+                    wait_with_backoff, _backoff_factor=0.1, _backoff_max=1
                 ),
                 max_retry=0,  # we are testing keep failing timeout here
             )
@@ -361,7 +361,7 @@ class TestRetryTaskMap:
                 max_concurrent=self.MAX_CONCURRENT,
                 executor=pool,
                 retry_interval_f=partial(
-                    wait_with_backoff, _backoff_factor=0.01, _backoff_max=1
+                    wait_with_backoff, _backoff_factor=0.1, _backoff_max=1
                 ),
                 max_retry=0,  # we are testing keep failing timeout here
             )

--- a/tests/test_create_standby.py
+++ b/tests/test_create_standby.py
@@ -14,6 +14,7 @@
 
 
 import shutil
+import time
 import typing
 import pytest
 from pathlib import Path
@@ -115,6 +116,7 @@ class Test_OTAupdate_with_create_standby_RebuildMode:
             cookies_json=r'{"test": "my-cookie"}',
             fsm=_ota_update_fsm,
         )
+        time.sleep(2)  # wait for downloader to record stats
 
         # ------ assertions ------ #
         # --- assert update finished
@@ -125,8 +127,8 @@ class Test_OTAupdate_with_create_standby_RebuildMode:
         assert _snapshot.processed_files_size
         assert _snapshot.downloaded_files_num
         assert _snapshot.downloaded_files_size
-        assert _snapshot.downloaded_bytes
-        assert _snapshot.downloading_elapsed_time.export_pb().ToNanoseconds()
+        # assert _snapshot.downloaded_bytes
+        # assert _snapshot.downloading_elapsed_time.export_pb().ToNanoseconds()
         assert _snapshot.update_applying_elapsed_time.export_pb().ToNanoseconds()
         # --- check slot creating result
         # NOTE: merge contents from slot_b_boot_dir to slot_b

--- a/tests/test_update_stats.py
+++ b/tests/test_update_stats.py
@@ -92,17 +92,17 @@ class TestOTAUpdateStatsCollector:
         # download operation
         assert _snapshot.downloaded_files_num == self.TOTAL_FILE_NUM // 3
         assert _snapshot.downloaded_files_size == self.TOTAL_SIZE // 3
-        assert (
-            _snapshot.downloading_elapsed_time.export_pb().ToNanoseconds()
-            == self.WORKLOAD_COUNT // 3
-        )
+        # NOTE: downloading_elapsed_time and downloaded_bytes is collected
+        #       by accessing the downloader's properties, so comment out the following
+        #       2 asserts.
+        # assert (
+        #     _snapshot.downloading_elapsed_time.export_pb().ToNanoseconds()
+        #     == self.WORKLOAD_COUNT // 3
+        # )
         # actual download_bytes is half of the file_size_processed_download to
         # simulate compression enabled scheme
-        assert _snapshot.downloaded_bytes == _snapshot.downloaded_files_size // 2
-        assert (
-            _snapshot.downloading_elapsed_time.export_pb().ToNanoseconds()
-            == self.WORKLOAD_COUNT // 3
-        )
+        # assert _snapshot.downloaded_bytes == _snapshot.downloaded_files_size // 2
+
         # prepare local copy operation
         assert (
             _snapshot.delta_generating_elapsed_time.export_pb().ToNanoseconds()


### PR DESCRIPTION
## Introduction
Previously, the downloading retry strategy(implemented by **RetryTaskMap** with **keep_failing_timer**) used by otaclient breaks out when **no more succeeded files keeps longer than <timeout_setting>**, there is a potential edge condition that all downloading threads are stuck by downloading large files, resulting in unwanted pre-mature breakout.

This PR fixes this edge condition by introducing another breakout condition, **no more traffic in downloader/downloader becomes inactive longer than \<limit\>**, and change the breakout logic.

## Inactive breakout logic
The download tasks group(outer for loop) has `last_active_timestamp`, which indicates the latest unix timestamp for latest activity(either a successful task, or traffic by downloader). 
If the download tasks group stalls(becomes inactive) longer than \<limit\>, the download tasks group will breakout.
`last_active_timestamp` will be updated by either a succeeded task, or downloader's `last_active_timestamp`, and the newer value will be used.

## Changes
1. **downloader**: now has 3 new properties: `downloaded_bytes`, `downloader_active_seconds` and `last_active_stamp`, these 3 properties are updated per second, and the stats updating starts from the downloader being initialized.
2. **otaclient status API** now report `downloaded_bytes(download_bytes in v1)`, `downloading_elapsed_time(elapsed_time_download in v1)` by accessing the corresponding properties of downloader.
3. **otaclient.download_files & ota_metadata._process_text_base_otameta_file** now have new breakout logic on exceeded inactive duration.
4. **update_stats**: do not update `downloaded_bytes` and `downloading_elapsed_time` anymore, these fields are updated by otaclient status API handler now.

## Other changes
1. fix/update test files accordingly.
2. configs: change `DOWNLOAD_GROUP_BACKOFF_FACTOR` from 0.1 to 1, each retry round should have longer initial interval.
3. configs: rename `DOWNLOAD_GROUP_NO_SUCCESS_RETRY_TIMEOUT` -> `DOWNLOAD_GROUP_INACTIVE_TIMEOUT`.

## Ticket
fix: [[OTA] downloader/RetryTaskMap: edge condition related to 5mins keep_failing breakout](https://tier4.atlassian.net/browse/T4PB-27222)
