### PR TITLE
[Refinement] cleanup ota_client_service.py, implement test file

### DIFF
--- a/otaclient/app/ota_client_service.py
+++ b/otaclient/app/ota_client_service.py
@@ -15,17 +15,9 @@
 
 import grpc.aio
 
-from . import log_setting
-from .proto import wrapper
-from .proto import v2_grpc
-from .proto import v2
+from .configs import server_cfg
+from .proto import wrapper, v2, v2_grpc
 from .ota_client_stub import OtaClientStub
-from .configs import server_cfg, config as cfg
-
-
-logger = log_setting.get_logger(
-    __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)
-)
 
 
 class OtaClientServiceV2(v2_grpc.OtaClientServiceServicer):
@@ -47,35 +39,14 @@ class OtaClientServiceV2(v2_grpc.OtaClientServiceServicer):
         return response.export_pb()
 
 
-async def service_start(port, service_list) -> grpc.aio.Server:
-    server = grpc.aio.server()
-    for service in service_list:
-        service["grpc"].add_OtaClientServiceServicer_to_server(
-            service["instance"], server
-        )
-    server.add_insecure_port(port)
-
-    await server.start()
-    return server
-
-
 async def launch_otaclient_grpc_server():
-    ota_client_stub = OtaClientStub()
-    ota_client_service_v2 = OtaClientServiceV2(ota_client_stub)
+    service_stub = OtaClientStub()
+    ota_client_service_v2 = OtaClientServiceV2(service_stub)
 
-    server = await service_start(
-        f"{ota_client_stub.host_addr()}:{server_cfg.SERVER_PORT}",
-        [
-            {"grpc": v2_grpc, "instance": ota_client_service_v2},
-        ],
+    server = grpc.aio.server()
+    v2_grpc.add_OtaClientServiceServicer_to_server(
+        server=server, servicer=ota_client_service_v2
     )
-
-    await service_wait_for_termination(server)
-
-
-async def service_wait_for_termination(server: grpc.aio.Server):
+    server.add_insecure_port(f"{service_stub.host_addr()}:{server_cfg.SERVER_PORT}")
+    await server.start()
     await server.wait_for_termination()
-
-
-async def service_stop(server: grpc.aio.Server):
-    await server.stop(None)

--- a/otaclient/app/ota_client_service.py
+++ b/otaclient/app/ota_client_service.py
@@ -39,7 +39,7 @@ class OtaClientServiceV2(v2_grpc.OtaClientServiceServicer):
         return response.export_pb()
 
 
-async def launch_otaclient_grpc_server():
+def create_otaclient_grpc_server():
     service_stub = OtaClientStub()
     ota_client_service_v2 = OtaClientServiceV2(service_stub)
 
@@ -48,5 +48,10 @@ async def launch_otaclient_grpc_server():
         server=server, servicer=ota_client_service_v2
     )
     server.add_insecure_port(f"{service_stub.host_addr()}:{server_cfg.SERVER_PORT}")
+    return server
+
+
+async def launch_otaclient_grpc_server():
+    server = create_otaclient_grpc_server()
     await server.start()
     await server.wait_for_termination()

--- a/otaclient/app/ota_client_service.py
+++ b/otaclient/app/ota_client_service.py
@@ -15,7 +15,8 @@
 
 import grpc.aio
 
-from .configs import server_cfg
+from .configs import config as cfg, server_cfg
+from .ecu_info import ECUInfo
 from .proto import wrapper, v2, v2_grpc
 from .ota_client_stub import OtaClientStub
 
@@ -40,6 +41,8 @@ class OtaClientServiceV2(v2_grpc.OtaClientServiceServicer):
 
 
 def create_otaclient_grpc_server():
+    ecu_info = ECUInfo.parse_ecu_info(cfg.ECU_INFO_FILE)
+
     service_stub = OtaClientStub()
     ota_client_service_v2 = OtaClientServiceV2(service_stub)
 
@@ -47,7 +50,7 @@ def create_otaclient_grpc_server():
     v2_grpc.add_OtaClientServiceServicer_to_server(
         server=server, servicer=ota_client_service_v2
     )
-    server.add_insecure_port(f"{service_stub.host_addr()}:{server_cfg.SERVER_PORT}")
+    server.add_insecure_port(f"{ecu_info.ip_addr}:{server_cfg.SERVER_PORT}")
     return server
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ class TestConfiguration:
     RPI_BOOT_MODULE_PATH = "otaclient.app.boot_control._rpi_boot"
     OTACLIENT_MODULE_PATH = "otaclient.app.ota_client"
     OTACLIENT_STUB_MODULE_PATH = "otaclient.app.ota_client_stub"
+    OTACLIENT_SERVICE_MODULE_PATH = "otaclient.app.ota_client_service"
     OTAMETA_MODULE_PATH = "otaclient.app.ota_metadata"
     OTAPROXY_MODULE_PATH = "otaclient.ota_proxy"
     CREATE_STANDBY_MODULE_PATH = "otaclient.app.create_standby"

--- a/tests/test_ota_client_service.py
+++ b/tests/test_ota_client_service.py
@@ -1,0 +1,118 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import asyncio
+import pytest
+import pytest_mock
+
+from otaclient.app.configs import server_cfg
+from otaclient.app.ecu_info import ECUInfo
+from otaclient.app.ota_client_service import create_otaclient_grpc_server
+from otaclient.app.ota_client_call import OtaClientCall
+from otaclient.app.proto import wrapper
+from tests.conftest import cfg
+from tests.utils import compare_message
+
+
+class _MockedOTAClientServiceStub:
+    MY_ECU_ID = "autoware"
+    UPDATE_RESP_ECU = wrapper.UpdateResponseEcu(
+        ecu_id=MY_ECU_ID,
+        result=wrapper.FailureType.NO_FAILURE,
+    )
+    UPDATE_RESP = wrapper.UpdateResponse(ecu=[UPDATE_RESP_ECU])
+    ROLLBACK_RESP_ECU = wrapper.RollbackResponseEcu(
+        ecu_id=MY_ECU_ID,
+        result=wrapper.FailureType.NO_FAILURE,
+    )
+    ROLLBACK_RESP = wrapper.RollbackResponse(ecu=[ROLLBACK_RESP_ECU])
+    STATUS_RESP_ECU = wrapper.StatusResponseEcuV2(
+        ecu_id=MY_ECU_ID,
+        otaclient_version="mocked_otaclient",
+        firmware_version="firmware",
+        ota_status=wrapper.StatusOta.SUCCESS,
+        failure_type=wrapper.FailureType.NO_FAILURE,
+    )
+    STATUS_RESP = wrapper.StatusResponse(
+        available_ecu_ids=[MY_ECU_ID], ecu_v2=[STATUS_RESP_ECU]
+    )
+
+    async def update(self, *arg, **kwargs):
+        return self.UPDATE_RESP
+
+    async def rollback(self, *args, **kwargs):
+        return self.ROLLBACK_RESP
+
+    async def status(self, *args, **kwargs):
+        return self.STATUS_RESP
+
+
+class Test_ota_client_service:
+    MY_ECU_ID = _MockedOTAClientServiceStub.MY_ECU_ID
+    LISTEN_ADDR = "127.0.0.1"
+    LISTEN_PORT = server_cfg.SERVER_PORT
+
+    @pytest.fixture(autouse=True)
+    def setup_test(self, mocker: pytest_mock.MockerFixture):
+        self.otaclient_service_stub = _MockedOTAClientServiceStub()
+        mocker.patch(
+            f"{cfg.OTACLIENT_SERVICE_MODULE_PATH}.OtaClientStub",
+            return_value=self.otaclient_service_stub,
+        )
+
+        ecu_info_mock = mocker.MagicMock(spec=ECUInfo)
+        # NOTE: mocked to use 127.0.0.1, and still use server_cfg.SERVER_PORT
+        ecu_info_mock.parse_ecu_info.return_value = ECUInfo(
+            ecu_id=self.otaclient_service_stub.MY_ECU_ID,
+            ip_addr=self.LISTEN_ADDR,
+        )
+        mocker.patch(f"{cfg.OTACLIENT_SERVICE_MODULE_PATH}.ECUInfo", ecu_info_mock)
+
+    @pytest.fixture(autouse=True)
+    async def launch_otaclient_server(self, setup_test):
+        server = create_otaclient_grpc_server()
+        try:
+            await server.start()
+            await asyncio.sleep(0.1)  # wait for fully up
+            yield
+        finally:
+            await server.stop(None)
+
+    async def test_otaclient_service(self):
+        # --- test update call --- #
+        update_resp = await OtaClientCall.update_call(
+            ecu_id=self.MY_ECU_ID,
+            ecu_ipaddr=self.LISTEN_ADDR,
+            ecu_port=self.LISTEN_PORT,
+            request=wrapper.UpdateRequest(),
+        )
+        compare_message(update_resp, self.otaclient_service_stub.UPDATE_RESP)
+
+        # --- test rollback call --- #
+        rollback_resp = await OtaClientCall.rollback_call(
+            ecu_id=self.MY_ECU_ID,
+            ecu_ipaddr=self.LISTEN_ADDR,
+            ecu_port=self.LISTEN_PORT,
+            request=wrapper.RollbackRequest(),
+        )
+        compare_message(rollback_resp, self.otaclient_service_stub.ROLLBACK_RESP)
+
+        # --- test status call --- #
+        status_resp = await OtaClientCall.status_call(
+            ecu_id=self.MY_ECU_ID,
+            ecu_ipaddr=self.LISTEN_ADDR,
+            ecu_port=self.LISTEN_PORT,
+        )
+        compare_message(status_resp, self.otaclient_service_stub.STATUS_RESP)

--- a/tests/test_ota_client_service.py
+++ b/tests/test_ota_client_service.py
@@ -1,4 +1,4 @@
-# Copyright 2022 TIER IV, INC. All rights reserved.
+# Copyright 2023 TIER IV, INC. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. 

For better understanding, adding reason/motivation of this PR are also recommended.
-->

This PR introduces some cleanup and replaces the old, duplicated codes in `ota_client_service.py` with 2 new functions, each create otaclient server instance and launch it. 
Now otaclient grpc server's address and port configurations are obtained directly in `ota_client_service`, not via `OtaClientStub`.
This PR also adds missing test files for `ota_client_service`. 

#### NOTE
This PR is split from #212 , as part of not directly related changes.

#### Motivation
About otaclient grpc server configuration, basically each module should only know what they need, `ota_client_stub` should only focus on API handling, so it doesn't need to know the server configuration, neither expose method to provide such information. Instead, the `ota_client_service` module should take the responsibility of loading such configuration.

For `ECUInfo`, in #212 , the new refactored `ota_client_stub.OTAClientServiceStub(renamed from OtaClientStub)` doesn't load ecu_info by itself and read global server_cfg, instead taking `ECUInfo` instance and server_cfg instance as init param, this aligns dependency injection principle and reduces coupling in some extend. 

Newly added `create_otaclient_grpc_server` works like a factory function, to load required information, and construct otaclient grpc server instance.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file(s) that covers the change(s) is implemented.
- [x] local test is passed. 

## Changes

<!-- A list of code change(s) that introduced by this PR. -->

In `ota_client_service.py`:
1. add `create_otaclient_grpc_server` function, which inits `OtaClientStub` and constructs otaclient grpc server instance,
2. add `launch_otaclient_grpc_server`, a one-call helper function to create and launch otaclient grpc server,
3. implement test files.

## Behavior changes

Does this PR introduce behavior change(s)?

- [x] Yes, internal behaivor (will not impact user experience).

### Previous behavior

<!-- Behaivor before the PR is introduced -->

In `launch_otaclient_grpc_server`, otaclient grpc server's listen address config is queried from `OtaClientStub`(and `OtaClientStub` obtains this config by loading ecu_info and read server_cfg).

### Behavior with this PR

<!-- Behavior after the PR is introduced -->

In `ota_client_service`, in `create_otaclient_grpc_server`, now grpc server listen address/port configs are directly queried from loading `ecu_info` and `server_cfg`. 

## Breaking change

Does this PR introduce breaking change?
- [x] No.

<!-- List the breaking change(s) -->