### PR TITLE
[Refinement] refinement related to otaproxy launching

### DIFF
--- a/otaclient/ota_proxy/__init__.py
+++ b/otaclient/ota_proxy/__init__.py
@@ -98,7 +98,7 @@ def subprocess_start_otaproxy(*args, **kwargs) -> SpawnProcess:
     mp_ctx = multiprocessing.get_context("spawn")
     otaproxy_subprocess = mp_ctx.Process(
         target=partial(_subprocess_main, *args, **kwargs),
-        daemon=True,  # kill otaproxy if otaclient exists
+        daemon=True,  # kill otaproxy if the parent process exists
     )
     otaproxy_subprocess.start()
     return otaproxy_subprocess

--- a/otaclient/ota_proxy/__init__.py
+++ b/otaclient/ota_proxy/__init__.py
@@ -13,9 +13,127 @@
 # limitations under the License.
 
 
+import asyncio
+import logging
+import multiprocessing
+from functools import partial
+from multiprocessing.context import SpawnProcess
+from pathlib import Path
+from typing import Callable
+
 from .cache_control import OTAFileCacheControl
 from .server_app import App
 from .ota_cache import OTACache, OTACacheScrubHelper
 from .config import config
 
-__all__ = ("App", "OTACache", "OTACacheScrubHelper", "OTAFileCacheControl", "config")
+logger = logging.getLogger(__name__)
+
+
+__all__ = (
+    "App",
+    "OTACache",
+    "OTACacheScrubHelper",
+    "OTAFileCacheControl",
+    "config",
+    "subprocess_start_otaproxy",
+)
+
+
+def _subprocess_main(
+    host: str,
+    port: int,
+    *,
+    init_cache: bool,
+    cache_dir: str,
+    cache_db_f: str,
+    upper_proxy: str,
+    enable_cache: bool,
+    enable_https: bool,
+    subprocess_init: Callable,
+):
+    import uvloop
+
+    # ------ pre-start callable ------ #
+    subprocess_init()
+    # ------ scrub cache folder if cache re-use is possible ------ #
+    should_init_cache = (
+        init_cache or not Path(cache_dir).is_dir() or not Path(cache_db_f).is_file()
+    )
+
+    if not should_init_cache:
+        scrub_helper = OTACacheScrubHelper(cache_db_f, cache_dir)
+        try:
+            scrub_helper.scrub_cache()
+        except Exception as e:
+            logger.error(f"scrub cache failed, force init: {e!r}")
+            should_init_cache = True
+        finally:
+            del scrub_helper
+
+    uvloop.install()
+    asyncio.run(
+        run_otaproxy(
+            host=host,
+            port=port,
+            cache_dir=cache_dir,
+            cache_db_f=cache_db_f,
+            enable_cache=enable_cache,
+            upper_proxy=upper_proxy,
+            enable_https=enable_https,
+            init_cache=should_init_cache,
+        )
+    )
+
+
+def subprocess_start_otaproxy(*args, **kwargs) -> SpawnProcess:
+    """Helper method to launch otaproxy in subprocess.
+
+    This method works like a wrapper and passthrough all args and kwargs
+    to the _subprocess_main function, and then execute the function in
+    a subprocess.
+    check _subprocess_main function for more details.
+    """
+
+    # run otaproxy in async loop in new subprocess
+    mp_ctx = multiprocessing.get_context("spawn")
+    otaproxy_subprocess = mp_ctx.Process(
+        target=partial(_subprocess_main, *args, **kwargs),
+        daemon=True,  # kill otaproxy if otaclient exists
+    )
+    otaproxy_subprocess.start()
+    return otaproxy_subprocess
+
+
+async def run_otaproxy(
+    host: str,
+    port: int,
+    *,
+    init_cache: bool,
+    cache_dir: str,
+    cache_db_f: str,
+    upper_proxy: str,
+    enable_cache: bool,
+    enable_https: bool,
+):
+    import uvicorn
+    from . import App, OTACache
+
+    _ota_cache = OTACache(
+        base_dir=cache_dir,
+        db_file=cache_db_f,
+        cache_enabled=enable_cache,
+        upper_proxy=upper_proxy,
+        enable_https=enable_https,
+        init_cache=init_cache,
+    )
+    _config = uvicorn.Config(
+        App(_ota_cache),
+        host=host,
+        port=port,
+        log_level="error",
+        lifespan="on",
+        loop="uvloop",
+        http="h11",
+    )
+    _server = uvicorn.Server(_config)
+    await _server.serve()

--- a/otaclient/ota_proxy/__main__.py
+++ b/otaclient/ota_proxy/__main__.py
@@ -18,6 +18,9 @@ import asyncio
 import logging
 import uvloop
 
+from . import run_otaproxy
+from .config import config as cfg
+
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
@@ -51,30 +54,29 @@ if __name__ == "__main__":
         action="store_true",
         default=False,
     )
+    parser.add_argument(
+        "--cache-dir",
+        helper="where to store the cache entries",
+        default=cfg.BASE_DIR,
+    )
+    parser.add_argument(
+        "--cache-db-file",
+        helper="the location of cache db sqlite file",
+        default=cfg.DB_FILE,
+    )
     args = parser.parse_args()
 
-    async def _launch_server():
-        import uvicorn
-        from . import App, OTACache
-
-        _ota_cache = OTACache(
-            cache_enabled=args.enable_cache,
+    logger.info(f"launch ota_proxy at {args.host}:{args.port}")
+    uvloop.install()
+    asyncio.run(
+        run_otaproxy(
+            host=args.host,
+            port=args.port,
+            cache_dir=args.cache_dir,
+            cache_db_f=args.cache_db_file,
+            enable_cache=args.enable_cache,
             upper_proxy=args.upper_proxy,
             enable_https=args.enable_https,
             init_cache=args.init_cache,
         )
-        _config = uvicorn.Config(
-            App(_ota_cache),
-            host=args.host,
-            port=args.port,
-            log_level="error",
-            lifespan="on",
-            loop="uvloop",
-            http="h11",
-        )
-        _server = uvicorn.Server(_config)
-        await _server.serve()
-
-    logger.info(f"launch ota_proxy at {args.host}:{args.port}")
-    uvloop.install()
-    asyncio.run(_launch_server())
+    )

--- a/tests/test_ota_proxy/test_subprocess_launch_otaproxy.py
+++ b/tests/test_ota_proxy/test_subprocess_launch_otaproxy.py
@@ -1,0 +1,51 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import time
+from functools import partial
+from pathlib import Path
+from otaclient.ota_proxy import subprocess_start_otaproxy
+
+
+def _subprocess_init(_sentinel_file):
+    Path(_sentinel_file).touch()
+
+
+def test_subprocess_start_otaproxy(tmp_path: Path):
+    # --- setup --- #
+    (ota_cache_dir := tmp_path / "ota-cache").mkdir(exist_ok=True)
+    ota_cache_db = ota_cache_dir / "cache_db"
+    subprocess_init_sentinel = tmp_path / "otaproxy_started"
+
+    # --- execution --- #
+    otaproxy_subprocess = subprocess_start_otaproxy(
+        host="127.0.0.1",
+        port=8082,
+        init_cache=True,
+        cache_dir=str(ota_cache_dir),
+        cache_db_f=str(ota_cache_db),
+        upper_proxy="",
+        enable_cache=True,
+        enable_https=False,
+        subprocess_init=partial(_subprocess_init, subprocess_init_sentinel),
+    )
+    time.sleep(1)  # wait for subprocess to finish up initializing
+
+    # --- assertion --- #
+    try:
+        assert otaproxy_subprocess.is_alive()
+        assert subprocess_init_sentinel.is_file()
+    finally:
+        otaproxy_subprocess.terminate()


### PR DESCRIPTION
## Description
This PR introduces exposed helper functions for external launching otaproxy, supports configuring `cache_dir` and `cache_db_file` location for standalone otaproxy CLI.

### Motivation
1. Previously the standalone otaproxy startup cli (\_\_main__.py) **doesn't support configure cache_dir and cache_db_file location**, make the launching and testing standalone otaproxy harder as we have to modify the `otaproxy/config.py` every-time. 
2. Previously a wrapper for launching otaproxy in subprocess is implemented `ota_client_stubs`. This wrapper does the job of constructing otaproxy components, configuring ota_cache and otaproxy uvicorn server and laucnhing it in subprocess. **This reduces `ota_client_stub` module's cohesion and introduce deep coupling with otaproxy package, which is not ideal.**

### NOTE
The helper functions introduced by this PR is not yet used in main branch, it is used in refactored `ota_client_stub.py` in #212 . 

## Check list

- [x] test file(s) that covers the change(s) is implemented.
- [x] local test is passed. 

## Changes
at `otaclient.ota_proxy` package:
1.  `__init__.py`: add `run_otaproxy` helper function for setting up and starting otaproxy server, add wrapper function `subprocess_start_otaproxy` helper function for starting otaproxy as subprocess in one call.
4. `__main__.py`: add `--cache-dir` and `--cache-db-file` options for CLI interface. 

## Behavior changes

Does this PR introduce behavior change(s)?

- [ ] Yes, internal behaivor (will not impact user experience).
- [ ] Yes, external behaivor (will impact user experience).
- [x] No.

## Breaking change

Does this PR introduce breaking change?
- [ ] Yes
- [x] No