### PR TITLE
[Fix] downloader: fix potential download_bytes incorrect record

### DIFF
--- a/otaclient/app/downloader.py
+++ b/otaclient/app/downloader.py
@@ -29,21 +29,17 @@ from hashlib import sha256
 from os import PathLike
 from pathlib import Path
 from typing import (
-    IO,
     Any,
-    ByteString,
     Callable,
     Dict,
     Iterator,
     Optional,
     Protocol,
     Tuple,
-    Union,
 )
 from requests.adapters import HTTPAdapter
 from urllib.parse import urlsplit
 from urllib3.util.retry import Retry
-from urllib3.response import HTTPResponse
 
 from .configs import config as cfg
 from .common import OTAFileCacheControl, wait_with_backoff

--- a/otaclient/app/downloader.py
+++ b/otaclient/app/downloader.py
@@ -386,6 +386,11 @@ class Downloader:
                             _traffic_on_wire - traffic_on_wire
                         )
                         traffic_on_wire = _traffic_on_wire
+                    # double check the wrapper's bytes_read in case we left anything
+                    self._traffic_report_que.put_nowait(
+                        wrapped_resp.tell() - traffic_on_wire
+                    )
+                    traffic_on_wire = wrapped_resp.tell()
                 # un-compressed file
                 else:
                     for data_chunk in resp.iter_content(chunk_size=self.CHUNK_SIZE):

--- a/otaclient/app/downloader.py
+++ b/otaclient/app/downloader.py
@@ -258,11 +258,6 @@ class Downloader:
             threading.get_native_id()
         ] = threading.Event()
 
-    @property
-    def _session(self) -> requests.Session:
-        """A thread-local private session."""
-        return self._local.session
-
     def _get_decompressor(
         self, compression_alg: Any
     ) -> Optional[DecompressionAdapterProtocol]:
@@ -359,7 +354,7 @@ class Downloader:
         # flag this thread as actively downloading thread
         active_flag = self._downloading_thread_active_flag[threading.get_native_id()]
         try:
-            with self._session.get(
+            with self._local.session.get(
                 url,
                 stream=True,
                 proxies=_proxies,


### PR DESCRIPTION
## Introduction
Starts from introducing compression support for OTA image, `download_bytes` record when downloading compressed OTA file is done by querying raw response(which is `urllib3.response.HTTPResponse`) `tell` method. However, there is report that indicates `download_bytes` record is not correct in some case. 
This PR introduces another mechanism, which collects the `download_bytes` for each downloading task by our code instead of using raw response' `tell` method.

## Mechanism
A new `HTTPResponseWrapper` is introduced, which wrap around the raw response `read` method. This method collects the actual number of bytes read from the underlying raw response object. We use this wrapper to get the actual bytes read from raw response instead of using raw response's tell method.

## Ticket
https://tier4.atlassian.net/browse/RT4-4198