### PR TITLE
[Refinement] align and regulate each call's behavior in otaclient_call module

### DIFF
--- a/otaclient/app/ota_client_call.py
+++ b/otaclient/app/ota_client_call.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-import asyncio
 import grpc.aio
 
 from . import log_setting

--- a/otaclient/app/ota_client_call.py
+++ b/otaclient/app/ota_client_call.py
@@ -15,7 +15,6 @@
 
 import asyncio
 import grpc.aio
-from typing import Optional
 
 from . import log_setting
 from .proto import wrapper, v2, v2_grpc
@@ -26,6 +25,10 @@ logger = log_setting.get_logger(
 )
 
 
+class ECUNoResponse(Exception):
+    """Raised when ECU cannot response to request on-time."""
+
+
 class OtaClientCall:
     @staticmethod
     async def status_call(
@@ -33,19 +36,20 @@ class OtaClientCall:
         ecu_ipaddr: str,
         ecu_port: int = server_cfg.SERVER_PORT,
         *,
+        request: wrapper.StatusRequest,
         timeout=None,
-    ) -> Optional[wrapper.StatusResponse]:
+    ) -> wrapper.StatusResponse:
         try:
             ecu_addr = f"{ecu_ipaddr}:{ecu_port}"
             async with grpc.aio.insecure_channel(ecu_addr) as channel:
                 stub = v2_grpc.OtaClientServiceStub(channel)
-                resp = await stub.Status(v2.StatusRequest(), timeout=timeout)
+                resp = await stub.Status(request.export_pb(), timeout=timeout)
                 return wrapper.StatusResponse.convert(resp)
         except (grpc.aio.AioRpcError, asyncio.TimeoutError):
-            # NOTE(20220801): for status querying, if the target ecu
-            # is unreachable, just return nothing, instead of return
-            # a response with result=RECOVERABLE
             logger.debug(f"{ecu_id=} failed to respond to status request on-time.")
+            raise ECUNoResponse(f"{ecu_id=} doesn't response on-time")
+        except Exception as e:
+            raise ECUNoResponse(f"failed to connect to {ecu_id=}: {e!r}") from e
 
     @staticmethod
     async def update_call(
@@ -63,15 +67,10 @@ class OtaClientCall:
                 resp = await stub.Update(request.export_pb(), timeout=timeout)
                 return wrapper.UpdateResponse.convert(resp)
         except (grpc.aio.AioRpcError, asyncio.TimeoutError):
-            resp = wrapper.UpdateResponse()
-            # treat unreachable ecu as recoverable
-            resp.add_ecu(
-                wrapper.UpdateResponseEcu(
-                    ecu_id=ecu_id,
-                    result=wrapper.FailureType.RECOVERABLE,
-                )
-            )
-            return resp
+            logger.debug(f"{ecu_id=} failed to respond to update request on-time.")
+            raise ECUNoResponse(f"{ecu_id=} doesn't response on-time")
+        except Exception as e:
+            raise ECUNoResponse(f"failed to connect to {ecu_id=}: {e!r}") from e
 
     @staticmethod
     async def rollback_call(
@@ -89,12 +88,7 @@ class OtaClientCall:
                 resp = await stub.Rollback(request.export_pb(), timeout=timeout)
                 return wrapper.RollbackResponse.convert(resp)
         except (grpc.aio.AioRpcError, asyncio.TimeoutError):
-            resp = wrapper.RollbackResponse()
-            # treat unreachable ecu as recoverable
-            resp.add_ecu(
-                wrapper.RollbackResponseEcu(
-                    ecu_id=ecu_id,
-                    result=wrapper.FailureType.RECOVERABLE,
-                )
-            )
-            return resp
+            logger.debug(f"{ecu_id=} failed to respond to rollback request on-time.")
+            raise ECUNoResponse(f"{ecu_id=} doesn't response on-time")
+        except Exception as e:
+            raise ECUNoResponse(f"failed to connect to {ecu_id=}: {e!r}") from e

--- a/otaclient/app/ota_client_call.py
+++ b/otaclient/app/ota_client_call.py
@@ -45,11 +45,10 @@ class OtaClientCall:
                 stub = v2_grpc.OtaClientServiceStub(channel)
                 resp = await stub.Status(request.export_pb(), timeout=timeout)
                 return wrapper.StatusResponse.convert(resp)
-        except (grpc.aio.AioRpcError, asyncio.TimeoutError):
-            logger.debug(f"{ecu_id=} failed to respond to status request on-time.")
-            raise ECUNoResponse(f"{ecu_id=} doesn't response on-time")
         except Exception as e:
-            raise ECUNoResponse(f"failed to connect to {ecu_id=}: {e!r}") from e
+            _msg = f"{ecu_id=} failed to respond to status request on-time: {e!r}"
+            logger.debug(_msg)
+            raise ECUNoResponse(_msg)
 
     @staticmethod
     async def update_call(
@@ -66,11 +65,10 @@ class OtaClientCall:
                 stub = v2_grpc.OtaClientServiceStub(channel)
                 resp = await stub.Update(request.export_pb(), timeout=timeout)
                 return wrapper.UpdateResponse.convert(resp)
-        except (grpc.aio.AioRpcError, asyncio.TimeoutError):
-            logger.debug(f"{ecu_id=} failed to respond to update request on-time.")
-            raise ECUNoResponse(f"{ecu_id=} doesn't response on-time")
         except Exception as e:
-            raise ECUNoResponse(f"failed to connect to {ecu_id=}: {e!r}") from e
+            _msg = f"{ecu_id=} failed to respond to update request on-time: {e!r}"
+            logger.debug(_msg)
+            raise ECUNoResponse(_msg)
 
     @staticmethod
     async def rollback_call(
@@ -87,8 +85,7 @@ class OtaClientCall:
                 stub = v2_grpc.OtaClientServiceStub(channel)
                 resp = await stub.Rollback(request.export_pb(), timeout=timeout)
                 return wrapper.RollbackResponse.convert(resp)
-        except (grpc.aio.AioRpcError, asyncio.TimeoutError):
-            logger.debug(f"{ecu_id=} failed to respond to rollback request on-time.")
-            raise ECUNoResponse(f"{ecu_id=} doesn't response on-time")
         except Exception as e:
-            raise ECUNoResponse(f"failed to connect to {ecu_id=}: {e!r}") from e
+            _msg = f"{ecu_id=} failed to respond to rollback request on-time: {e!r}"
+            logger.debug(_msg)
+            raise ECUNoResponse(_msg)

--- a/otaclient/app/ota_client_call.py
+++ b/otaclient/app/ota_client_call.py
@@ -17,7 +17,7 @@ import asyncio
 import grpc.aio
 
 from . import log_setting
-from .proto import wrapper, v2, v2_grpc
+from .proto import wrapper, v2_grpc
 from .configs import config as cfg, server_cfg
 
 logger = log_setting.get_logger(

--- a/otaclient/app/ota_client_stub.py
+++ b/otaclient/app/ota_client_stub.py
@@ -469,7 +469,10 @@ class OtaClientStub:
 
         # wait for all sub ecu acknowledge ota update requests
         update_resp: wrapper.UpdateResponse
-        for update_resp in await asyncio.gather(*coros):
+        for update_resp in await asyncio.gather(*coros, return_exceptions=True):
+            if isinstance(update_resp, ECUNoResponse):
+                logger.error(f"update request dispatch failed: {update_resp!r}")
+                continue
             response.merge_from(update_resp)
 
         # after all subecus ack the update request, update my ecu

--- a/otaclient/app/ota_client_stub.py
+++ b/otaclient/app/ota_client_stub.py
@@ -565,7 +565,10 @@ class OtaClientStub:
         logger.info(f"rollback: {tracked_ecus_dict=}")
 
         # wait for all sub ecu acknowledge ota rollback requests
-        for rollback_resp in await asyncio.gather(*coros):
+        for rollback_resp in await asyncio.gather(*coros, return_exceptions=True):
+            if isinstance(rollback_resp, ECUNoResponse):
+                logger.error(f"failed to dispatch rollback req: {rollback_resp!r}")
+                continue
             response.merge_from(rollback_resp)
 
         # after all subecus response the request, rollback my ecu

--- a/otaclient/app/ota_client_stub.py
+++ b/otaclient/app/ota_client_stub.py
@@ -300,12 +300,16 @@ class _SubECUTracker:
         """Query ecu status API once."""
         try:
             resp = await OtaClientCall.status_call(
-                ecu_id, ecu_addr, ecu_port, request=wrapper.StatusRequest(), timeout=self.subecu_query_timeout,
+                ecu_id,
+                ecu_addr,
+                ecu_port,
+                request=wrapper.StatusRequest(),
+                timeout=self.subecu_query_timeout,
             )
         except ECUNoResponse as e:
             logger.debug(f"failed to query ECU's status: {e!r}")
             return self.ECUStatus.UNREACHABLE
-        
+
         # if ANY OF the subecu and its child ecu are
         # not in SUCCESS/FAILURE otastatus, or unreacable, return False
         all_ready, all_success = True, True
@@ -436,7 +440,6 @@ class OtaClientStub:
                     result=wrapper.FailureType.RECOVERABLE,
                 )
             )
-
             logger.debug("ignore duplicated update request")
             return response
         else:
@@ -451,29 +454,43 @@ class OtaClientStub:
         tracked_ecus_dict: Dict[str, str] = {}
 
         # simultaneously dispatching update requests to all subecus without blocking
-        coros: List[Coroutine] = []
+        tasks: Dict[asyncio.Task, str] = {}
         for _ecu_id, _ecu_ip in self.subecus_dict.items():
-            if request.if_contains_ecu(_ecu_id):
-                # add to tracked ecu list
-                tracked_ecus_dict[_ecu_id] = _ecu_ip
-                coros.append(
-                    OtaClientCall.update_call(
-                        _ecu_id,
-                        _ecu_ip,
-                        server_cfg.SERVER_PORT,
-                        request=request,
-                        timeout=server_cfg.WAITING_SUBECU_ACK_UPDATE_REQ_TIMEOUT,
-                    )
-                )
-        logger.info(f"update: {tracked_ecus_dict=}")
-
-        # wait for all sub ecu acknowledge ota update requests
-        update_resp: wrapper.UpdateResponse
-        for update_resp in await asyncio.gather(*coros, return_exceptions=True):
-            if isinstance(update_resp, ECUNoResponse):
-                logger.error(f"update request dispatch failed: {update_resp!r}")
+            if not request.if_contains_ecu(_ecu_id):
                 continue
-            response.merge_from(update_resp)
+
+            # add to tracked ecu list
+            tracked_ecus_dict[_ecu_id] = _ecu_ip
+            _task = asyncio.create_task(
+                OtaClientCall.update_call(
+                    _ecu_id,
+                    _ecu_ip,
+                    server_cfg.SERVER_PORT,
+                    request=request,
+                    timeout=server_cfg.WAITING_SUBECU_ACK_UPDATE_REQ_TIMEOUT,
+                )
+            )
+            tasks[_task] = _ecu_id
+
+        if tasks:  # NOTE: input for asyncio.wait must not be empty!
+            done, _ = await asyncio.wait(tasks)
+            for _task in done:
+                try:
+                    _ecu_resp: wrapper.UpdateResponse = _task.result()
+                    response.merge_from(_ecu_resp)
+                except ECUNoResponse as e:
+                    ecu_id = tasks[_task]
+                    logger.warning(
+                        f"{tasks[_task]} doesn't respond to update request on-time"
+                        f"(within {server_cfg.WAITING_SUBECU_ACK_UPDATE_REQ_TIMEOUT}s): {e!r}"
+                    )
+                    response.add_ecu(
+                        wrapper.UpdateResponseEcu(
+                            ecu_id=ecu_id,
+                            result=wrapper.FailureType.RECOVERABLE,
+                        )
+                    )
+            tasks.clear()
 
         # after all subecus ack the update request, update my ecu
         my_ecu_tracking_task: Optional[Coroutine] = None
@@ -545,31 +562,46 @@ class OtaClientStub:
         logger.info(f"{request=}")
         response = wrapper.RollbackResponse()
 
-        # wait for all subecus to ack the requests
         tracked_ecus_dict: Dict[str, str] = {}
-        coros: List[Coroutine] = []
+        tasks: Dict[asyncio.Task, str] = {}
         for _ecu_id, _ecu_ip in self.subecus_dict.items():
-            if request.if_contains_ecu(_ecu_id):
-                # add to tracked ecu list
-                tracked_ecus_dict[_ecu_id] = _ecu_ip
-                coros.append(
-                    OtaClientCall.rollback_call(
-                        _ecu_id,
-                        _ecu_ip,
-                        server_cfg.SERVER_PORT,
-                        request=request,
-                        # TODO: should rollback timeout has its own value?
-                        timeout=server_cfg.WAITING_SUBECU_ACK_UPDATE_REQ_TIMEOUT,
-                    )
-                )
-        logger.info(f"rollback: {tracked_ecus_dict=}")
-
-        # wait for all sub ecu acknowledge ota rollback requests
-        for rollback_resp in await asyncio.gather(*coros, return_exceptions=True):
-            if isinstance(rollback_resp, ECUNoResponse):
-                logger.error(f"failed to dispatch rollback req: {rollback_resp!r}")
+            if not request.if_contains_ecu(_ecu_id):
                 continue
-            response.merge_from(rollback_resp)
+
+            # add to tracked ecu list
+            tracked_ecus_dict[_ecu_id] = _ecu_ip
+            _task = asyncio.create_task(
+                OtaClientCall.rollback_call(
+                    _ecu_id,
+                    _ecu_ip,
+                    server_cfg.SERVER_PORT,
+                    request=request,
+                    timeout=server_cfg.WAITING_SUBECU_ACK_UPDATE_REQ_TIMEOUT,
+                )
+            )
+            tasks[_task] = _ecu_id
+
+        if tasks:  # NOTE: input for asyncio.wait must not be empty!
+            done, _ = await asyncio.wait(tasks)
+            for _task in done:
+                try:
+                    _ecu_resp: wrapper.RollbackResponse = _task.result()
+                    response.merge_from(_ecu_resp)
+                except ECUNoResponse as e:
+                    ecu_id = tasks[_task]
+                    logger.warning(
+                        f"{tasks[_task]} doesn't respond to rollback request on-time"
+                        f"(within {server_cfg.WAITING_SUBECU_ACK_UPDATE_REQ_TIMEOUT}s): {e!r}"
+                    )
+                    response.add_ecu(
+                        wrapper.RollbackResponseEcu(
+                            ecu_id=ecu_id,
+                            result=wrapper.FailureType.RECOVERABLE,
+                        )
+                    )
+            tasks.clear()
+        # NOTE: we don't track ECU rollbacking currently
+        logger.info(f"rollback: {tracked_ecus_dict=}")
 
         # after all subecus response the request, rollback my ecu
         if entry := request.if_contains_ecu(self.my_ecu_id):

--- a/tests/test_ota_client_call.py
+++ b/tests/test_ota_client_call.py
@@ -14,8 +14,9 @@
 
 
 import grpc
+import pytest
 import pytest_asyncio
-from otaclient.app.ota_client_call import OtaClientCall
+from otaclient.app.ota_client_call import ECUNoResponse, OtaClientCall
 
 from otaclient.app.proto import v2, v2_grpc, wrapper
 from tests.utils import compare_message
@@ -118,7 +119,7 @@ class TestOTAClientCall:
     OTA_CLIENT_SERVICE_IP = "127.0.0.1"
     DUMMY_ECU_ID = "autoware"
 
-    @pytest_asyncio.fixture(autouse=True)
+    @pytest_asyncio.fixture
     async def dummy_ota_client_service(self):
         server = grpc.aio.server()
         v2_grpc.add_OtaClientServiceServicer_to_server(_DummyOTAClientService(), server)
@@ -131,7 +132,7 @@ class TestOTAClientCall:
         finally:
             await server.stop(None)
 
-    async def test_update_call(self):
+    async def test_update_call(self, dummy_ota_client_service):
         _req = wrapper.UpdateRequest.convert(
             _DummyOTAClientService.DUMMY_UPDATE_REQUEST
         )
@@ -145,7 +146,7 @@ class TestOTAClientCall:
             _response.export_pb(), _DummyOTAClientService.DUMMY_UPDATE_RESPONSE
         )
 
-    async def test_rollback_call(self):
+    async def test_rollback_call(self, dummy_ota_client_service):
         _req = wrapper.RollbackRequest.convert(
             _DummyOTAClientService.DUMMY_ROLLBACK_REQUEST
         )
@@ -159,7 +160,7 @@ class TestOTAClientCall:
             _response.export_pb(), _DummyOTAClientService.DUMMY_ROLLBACK_RESPONSE
         )
 
-    async def test_status_call(self):
+    async def test_status_call(self, dummy_ota_client_service):
         _response = await OtaClientCall.status_call(
             ecu_id=self.DUMMY_ECU_ID,
             ecu_ipaddr=self.OTA_CLIENT_SERVICE_IP,
@@ -169,3 +170,16 @@ class TestOTAClientCall:
 
         assert _response is not None
         compare_message(_response.export_pb(), _DummyOTAClientService.DUMMY_STATUS)
+
+    async def test_update_call_no_response(self):
+        _req = wrapper.UpdateRequest.convert(
+            _DummyOTAClientService.DUMMY_UPDATE_REQUEST
+        )
+        with pytest.raises(ECUNoResponse):
+            await OtaClientCall.update_call(
+                ecu_id=self.DUMMY_ECU_ID,
+                ecu_ipaddr=self.OTA_CLIENT_SERVICE_IP,
+                ecu_port=self.OTA_CLIENT_SERVICE_PORT,
+                request=_req,
+                timeout=1,
+            )

--- a/tests/test_ota_client_call.py
+++ b/tests/test_ota_client_call.py
@@ -164,6 +164,7 @@ class TestOTAClientCall:
             ecu_id=self.DUMMY_ECU_ID,
             ecu_ipaddr=self.OTA_CLIENT_SERVICE_IP,
             ecu_port=self.OTA_CLIENT_SERVICE_PORT,
+            request=wrapper.StatusRequest(),
         )
 
         assert _response is not None

--- a/tests/test_ota_client_service.py
+++ b/tests/test_ota_client_service.py
@@ -114,5 +114,6 @@ class Test_ota_client_service:
             ecu_id=self.MY_ECU_ID,
             ecu_ipaddr=self.LISTEN_ADDR,
             ecu_port=self.LISTEN_PORT,
+            request=wrapper.StatusRequest(),
         )
         compare_message(status_resp, self.otaclient_service_stub.STATUS_RESP)

--- a/tools/test_utils/_status_call.py
+++ b/tools/test_utils/_status_call.py
@@ -16,7 +16,8 @@
 import itertools
 import time
 from typing import Optional
-from otaclient.app.ota_client_call import OtaClientCall
+from otaclient.app.ota_client_call import ECUNoResponse, OtaClientCall
+from otaclient.app.proto import wrapper
 from . import _logutil
 
 logger = _logutil.get_logger(__name__)
@@ -37,9 +38,9 @@ async def call_status(
     for poll_round in count_iter:
         logger.debug(f"status request#{poll_round}")
         try:
-            if response := await OtaClientCall.status_call(ecu_id, ecu_ip, ecu_port):
-                logger.debug(f"{response.export_pb()=}")
-        except Exception as e:
+            response = await OtaClientCall.status_call(ecu_id, ecu_ip, ecu_port, request=wrapper.StatusRequest())
+            logger.debug(f"{response.export_pb()=}")
+        except ECUNoResponse as e:
             logger.debug(f"API request failed: {e!r}")
             continue
         time.sleep(interval)

--- a/tools/test_utils/_update_call.py
+++ b/tools/test_utils/_update_call.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 
-import asyncio
 import yaml
-from otaclient.app.ota_client_call import OtaClientCall
+from otaclient.app.ota_client_call import ECUNoResponse, OtaClientCall
 from otaclient.app.proto import wrapper
 from . import _logutil
 
@@ -53,5 +52,5 @@ async def call_update(
             ecu_id, ecu_ip, ecu_port, request=update_request
         )
         logger.info(f"{update_response.export_pb()=}")
-    except Exception as e:
+    except ECUNoResponse as e:
         logger.exception(f"update request failed: {e!r}")


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. 

For better understanding, adding reason/motivation of this PR are also recommended.
-->

This PR aligns the behaviors of each calls in `otaclient_call` module. Now each call will only return when ECU responds, otherwise raise `ECUNoResponse` exception.

> **Note**
> This PR is required by #212.

### Motivation
Previously, status call has different behavior with update/rollback calls, which is confusing. 
Also, it is not so proper for update/rollback call to return pre-set  <FailureType: Recoverable> response for unresponsive ECUs, as this will confuse the upper caller, upper caller will not be able to tell the difference between a pre-set  <FailureType: Recoverable> response and a  <FailureType: Recoverable> returned by ECU. 

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file(s) that covers the change(s) is implemented.
- [x] local test is passed. 

## Changes

<!-- A list of code change(s) that introduced by this PR. -->

1. otaclient_call: aligns each call's behavior, define ECUNoResponse exceptin.
2. otaclient_stub: integrate new otaclient_call.
3. tools/test_utils: integrate new otaclient_call.

## Behavior changes

Does this PR introduce behavior change(s)?

- [x] Yes, internal behaivor (will not impact user experience).

### Previous behavior

<!-- Behaivor before the PR is introduced -->

Previously, `status` call and `update/rollback` calls have different behaviors:
1. status_call: return None if ECU doesn't respond,
4. update_call/rollback_call: create and return <FailureType: Recoverable> response if ECU doesn't respond.

### Behavior with this PR

<!-- Behavior after the PR is introduced -->
1. Now all calls in otaclient_call have the same behavior: only return valid response when ECU responds, otherwise raise `ECUNoResponse` exception.
2. The logic for create <FailureType: Recoverable> response for unresponsive ECU is done in `otaclient_stub` module instead.

## Breaking change

Does this PR introduce breaking change?
- [x] No.

<!-- List the breaking change(s) -->