### PR TITLE
[Refinement] common: add ensure_otaproxy_start for probing otaproxy online

### DIFF
--- a/otaclient/app/common.py
+++ b/otaclient/app/common.py
@@ -629,7 +629,7 @@ def ensure_otaproxy_start(
             except Exception as e:  # server is not up yet
                 if cur_time >= next_warning:
                     logger.warning(
-                        f"otaproxy@{otaproxy_url} is not up after {warning_count * warning_interval} seconds"
+                        f"otaproxy@{otaproxy_url} is not up after {cur_time - start_time} seconds"
                         f"it might be something wrong with this otaproxy: {e!r}"
                     )
                     warning_count, next_warning = (

--- a/otaclient/app/common.py
+++ b/otaclient/app/common.py
@@ -19,6 +19,7 @@ import os
 import shlex
 import shutil
 import enum
+import requests
 import subprocess
 import time
 from concurrent.futures import Future, ThreadPoolExecutor, CancelledError, TimeoutError
@@ -597,3 +598,45 @@ class RetryTaskMap(Generic[_T]):
 
 def create_tmp_fname(prefix="tmp", length=6, sep="_") -> str:
     return f"{prefix}{sep}{os.urandom(length).hex()}"
+
+
+def ensure_otaproxy_start(
+    otaproxy_url: str,
+    *,
+    interval: float = 1,
+    connection_timeout: float = 5,
+    probing_timeout: Optional[float] = None,
+    warning_interval: int = 3 * 60,  # seconds
+):
+    """Loop probing <otaproxy_url> until online or exceed <probing_timeout>.
+
+    This function will issue a logging.warning every <warning_interval> seconds.
+
+    Raises:
+        A ConnectionError if exceeds <probing_timeout>.
+    """
+    start_time = int(time.time())
+    warning_count, next_warning = 0, start_time + warning_interval
+    probing_timeout = (
+        probing_timeout if probing_timeout and probing_timeout >= 0 else float("inf")
+    )
+    with requests.Session() as session:
+        while start_time + probing_timeout > (cur_time := int(time.time())):
+            try:
+                resp = session.get(otaproxy_url, timeout=connection_timeout)
+                resp.close()
+                return
+            except Exception as e:  # server is not up yet
+                if cur_time >= next_warning:
+                    logger.warning(
+                        f"otaproxy@{otaproxy_url} is not up after {warning_count * warning_interval} seconds"
+                        f"it might be something wrong with this otaproxy: {e!r}"
+                    )
+                    warning_count, next_warning = (
+                        warning_count + 1,
+                        next_warning + warning_interval,
+                    )
+                time.sleep(interval)
+    raise ConnectionError(
+        f"failed to ensure connection to {otaproxy_url} in {probing_timeout=}seconds"
+    )

--- a/otaclient/app/common.py
+++ b/otaclient/app/common.py
@@ -616,7 +616,7 @@ def ensure_otaproxy_start(
         A ConnectionError if exceeds <probing_timeout>.
     """
     start_time = int(time.time())
-    warning_count, next_warning = 0, start_time + warning_interval
+    next_warning = start_time + warning_interval
     probing_timeout = (
         probing_timeout if probing_timeout and probing_timeout >= 0 else float("inf")
     )
@@ -632,10 +632,7 @@ def ensure_otaproxy_start(
                         f"otaproxy@{otaproxy_url} is not up after {cur_time - start_time} seconds"
                         f"it might be something wrong with this otaproxy: {e!r}"
                     )
-                    warning_count, next_warning = (
-                        warning_count + 1,
-                        next_warning + warning_interval,
-                    )
+                    next_warning = next_warning + warning_interval
                 time.sleep(interval)
     raise ConnectionError(
         f"failed to ensure connection to {otaproxy_url} in {probing_timeout=}seconds"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -423,7 +423,8 @@ class Test_ensure_otaproxy_start:
         NOTE: we intentionally not use the subprocess_launch_server fixture here
               to let the probing timeout.
         """
-        probing_timeout = self.LAUNCH_DELAY * 2
+        # make testing faster
+        probing_timeout = self.LAUNCH_DELAY // 2
 
         start_time = int(time.time())
         with pytest.raises(ConnectionError):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -390,6 +390,10 @@ class Test_ensure_otaproxy_start:
     DUMMY_SERVER_URL = f"http://{DUMMY_SERVER_ADDR}:{DUMMY_SERVER_PORT}"
     LAUNCH_DELAY = 6
 
+    # for faster testing
+    PROBING_INTERVAL = 0.1
+    PROBING_CONNECTION_TIMEOUT = 0.1
+
     @staticmethod
     def _launch_server_helper(addr: str, port: int, launch_delay: int, directory: str):
         time.sleep(launch_delay)
@@ -419,26 +423,28 @@ class Test_ensure_otaproxy_start:
         NOTE: we intentionally not use the subprocess_launch_server fixture here
               to let the probing timeout.
         """
-        probing_timeout = 3
+        probing_timeout = self.LAUNCH_DELAY * 2
 
         start_time = int(time.time())
         with pytest.raises(ConnectionError):
             ensure_otaproxy_start(
                 self.DUMMY_SERVER_URL,
-                interval=0.1,
-                connection_timeout=0.1,
+                interval=self.PROBING_INTERVAL,
+                connection_timeout=self.PROBING_CONNECTION_TIMEOUT,
                 probing_timeout=probing_timeout,
             )
+        # probing should cost at least <LAUNCH_DELAY> seconds
         assert int(time.time()) >= start_time + probing_timeout
 
     def test_probing_delayed_online_server(self, subprocess_launch_server):
         start_time = int(time.time())
-        probing_timeout = self.LAUNCH_DELAY + 6
+        probing_timeout = self.LAUNCH_DELAY * 2
 
         ensure_otaproxy_start(
             self.DUMMY_SERVER_URL,
-            interval=0.1,
-            connection_timeout=0.1,
+            interval=self.PROBING_INTERVAL,
+            connection_timeout=self.PROBING_CONNECTION_TIMEOUT,
             probing_timeout=probing_timeout,
         )
+        # probing should cost at least <LAUNCH_DELAY> seconds
         assert int(time.time()) >= start_time + self.LAUNCH_DELAY


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. 

For better understanding, adding reason/motivation of this PR are also recommended.
-->

This PR introduces `ensure_otaproxy_start` function that can be used for probing otaproxy until it is online or exceed \<timeout>.

**NOTE**: this PR is split from #212 , and intended to be used in #212, this PR only implements the function but not yet uses.

### Motivation

There is an interval between subECU starts updating and mainECU's otaproxy become online, as otaproxy has to take some time to launch and become ready, especially when there are left over cache files needed to be scrubbed. 

To reduce unnecessary downloading failures and retrying when otaproxy is not yet online, this PR introduces the `ensure_otaproxy_start` function,  which allow otaclient to probe otaproxy online before it starts any downloading.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file(s) that covers the change(s) is implemented.
- [x] local test is passed. 

## Changes

<!-- A list of code change(s) that introduced by this PR. -->

## Behavior changes

Does this PR introduce behavior change(s)?

- [x] No (function is only implemented, not yet in used).

## Breaking change

Does this PR introduce breaking change?

- [x] No (function is only implemented, not yet in used).

<!-- List the breaking change(s) -->