### PR TITLE
[Refine] otaproxy: suppress flooding loggings when network disconnected

### DIFF
--- a/otaclient/_utils/__init__.py
+++ b/otaclient/_utils/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/otaclient/_utils/logging.py
+++ b/otaclient/_utils/logging.py
@@ -61,9 +61,3 @@ class BurstSuppressFilter(logging.Filter):
             )
             self._round_warned = True
         return False
-
-
-def set_loglevel(level: int, /, name: str = __name__):
-    if not name.startswith(__name__):
-        return  # reject out-of-package logging setting
-    logging.getLogger(name).setLevel(level)

--- a/otaclient/_utils/logging.py
+++ b/otaclient/_utils/logging.py
@@ -1,0 +1,69 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import logging
+import itertools
+import time
+from typing import Optional
+
+
+class BurstSuppressFilter(logging.Filter):
+    def __init__(
+        self,
+        name: str,
+        burst_max: int,
+        burst_round_length: int,
+        upper_logger_name: Optional[str] = None,
+    ) -> None:
+        self.name = name
+        self.upper_logger_name = upper_logger_name
+        self.round_length = burst_round_length
+        self.burst_max = burst_max
+        # for each round
+        self._round_logging_count = itertools.count()
+        self._round_start = 0
+        self._round_reach_burst_limit = False
+        self._round_warned = False
+
+    def filter(self, _: logging.LogRecord) -> bool:
+        upper_logger = logging.getLogger(self.upper_logger_name)
+        if (cur_timestamp := int(time.time())) > self._round_start + self.round_length:
+            if self._round_warned:
+                upper_logger.warning(
+                    f"{next(self._round_logging_count)-1} lines of logging suppressed for logger {self.name} "
+                    f"from {self._round_start} to {self._round_start+self.round_length} "
+                )
+            # reset logging round
+            self._round_start = cur_timestamp
+            self._round_reach_burst_limit = self._round_warned = False
+            self._round_logging_count = itertools.count(start=2)
+            return True
+
+        if next(self._round_logging_count) <= self.burst_max:
+            return True
+
+        if not self._round_warned:
+            upper_logger.warning(
+                f"logging suppressed for {self.name} until {self._round_start + self.round_length}: "
+                f"exceed burst_limit={self.burst_max}"
+            )
+            self._round_warned = True
+        return False
+
+
+def set_loglevel(level: int, /, name: str = __name__):
+    if not name.startswith(__name__):
+        return  # reject out-of-package logging setting
+    logging.getLogger(name).setLevel(level)

--- a/otaclient/ota_proxy/ota_cache.py
+++ b/otaclient/ota_proxy/ota_cache.py
@@ -1058,11 +1058,9 @@ class OTACache:
                     session=self._session,
                     upper_proxy=self._upper_proxy,
                 )
-            except Exception as e:
-                _err_msg = f"failed to open remote connection for {raw_url=}: {e!r}"
-                logger.debug(_err_msg)
+            except Exception:
                 await _tracker.provider_on_failed()
-                raise CacheStreamingFailed(_err_msg) from e
+                raise
 
             return await RemoteOTAFile(
                 fd=_remote_fd,

--- a/tests/test__utils/test_logging.py
+++ b/tests/test__utils/test_logging.py
@@ -1,0 +1,51 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import logging
+import time
+from pytest import LogCaptureFixture
+
+from otaclient._utils import logging as _logging
+
+
+def test_BurstSuppressFilter(caplog: LogCaptureFixture):
+    logger_name = "test_BurstSuppressFilter"
+    logger = logging.getLogger(logger_name)
+    burst_round_length = 1
+    logger.addFilter(
+        _logging.BurstSuppressFilter(
+            logger_name,
+            burst_max=1,
+            burst_round_length=burst_round_length,
+        )
+    )
+
+    # test loggging suppressing
+    # NOTE: outer loop ensures that suppression only works
+    #       within each burst_round, and should be refresed
+    #       in new round.
+    for _ in range(2):
+        for idx in range(2000):
+            logger.error(idx)
+        time.sleep(burst_round_length * 2)
+        logger.error("burst_round end")
+
+        # the four logging lines are:
+        #   1. logger.error(idx) # idx==0
+        #   2. a warning of exceeded loggings are suppressed
+        #   3. a warning of how many loggings are suppressed
+        #   4. logger.error("burst_round end")
+        assert len(caplog.records) <= 4
+        caplog.clear()


### PR DESCRIPTION
## Introduction
otaproxy will log errors when any request cannot be satisfied, in normal situation it is fine, but when network is disconnected, connection error loggings will flood, which is unwanted. 
This PR introduces a log filter that can suppress exceeding loggings to prevent flooding, and we define a dedicated logger only for logging connection errors.

## Changes
1. utils.logging: introduce new module, and define `BurstSuppressFilter`.
2. otaproxy.server_app: suppress connection error logging(max 6 lines per 30 seconds).
3. otaproxy.ota_cache: expose aiohttp connection errors to upper caller(server_app).
4. implement test files for utils.logging.

## How it looks like
```
[2023-04-12 16:16:08,659][INFO]-otaclient.app.ota_client:_update_standby_slot:256,start to download needed files...total_download_files_size=20,703,405,289bytes
[2023-04-12 16:16:09,630][ERROR]-otaclient.ota_proxy.server_app.connection_err:_pull_data_and_send:228,request for url='http://10.0.0.1:8443/data/home/autoware/.ansible/collections/ansible_collections/autoware/dev_env/roles/pacmod/meta/main.yaml' failed due to connection error: ClientConnectorError(ConnectionKey(host='10.0.0.1', port=8443, is_ssl=True, ssl=False, proxy=URL(''), proxy_auth=None, proxy_headers_hash=None), ConnectionRefusedError(111, 'Connection refused'))
[2023-04-12 16:16:09,778][ERROR]-otaclient.ota_proxy.server_app.connection_err:_pull_data_and_send:228,request for url='http://10.0.0.1:8443/data/home/autoware/.ansible/collections/ansible_collections/autoware/dev_env/roles/pacmod/meta/main.yaml' failed due to connection error: ClientConnectorError(ConnectionKey(host='10.0.0.1', port=8443, is_ssl=True, ssl=False, proxy=URL(''), proxy_auth=None, proxy_headers_hash=None), ConnectionRefusedError(111, 'Connection refused'))
[2023-04-12 16:16:09,999][ERROR]-otaclient.ota_proxy.server_app.connection_err:_pull_data_and_send:228,request for url='http://10.0.0.1:8443/data/home/autoware/.ansible/collections/ansible_collections/autoware/dev_env/roles/pacmod/meta/main.yaml' failed due to connection error: ClientConnectorError(ConnectionKey(host='10.0.0.1', port=8443, is_ssl=True, ssl=False, proxy=URL(''), proxy_auth=None, proxy_headers_hash=None), ConnectionRefusedError(111, 'Connection refused'))
[2023-04-12 16:16:10,420][ERROR]-otaclient.ota_proxy.server_app.connection_err:_pull_data_and_send:228,request for url='http://10.0.0.1:8443/data/home/autoware/.ansible/collections/ansible_collections/autoware/dev_env/roles/pacmod/meta/main.yaml' failed due to connection error: ClientConnectorError(ConnectionKey(host='10.0.0.1', port=8443, is_ssl=True, ssl=False, proxy=URL(''), proxy_auth=None, proxy_headers_hash=None), ConnectionRefusedError(111, 'Connection refused'))
[2023-04-12 16:16:12,854][ERROR]-otaclient.ota_proxy.server_app.connection_err:_pull_data_and_send:228,request for url='http://10.0.0.1:8443/data/home/autoware/autoware.proj/install/tier4_simulator_launch/share/colcon-core/packages/tier4_simulator_launch' failed due to connection error: ClientConnectorError(ConnectionKey(host='10.0.0.1', port=8443, is_ssl=True, ssl=False, proxy=URL(''), proxy_auth=None, proxy_headers_hash=None), ConnectionRefusedError(111, 'Connection refused'))
[2023-04-12 16:16:12,870][ERROR]-otaclient.ota_proxy.server_app.connection_err:_pull_data_and_send:228,request for url='http://10.0.0.1:8443/data/home/autoware/autoware.proj/install/tier4_simulator_launch/share/colcon-core/packages/tier4_simulator_launch' failed due to connection error: ClientConnectorError(ConnectionKey(host='10.0.0.1', port=8443, is_ssl=True, ssl=False, proxy=URL(''), proxy_auth=None, proxy_headers_hash=None), ConnectionRefusedError(111, 'Connection refused'))
[2023-04-12 16:16:13,083][WARNING]-otaclient.ota_proxy.server_app:filter:58,logging suppressed for otaclient.ota_proxy.server_app.connection_err until 1681283799: exceed burst_limit=6
[2023-04-12 16:16:40,049][WARNING]-otaclient.ota_proxy.server_app:filter:44,1001 lines of logging suppressed for logger otaclient.ota_proxy.server_app.connection_err from 1681283769 to 1681283799 
[2023-04-12 16:16:40,049][ERROR]-otaclient.ota_proxy.server_app.connection_err:_pull_data_and_send:228,request for url='http://10.0.0.1:8443/data/home/autoware/autoware.proj/src/autoware/universe/control/pure_pursuit/include/pure_pursuit/util/planning_utils.hpp' failed due to connection error: ClientConnectorError(ConnectionKey(host='10.0.0.1', port=8443, is_ssl=True, ssl=False, proxy=URL(''), proxy_auth=None, proxy_headers_hash=None), ConnectionRefusedError(111, 'Connection refused'))
[2023-04-12 16:16:40,050][ERROR]-otaclient.ota_proxy.server_app.connection_err:_pull_data_and_send:228,request for url='http://10.0.0.1:8443/data/home/autoware/autoware.proj/install/pure_pursuit/include/pure_pursuit/pure_pursuit.hpp' failed due to connection error: ClientConnectorError(ConnectionKey(host='10.0.0.1', port=8443, is_ssl=True, ssl=False, proxy=URL(''), proxy_auth=None, proxy_headers_hash=None), ConnectionRefusedError(111, 'Connection refused'))
[2023-04-12 16:16:40,052][ERROR]-otaclient.ota_proxy.server_app.connection_err:_pull_data_and_send:228,request for url='http://10.0.0.1:8443/data/home/autoware/autoware.proj/src/autoware/universe/control/pure_pursuit/include/pure_pursuit/pure_pursuit_viz.hpp' failed due to connection error: ClientConnectorError(ConnectionKey(host='10.0.0.1', port=8443, is_ssl=True, ssl=False, proxy=URL(''), proxy_auth=None, proxy_headers_hash=None), ConnectionRefusedError(111, 'Connection refused'))
[2023-04-12 16:16:40,185][ERROR]-otaclient.ota_proxy.server_app.connection_err:_pull_data_and_send:228,request for url='http://10.0.0.1:8443/data/home/autoware/autoware.proj/install/pure_pursuit/include/pure_pursuit/util/tf_utils.hpp' failed due to connection error: ClientConnectorError(ConnectionKey(host='10.0.0.1', port=8443, is_ssl=True, ssl=False, proxy=URL(''), proxy_auth=None, proxy_headers_hash=None), ConnectionRefusedError(111, 'Connection refused'))
[2023-04-12 16:16:40,204][ERROR]-otaclient.ota_proxy.server_app.connection_err:_pull_data_and_send:228,request for url='http://10.0.0.1:8443/data/home/autoware/autoware.proj/install/pure_pursuit/include/pure_pursuit/util/interpolate.hpp' failed due to connection error: ClientConnectorError(ConnectionKey(host='10.0.0.1', port=8443, is_ssl=True, ssl=False, proxy=URL(''), proxy_auth=None, proxy_headers_hash=None), ConnectionRefusedError(111, 'Connection refused'))
[2023-04-12 16:16:40,208][ERROR]-otaclient.ota_proxy.server_app.connection_err:_pull_data_and_send:228,request for url='http://10.0.0.1:8443/data/home/autoware/autoware.proj/src/autoware/universe/control/pure_pursuit/include/pure_pursuit/util/marker_helper.hpp' failed due to connection error: ClientConnectorError(ConnectionKey(host='10.0.0.1', port=8443, is_ssl=True, ssl=False, proxy=URL(''), proxy_auth=None, proxy_headers_hash=None), ConnectionRefusedError(111, 'Connection refused'))
[2023-04-12 16:16:40,209][WARNING]-otaclient.ota_proxy.server_app:filter:58,logging suppressed for otaclient.ota_proxy.server_app.connection_err until 1681283830: exceed burst_limit=6
[2023-04-12 16:17:11,134][WARNING]-otaclient.ota_proxy.server_app:filter:44,1264 lines of logging suppressed for logger otaclient.ota_proxy.server_app.connection_err from 1681283800 to 1681283830 
[2023-04-12 16:17:11,133][ERROR]-otaclient.ota_proxy.server_app.connection_err:_pull_data_and_send:228,request for url='http://10.0.0.1:8443/data/home/autoware/autoware.proj/src/autoware/universe/localization/gyro_odometer/CMakeLists.txt' failed due to connection error: ClientConnectorError(ConnectionKey(host='10.0.0.1', port=8443, is_ssl=True, ssl=False, proxy=URL(''), proxy_auth=None, proxy_headers_hash=None), ConnectionRefusedError(111, 'Connection refused'))
[2023-04-12 16:17:11,135][ERROR]-otaclient.ota_proxy.server_app.connection_err:_pull_data_and_send:228,request for url='http://10.0.0.1:8443/data/home/autoware/autoware.proj/install/gyro_odometer/share/gyro_odometer/launch/gyro_odometer.launch.xml' failed due to connection error: ClientConnectorError(ConnectionKey(host='10.0.0.1', port=8443, is_ssl=True, ssl=False, proxy=URL(''), proxy_auth=None, proxy_headers_hash=None), ConnectionRefusedError(111, 'Connection refused'))
[2023-04-12 16:17:11,136][ERROR]-otaclient.ota_proxy.server_app.connection_err:_pull_data_and_send:228,request for url='http://10.0.0.1:8443/data/home/autoware/autoware.proj/install/gyro_odometer/include/gyro_odometer/gyro_odometer_core.hpp' failed due to connection error: ClientConnectorError(ConnectionKey(host='10.0.0.1', port=8443, is_ssl=True, ssl=False, proxy=URL(''), proxy_auth=None, proxy_headers_hash=None), ConnectionRefusedError(111, 'Connection refused'))
[2023-04-12 16:17:11,137][ERROR]-otaclient.ota_proxy.server_app.connection_err:_pull_data_and_send:228,request for url='http://10.0.0.1:8443/data/home/autoware/autoware.proj/src/autoware/universe/localization/gyro_odometer/README.md' failed due to connection error: ClientConnectorError(ConnectionKey(host='10.0.0.1', port=8443, is_ssl=True, ssl=False, proxy=URL(''), proxy_auth=None, proxy_headers_hash=None), ConnectionRefusedError(111, 'Connection refused'))
[2023-04-12 16:17:11,137][ERROR]-otaclient.ota_proxy.server_app.connection_err:_pull_data_and_send:228,request for url='http://10.0.0.1:8443/data/home/autoware/autoware.proj/src/autoware/universe/localization/gyro_odometer/src/gyro_odometer_core.cpp' failed due to connection error: ClientConnectorError(ConnectionKey(host='10.0.0.1', port=8443, is_ssl=True, ssl=False, proxy=URL(''), proxy_auth=None, proxy_headers_hash=None), ConnectionRefusedError(111, 'Connection refused'))
[2023-04-12 16:17:11,140][ERROR]-otaclient.ota_proxy.server_app.connection_err:_pull_data_and_send:228,request for url='http://10.0.0.1:8443/data/home/autoware/autoware.proj/src/autoware/universe/localization/initial_pose_button_panel/src/initial_pose_button_panel.cpp' failed due to connection error: ClientConnectorError(ConnectionKey(host='10.0.0.1', port=8443, is_ssl=True, ssl=False, proxy=URL(''), proxy_auth=None, proxy_headers_hash=None), ConnectionRefusedError(111, 'Connection refused'))
[2023-04-12 16:17:11,145][WARNING]-otaclient.ota_proxy.server_app:filter:58,logging suppressed for otaclient.ota_proxy.server_app.connection_err until 1681283861: exceed burst_limit=6
```