### PR TITLE
[Chore] update .flake8 and pyproject.toml for linting configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,11 @@
 [flake8]
 max-line-length = 88
+# ignore the following Errors:
+#   E266(too many leading '#'):
+#       sometimes we use multiple # for separting sections
+#   E203(white space before ':'):
+#       this error conflicts with black linting
+#   E501(line is too long):
+#       TODO: deal with it in the future
 extend-ignore = E266, E501, E203
-exclude = **/*_pb2.py*, **/*_pb2_grpc.py*
+extend-exclude = *_pb2.py*, *_pb2_grpc.py*

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 88
 extend-ignore = E266, E501, E203
-exclude = otaclient/app/proto/*pb2*
+exclude = **/*_pb2.py*, **/*_pb2_grpc.py*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,23 +35,20 @@ local_scheme = "no-local-version"
 [tool.black]
 line-length = 88
 target-version = ['py38']
-include = '''(
-  otaclient.*\.py$
-)'''
 extend-exclude = '''(
-  (.*_pb2.pyi? | .*_pb2_grpc.pyi? )
+  (_pb2.pyi?|_pb2_grpc.pyi?)$
 )'''
 
 [tool.coverage.run]
 branch = false
 
 [tool.coverage.report]
-omit = ["**/*_pb2.py*","**/*_pb2_grpc.py*", "**/__*.py"]
+omit = ["**/*_pb2.py*","**/*_pb2_grpc.py*"]
 show_missing = true
 
 [tool.pyright]
 exclude = ["**/__pycache__"]
-ignore = ["**/*_pb2.py*","**/*_pb2_grpc.py*", "**/__*.py"]
+ignore = ["**/*_pb2.py*","**/*_pb2_grpc.py*"]
 pythonVersion = "3.8"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,22 +36,22 @@ local_scheme = "no-local-version"
 line-length = 88
 target-version = ['py38']
 include = '''(
-  otaclient.*\.pyi?$
+  otaclient.*\.py$
 )'''
 extend-exclude = '''(
-  .*pb2.*
+  (.*_pb2.pyi? | .*_pb2_grpc.pyi? )
 )'''
 
 [tool.coverage.run]
 branch = false
 
 [tool.coverage.report]
-omit = ["**/*pb2*", "**/__*.py"]
+omit = ["**/*_pb2.py*","**/*_pb2_grpc.py*", "**/__*.py"]
 show_missing = true
 
 [tool.pyright]
 exclude = ["**/__pycache__"]
-ignore = ["**/*pb2*"]
+ignore = ["**/*_pb2.py*","**/*_pb2_grpc.py*", "**/__*.py"]
 pythonVersion = "3.8"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Description
This PR updates `.flake8` and `pyproject.toml` for linting configuration. 
1. flake8: add comments for why ignores E266, E501 and E203.
2. flake8: use proper glob patterns to only match generated proto files, use `extend-exclude` instead of `exclude` to apply the extra excluded config on top of defaults, not overriding it.
3. black: remove `include` config, use default value, as black will automatically search for `otaclient` package.
4. black: use proper glob patterns to only match generated proto files in `extend-exclucede`.