### PR TITLE
[Fix] delta calculating: verify file when copying from active slot to standby slot

### DIFF
--- a/otaclient/app/common.py
+++ b/otaclient/app/common.py
@@ -593,3 +593,7 @@ class RetryTaskMap(Generic[_T]):
         """
         self._task_executor = self._execute(_func, _iter)
         return self._task_executor
+
+
+def create_tmp_fname(prefix="tmp", length=6, sep="_") -> str:
+    return f"{prefix}{sep}{os.urandom(length).hex()}"

--- a/otaclient/app/create_standby/common.py
+++ b/otaclient/app/create_standby/common.py
@@ -258,7 +258,7 @@ class DeltaGenerator:
         self._new = RegularDelta()
         self._rm: List[str] = []
         self._new_dirs: OrderedDict[DirectoryInf, None] = OrderedDict()
-        self._new_hash_list: Set[bytes] = set()
+        self._new_hash_size_dict: Dict[bytes, int] = {}
         self._download_list: List[RegularInf] = []
 
         self._stats_collector = stats_collector
@@ -269,14 +269,34 @@ class DeltaGenerator:
         self.total_download_files_size = 0
 
     def _prepare_local_copy_from_active_slot(
-        self, fpath: Path, *, _hash: Optional[str] = None
+        self,
+        fpath: Path,
+        *,
+        expected_hash: Optional[str] = None,
     ) -> None:
         """Hash(and verify the file) and prepare a copy for it in standby slot.
 
+        Params:
+            fpath: the path to the file to be verified
+            expected_hash: (optional) if we have the information for this file
+                (by stored OTA image meta for active slot), use it make the
+                verification process faster.
+
         NOTE: verify the file before copying to the standby slot!
         """
-        if _hash and _hash not in self._new_hash_list:
-            return  # skip uneeded/already prepared local copy
+        # if we have information related to this file in advance(with saved
+        #   OTA image meta for the active slot), use this information to
+        #   pre-check the file.
+        if expected_hash:
+            if expected_hash not in self._new_hash_size_dict:
+                return  # skip uneeded/already prepared local copy
+            # check file size with size information
+            try:
+                expected_size = self._new_hash_size_dict[expected_hash]
+                if expected_size and expected_size != fpath.stat().st_size:
+                    return
+            except KeyError:
+                pass
 
         start_time = time.thread_time_ns()
         tmp_f = self._local_copy_dir / create_tmp_fname()
@@ -287,12 +307,12 @@ class DeltaGenerator:
                     hash_f.update(chunk)
                     tmp_dst.write(chunk)
             hash_value = hash_f.hexdigest()
-            if _hash and _hash != hash_value:
+            if expected_hash and expected_hash != hash_value:
                 return  # skip invalid file
 
             # this tmp is valid, use it as local copy
             try:  # remove from new_hash_list to mark this hash as prepared
-                self._new_hash_list.remove(hash_f.digest())
+                self._new_hash_size_dict.pop(hash_f.digest())
             except KeyError:
                 return  # this hash has already been prepared by other thread
             tmp_f.rename(self._local_copy_dir / hash_value)
@@ -413,12 +433,12 @@ class DeltaGenerator:
         # the hash in the self._hash_set after local delta preparation representing
         # the file we need to download from remote
         for _hash, _reginf_set in self._new.items():
-            if _hash in self._new_hash_list:
+            if _hash in self._new_hash_size_dict:
                 # pick one entry from the reginf set for downloading
                 _entry = next(iter(_reginf_set))
                 self._download_list.append(_entry)
                 self.total_download_files_size += _entry.size if _entry.size else 0
-        self._new_hash_list.clear()
+        self._new_hash_size_dict.clear()
 
     # API
 
@@ -427,10 +447,11 @@ class DeltaGenerator:
         for _dir in self._ota_metadata.iter_metafile(MetafilesV1.DIRECTORY_FNAME):
             self._new_dirs[_dir] = None
         # pre-load from new regulars.txt
+        _entry: RegularInf
         for _entry in self._ota_metadata.iter_metafile(MetafilesV1.REGULAR_FNAME):
             self.total_regulars_num += 1
             self._new.add_entry(_entry)
-            self._new_hash_list.add(_entry.sha256hash)
+            self._new_hash_size_dict[_entry.sha256hash] = _entry.size
 
         # generate delta and prepare files
         self._process_delta_src()

--- a/otaclient/app/ota_client.py
+++ b/otaclient/app/ota_client.py
@@ -557,6 +557,7 @@ class OTAClient(OTAClientProtocol):
                 )
                 self.last_failure_type = wrapper.FailureType.NO_FAILURE
                 self.last_failure_reason = ""
+                self.last_failure_traceback = ""
                 self.live_ota_status.set_ota_status(wrapper.StatusOta.UPDATING)
                 self._update_executor.execute(version, url_base, cookies_json, fsm=fsm)
             except OTAUpdateError as e:
@@ -580,6 +581,7 @@ class OTAClient(OTAClientProtocol):
                 )
                 self.last_failure_type = wrapper.FailureType.NO_FAILURE
                 self.last_failure_reason = ""
+                self.last_failure_traceback = ""
                 self.live_ota_status.set_ota_status(wrapper.StatusOta.ROLLBACKING)
                 self._rollback_executor.execute()
             # silently ignore overlapping request


### PR DESCRIPTION
## Introduction
Previously, in `DELTA_CALCULATING` OTA stage, the local copy is prepared after the file in active slot is verified, there is chance that the file is updated after the hash verification. This PR fixes this edge condition by verifying file during the copy. 

## Other change
1. create_standby: when preparing local copy, also take size information into account if the information is available(by saved active slot's OTA image meta).
1. otaclient: fix not resetting `last_failure_traceback` when new update/rollback request is received.
1. common: add a helper method `create_tmp_fname`.

## Ticket
[T4PB-27531](https://tier4.atlassian.net/browse/T4PB-27531)

[T4PB-27531]: https://tier4.atlassian.net/browse/T4PB-27531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ