### PR TITLE
[Fix & Refinement] ota_metadata: implement validation over metadata.jwt

### DIFF
--- a/otaclient/app/errors.py
+++ b/otaclient/app/errors.py
@@ -35,8 +35,9 @@ class OTAErrorCode(Enum):
     E_OTAMETA_VERIFICATION_FAILED = 205
     E_UPDATEDELTA_GENERATION_FAILED = 206
     E_APPLY_OTAUPDATE_FAILED = 207
-    E_BASE_OTAMETA_VERIFICATION_FAILED = 208
+    E_METADATA_JWT_VERIFICATION_FAILED = 208
     E_OTAPROXY_FAILED_TO_START = 209
+    E_INVALID_METADATAJWT = 210
 
     E_OTA_ERR_UNRECOVERABLE = 300
     E_BOOTCONTROL_PLATFORM_UNSUPPORTED = 301
@@ -251,10 +252,16 @@ class ApplyOTAUpdateFailed(OTAErrorRecoverable):
     desc: str = f"{_RECOVERABLE_DEFAULT_DESC}: failed to apply ota update"
 
 
-class BaseOTAMetaVerificationFailed(OTAErrorRecoverable):
+class MetadataJWTVerficationFailed(OTAErrorRecoverable):
     module: OTAModules = OTAModules.API
-    errcode: OTAErrorCode = OTAErrorCode.E_BASE_OTAMETA_VERIFICATION_FAILED
-    desc: str = f"{_RECOVERABLE_DEFAULT_DESC}: verification failed for base otameta"
+    errcode: OTAErrorCode = OTAErrorCode.E_METADATA_JWT_VERIFICATION_FAILED
+    desc: str = f"{_RECOVERABLE_DEFAULT_DESC}: verification failed for metadata.jwt"
+
+
+class MetadataJWTInvalid(OTAErrorRecoverable):
+    module: OTAModules = OTAModules.API
+    errcode: OTAErrorCode = OTAErrorCode.E_INVALID_METADATAJWT
+    desc: str = f"{_RECOVERABLE_DEFAULT_DESC}: invalid metadata.jwt"
 
 
 class OTAProxyFailedToStart(OTAErrorRecoverable):

--- a/otaclient/app/ota_client.py
+++ b/otaclient/app/ota_client.py
@@ -152,7 +152,7 @@ class _OTAUpdater:
         self.updating_version: str = ""
         self.failure_reason = ""
         # init variables needed for update
-        self._otameta: OTAMetadata = None  # type: ignore
+        self._otameta: ota_metadata.OTAMetadata = None  # type: ignore
         self._url_base: str = None  # type: ignore
 
         # dynamic update status

--- a/otaclient/app/ota_client.py
+++ b/otaclient/app/ota_client.py
@@ -25,15 +25,7 @@ from typing import Type, Iterator
 from urllib.parse import urlparse
 
 from otaclient import __version__  # type: ignore
-from .errors import (
-    BaseOTAMetaVerificationFailed,
-    NetworkError,
-    OTA_APIError,
-    OTAError,
-    OTAProxyFailedToStart,
-    OTARollbackError,
-    OTAUpdateError,
-)
+from . import ota_metadata
 from .boot_control import BootControllerProtocol
 from .common import RetryTaskMap, wait_with_backoff
 from .configs import config as cfg
@@ -44,8 +36,10 @@ from .downloader import (
     Downloader,
     HashVerificaitonError,
 )
-from .interface import OTAClientProtocol
 from .errors import (
+    MetadataJWTInvalid,
+    MetadataJWTVerficationFailed,
+    NetworkError,
     ApplyOTAUpdateFailed,
     InvalidUpdateRequest,
     OTAMetaVerificationFailed,
@@ -53,8 +47,13 @@ from .errors import (
     OTAMetaDownloadFailed,
     StandbySlotSpaceNotEnoughError,
     UpdateDeltaGenerationFailed,
+    OTA_APIError,
+    OTAError,
+    OTAProxyFailedToStart,
+    OTARollbackError,
+    OTAUpdateError,
 )
-from .ota_metadata import OTAMetadata
+from .interface import OTAClientProtocol
 from .ota_status import LiveOTAStatus
 from .proto import wrapper
 from .proto.wrapper import UpdatePhase, RegularInf, StatusResponseEcuV2, UpdateStatus
@@ -369,7 +368,7 @@ class _OTAUpdater:
         # process metadata.jwt and ota metafiles
         logger.debug("process metadata.jwt...")
         try:
-            self._otameta = OTAMetadata(
+            self._otameta = ota_metadata.OTAMetadata(
                 url_base=self._url_base,
                 downloader=self._downloader,
             )
@@ -383,11 +382,14 @@ class _OTAUpdater:
         except DestinationNotAvailableError as e:
             logger.error("failed to save ota metafiles")
             raise OTAErrorUnRecoverable from e
-        except ValueError as e:
+        except ota_metadata.MetadataJWTVerificationFailed as e:
             logger.error(f"failed to verify metadata.jwt: {e!r}")
-            raise BaseOTAMetaVerificationFailed from e
+            raise MetadataJWTVerficationFailed from e
+        except ota_metadata.MetadataJWTPayloadInvalid as e:
+            logger.error(f"metadata.jwt is invalid: {e!r}")
+            raise MetadataJWTInvalid from e
         except Exception as e:
-            logger.error(f"failed to download ota metafiles: {e!r}")
+            logger.error(f"failed to prepare ota metafiles: {e!r}")
             raise OTAMetaDownloadFailed from e
 
         # ------ execute local update ------ #

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -182,6 +182,14 @@ class MetaFieldDescriptor(Generic[FV]):
         self.field_name = name
         self._attrn = f"_{owner.__name__}_{name}"
 
+    # API
+
+    def check_is_target_claim(self, value: Any) -> bool:
+        """Check whether the input claim dict is for this field."""
+        if not isinstance(value, dict):
+            return False
+        return self.field_name in value
+
 
 class _MetadataJWTParser:
     """Implementation of custom JWT parsing/loading/validating logic.

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -322,25 +322,50 @@ class _MetadataJWTParser:
         self._verify_metadata(metadata_cert)
 
 
+# place holder for unset must field in _MetadataJWTClaimsLayout
+_MUST_SET_CLAIM = object()
+
+
 @dataclass
 class _MetadataJWTClaimsLayout:
     """Version1 metadata.jwt payload mapping and parsing."""
 
     SCHEME_VERSION: ClassVar[int] = 1
     VERSION_KEY: ClassVar[str] = "version"
+    UNKNOWN_VERSION: ClassVar[int] = -1
 
     # metadata scheme
-    version: MetaFieldDescriptor[int] = MetaFieldDescriptor(int)
-    total_regular_size: MetaFieldDescriptor[int] = MetaFieldDescriptor(int)  # in bytes
-    rootfs_directory: MetaFieldDescriptor[str] = MetaFieldDescriptor(str)
-    compressed_rootfs_directory: MetaFieldDescriptor[str] = MetaFieldDescriptor(str)
+    version: MetaFieldDescriptor[int] = MetaFieldDescriptor(
+        int, default=UNKNOWN_VERSION
+    )
+    total_regular_size: MetaFieldDescriptor[int] = MetaFieldDescriptor(
+        int, default=0
+    )  # in bytes
+    rootfs_directory: MetaFieldDescriptor[str] = MetaFieldDescriptor(
+        str, default=_MUST_SET_CLAIM
+    )
+    compressed_rootfs_directory: MetaFieldDescriptor[str] = MetaFieldDescriptor(
+        str, default=""
+    )
     # sign certificate
-    certificate: MetaFieldDescriptor[MetaFile] = MetaFieldDescriptor(MetaFile)
+    certificate: MetaFieldDescriptor[MetaFile] = MetaFieldDescriptor(
+        MetaFile, default=_MUST_SET_CLAIM
+    )
     # metadata files definition
-    directory: MetaFieldDescriptor[MetaFile] = MetaFieldDescriptor(MetaFile)
-    symboliclink: MetaFieldDescriptor[MetaFile] = MetaFieldDescriptor(MetaFile)
-    regular: MetaFieldDescriptor[MetaFile] = MetaFieldDescriptor(MetaFile)
-    persistent: MetaFieldDescriptor[MetaFile] = MetaFieldDescriptor(MetaFile)
+    directory: MetaFieldDescriptor[MetaFile] = MetaFieldDescriptor(
+        MetaFile, default=_MUST_SET_CLAIM
+    )
+    symboliclink: MetaFieldDescriptor[MetaFile] = MetaFieldDescriptor(
+        MetaFile, default=_MUST_SET_CLAIM
+    )
+    regular: MetaFieldDescriptor[MetaFile] = MetaFieldDescriptor(
+        MetaFile, default=_MUST_SET_CLAIM
+    )
+    persistent: MetaFieldDescriptor[MetaFile] = MetaFieldDescriptor(
+        MetaFile, default=_MUST_SET_CLAIM
+    )
+
+    def assign_fields(self, claims: List[Dict[str, Any]]):
 
     @classmethod
     def parse_payload(cls, _input: Union[str, bytes], /) -> Self:

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -419,9 +419,17 @@ class _MetadataJWTClaimsLayout:
             field_assigned = False
             for claim in claims:
                 if fd.check_is_target_claim(claim):
-                    setattr(self, fd.field_name, claim)
-                    field_assigned = True
-                    break
+                    try:
+                        setattr(self, fd.field_name, claim)
+                        field_assigned = True
+                        break
+                    except ValueError as e:
+                        _err_msg = (
+                            f"failed to assign {fd.field_name} with {claim}: {e!r}"
+                        )
+                        logger.error(_err_msg)
+                        raise MetadataJWTPayloadInvalid(_err_msg) from e
+
             # failed to find target claim in metadata.jwt, and
             # this field is MUST_SET field
             if not field_assigned and fd.default is _MUST_SET_CLAIM:

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -13,18 +13,20 @@
 # limitations under the License.
 """OTA metadata version1 implementation.
 
+OTA metadata format definition: https://tier4.atlassian.net/l/cp/PCvwC6qk
+
 Version1 JWT verification algorithm: ES256
 Version1 JWT payload layout:
 [
-    {"version": 1},
-    {"directory": "dirs.txt", "hash": <sha256_hash>},
-    {"symboliclink": "symlinks.txt", "hash": <sha256_hash>},
-    {"regular": "regulars.txt", "hash": <sha256_hash>},
-    {"persistent": "persistents.txt", "hash": <sha256_hash>},
-    {"certificate": "sign.pem", "hash": <sha256_hash>},
-    {"total_regular_size": "23637537004"},
-    {"rootfs_directory": "data"},
-    {"compressed_rootfs_directory": "data.zstd"}
+    {"version": 1}, # must
+    {"directory": "dirs.txt", "hash": <sha256_hash>}, # must
+    {"symboliclink": "symlinks.txt", "hash": <sha256_hash>}, # must
+    {"regular": "regulars.txt", "hash": <sha256_hash>}, # must
+    {"persistent": "persistents.txt", "hash": <sha256_hash>}, # must
+    {"certificate": "sign.pem", "hash": <sha256_hash>}, # must
+    {"total_regular_size": "23637537004"}, # optional
+    {"rootfs_directory": "data"}, # must
+    {"compressed_rootfs_directory": "data.zstd"} # optional
 ]
 Version1 OTA metafiles list:
 - directory: all directories in the image,

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -178,7 +178,8 @@ class MetaFieldDescriptor(Generic[FV]):
                         obj,
                         self._attrn,
                         MetaFile(
-                            file=value[self.field_name], hash=value[self.HASH_KEY]
+                            file=str(value[self.field_name]),
+                            hash=str(value[self.HASH_KEY]),
                         ),
                     )
                 except KeyError:
@@ -188,9 +189,13 @@ class MetaFieldDescriptor(Generic[FV]):
             # normal key-value field
             else:
                 # use <field_type> to do default conversion before assignment
-                return setattr(
-                    obj, self._attrn, self.field_type(value[self.field_name])
-                )
+                if not isinstance(
+                    (field_value := value[self.field_name]), self.field_type
+                ):
+                    raise ValueError(
+                        f"invalid field value for {self.field_name}: {field_value=}"
+                    )
+                return setattr(obj, self._attrn, field_value)
         raise ValueError(f"attempt to assign invalid {value=} to {self.field_name=}")
 
     def __set_name__(self, owner: type, name: str):

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -265,10 +265,9 @@ class _MetadataJWTParser:
         try:
             cert_to_verify = load_pem(metadata_cert)
         except crypto.Error as e:
-            logger.exception(f"invalid certificate {metadata_cert}")
-            raise MetadataJWTVerificationFailed(
-                f"invalid certificate {metadata_cert}"
-            ) from e
+            _err_msg = f"invalid certificate {metadata_cert}: {e!r}"
+            logger.exception(_err_msg)
+            raise MetadataJWTVerificationFailed(_err_msg) from e
 
         for ca_prefix in sorted(ca_set_prefix):
             certs_list = [
@@ -288,10 +287,9 @@ class _MetadataJWTParser:
             except crypto.X509StoreContextError as e:
                 logger.info(f"verify against {ca_prefix} failed: {e}")
 
-        logger.error(f"metadata sign certificate {metadata_cert} could not be verified")
-        raise MetadataJWTVerificationFailed(
-            f"metadata sign certificate {metadata_cert} could not be verified"
-        )
+        _err_msg = f"metadata sign certificate {metadata_cert} could not be verified"
+        logger.error(_err_msg)
+        raise MetadataJWTVerificationFailed(_err_msg)
 
     def _verify_metadata(self, metadata_cert: bytes):
         """Verify metadata against sign certificate.
@@ -401,7 +399,9 @@ class _MetadataJWTClaimsLayout:
         #   check module docstring for more details
         claims: List[Dict[str, Any]] = json.loads(payload)
         if not claims or not isinstance(claims, list):
-            raise MetadataJWTPayloadInvalid(f"invalid {payload=}")
+            _err_msg = f"invalid {payload=}"
+            logger.error(_err_msg)
+            raise MetadataJWTPayloadInvalid(_err_msg)
         cls.check_metadata_version(claims)
 
         (res := cls()).assign_fields(claims)
@@ -433,9 +433,9 @@ class _MetadataJWTClaimsLayout:
             # failed to find target claim in metadata.jwt, and
             # this field is MUST_SET field
             if not field_assigned and fd.default is _MUST_SET_CLAIM:
-                raise MetadataJWTPayloadInvalid(
-                    f"must set field {fd.name} not found in metadata.jwt"
-                )
+                _err_msg = f"must set field {fd.name} not found in metadata.jwt"
+                logger.error(_err_msg)
+                raise MetadataJWTPayloadInvalid(_err_msg)
 
     def get_img_metafiles(self) -> Iterator[MetaFile]:
         """Get the metafiles that describes the OTA image."""

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -403,14 +403,17 @@ class _MetadataJWTClaimsLayout:
             # NOTE: default value for each field in dataclass is the descriptor
             # NOTE: skip non-metafield field
             if not isinstance((fd := field.default), MetaFieldDescriptor):
-                return
+                continue
 
+            field_assigned = False
             for claim in claims:
                 if fd.check_is_target_claim(claim):
-                    return setattr(self, fd.field_name, claim)
+                    setattr(self, fd.field_name, claim)
+                    field_assigned = True
+                    break
             # failed to find target claim in metadata.jwt, and
             # this field is MUST_SET field
-            if fd.default is _MUST_SET_CLAIM:
+            if not field_assigned and fd.default is _MUST_SET_CLAIM:
                 raise ValueError(f"must set field {fd.name} not found")
 
     def get_img_metafiles(self) -> Iterator[MetaFile]:

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -173,11 +173,18 @@ class MetaFieldDescriptor(Generic[FV]):
         if isinstance(value, dict):
             # metafile field
             if self.field_type is MetaFile:
-                return setattr(
-                    obj,
-                    self._attrn,
-                    MetaFile(file=value[self.field_name], hash=value[self.HASH_KEY]),
-                )
+                try:
+                    return setattr(
+                        obj,
+                        self._attrn,
+                        MetaFile(
+                            file=value[self.field_name], hash=value[self.HASH_KEY]
+                        ),
+                    )
+                except KeyError:
+                    raise ValueError(
+                        f"invalid metafile field {self.field_name}: {value}"
+                    )
             # normal key-value field
             else:
                 # use <field_type> to do default conversion before assignment

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -355,11 +355,10 @@ class _MetadataJWTClaimsLayout:
 
     SCHEME_VERSION: ClassVar[int] = 1
     VERSION_KEY: ClassVar[str] = "version"
-    UNKNOWN_VERSION: ClassVar[int] = -1
 
     # metadata scheme
     version: MetaFieldDescriptor[int] = MetaFieldDescriptor(
-        int, default=UNKNOWN_VERSION
+        int, default=_MUST_SET_CLAIM
     )
     # WARNING: total_regular_size should be int, but it comes as str in metadata.jwt,
     #          so we disable type_check for it, and convert it as field_type before assigning

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -391,7 +391,7 @@ class _MetadataJWTClaimsLayout:
                     logger.warning(f"metadata {version=}, expect {cls.SCHEME_VERSION}")
                 break
         if not version_field_found:
-            logger.warning(f"metadata version is missing in metadata.jwt!")
+            logger.warning("metadata version is missing in metadata.jwt!")
 
     @classmethod
     def parse_payload(cls, payload: Union[str, bytes], /) -> Self:


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->

This PR introduces the missing validation mechanism when parsing `metadata.jwt`, explicitly define default value for optional field, or raise exception on missing must_set field in `metadata.jwt`. For case of invalid `metadata.jwt`, new OTA error type for `metadata.jwt` invalid is defined in this PR.

### metadata.jwt format
```
# check the document in https://tier4.atlassian.net/l/cp/PCvwC6qk for more details
Version1 JWT payload layout(revision2):
[
    {"version": 1}, # must
    {"directory": "dirs.txt", "hash": <sha256_hash>}, # must
    {"symboliclink": "symlinks.txt", "hash": <sha256_hash>}, # must
    {"regular": "regulars.txt", "hash": <sha256_hash>}, # must
    {"persistent": "persistents.txt", "hash": <sha256_hash>}, # must
    {"certificate": "sign.pem", "hash": <sha256_hash>}, # must
    {"rootfs_directory": "data"}, # must
    {"total_regular_size": "23637537004"}, # optional, added in revision1, default is `0`
    {"compressed_rootfs_directory": "data.zstd"} # optional: added in revision2, default is `""`
]
```
> **Warning**
> `total_regular_size` in `metadata.jwt` is str, we need to convert it into int.

### validation mechanism
The validation includes the following operations:
1. for **must_set field**, check if any is missing and raise exception on missing,
2. for **optional field**, set proper default value for it if missing,
3. for metafiles field(`directory`, `symbolicklink`, `regular`, `persistent`, `certificate`), check input field value's format.

### error handling
`ota_metadata` module now internally defines `MetadataJWTPayloadInvalid` and `MetadataJWTVerificationFailed`. 
For external OTA errors definition, corresponding OTA recoverable error `MetadataJWTInvalid` and `MetadataJWTVerficationFailed` are defined.
`ota_client` now catches the internal `ota_metadata` exceptions, wraps it into corresponding OTA recoverable errors, and reports them.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file that covers the bug case(s) is implemented:
    1. default value for missing optional field is correctly set.
    2. exception is raised on invalid `metadata.jwt`.
    3. parsing over valid `metadata.jwt` is OK.
- [x] local test is passed. 
- [x] confirm bug cannot be reproduced with this PR on VM environment. 

## Behavior changes

Does this PR introduce behavior change(s)?

- [x] Yes, internal behaivor (will not impact user experience). Please check **Bug fix** section below for more details.

## Bug fix

### 1. ota_client's status API doesn't respond when `total_regular_size` field is missing in metadata.jwt

Ticket: https://tier4.atlassian.net/browse/RT4-4767

#### Current behavior(cause of the bug)

 `ota_metadata` doesn't define proper default value for missing `total_regular_size`(`None` is used). when ota_client status API constructing response, passing `None` to `total_regular_files_size_uncompressed` field in `StatusResponseECUV2` causing `TypeError`, resulting in status API not responding.

Also, if `metadata.jwt` missing any metafile fields(`directory`, `symbolicklink`, `regular`, `persistent`, `certificate`), it will cause exceptions at where these fields are being called, but the exception will be hard to reveal the real cause(fields missing in `metadata.jwt`).

#### Behaivor after fix

1. for valid `metadata.jwt` that missing optional fields, proper default value will be set after parsing:
    a. `total_regular_size` -> 0,
    b. `compressed_rootfs_directory` -> `""`,
2. for invalid `metadata.jwt`(either invalid json, or missing must_set fields), `MetadataJWTPayloadInvalid` OTA recoverable error will be reported.
3. OTA recoverable error `BaseOTAMetaVerificationFailed` now is renamed to `MetadataJWTVerficationFailed`.

## Related links & ticket

<!-- List of tickets or links related to this PR -->

Ticket: https://tier4.atlassian.net/browse/RT4-4767
ota_metadata format: https://tier4.atlassian.net/l/cp/PCvwC6qk