### PR TITLE
[Refinement] refine downloader and align its behavior as doc

### DIFF
--- a/otaclient/_utils/__init__.py
+++ b/otaclient/_utils/__init__.py
@@ -11,22 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Callable, TypeVar
+from typing import Any, Callable, TypeVar
 from typing_extensions import ParamSpec
 
-T, P = TypeVar("T"), ParamSpec("P")
+P = ParamSpec("P")
 
 
-def copy_callable_typehint(_source: Callable[P, T]):  # type: ignore
+def copy_callable_typehint(_source: Callable[P, Any]):
     """This helper function return a decorator that can type hint the target
     function as the _source function.
 
-    This decorator actually does nothing, but just return the input function as it.
+    At runtime, this decorator actually does nothing, but just return the input function as it.
     But the returned function will have the same type hint as the source function in ide.
     It will not impact the runtime behavior of the decorated function.
     """
 
-    def _decorator(target) -> Callable[P, T]:
+    def _decorator(target) -> Callable[P, Any]:
         return target
 
     return _decorator

--- a/otaclient/_utils/__init__.py
+++ b/otaclient/_utils/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable
 from typing_extensions import ParamSpec
 
 P = ParamSpec("P")

--- a/otaclient/_utils/__init__.py
+++ b/otaclient/_utils/__init__.py
@@ -11,3 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Callable, TypeVar
+from typing_extensions import ParamSpec
+
+T, P = TypeVar("T"), ParamSpec("P")
+
+
+def copy_callable_typehint(_source: Callable[P, T]):  # type: ignore
+    """This helper function return a decorator that can type hint the target
+    function as the _source function.
+
+    This decorator actually does nothing, but just return the input function as it.
+    But the returned function will have the same type hint as the source function in ide.
+    It will not impact the runtime behavior of the decorated function.
+    """
+
+    def _decorator(target) -> Callable[P, T]:
+        return target
+
+    return _decorator

--- a/otaclient/app/downloader.py
+++ b/otaclient/app/downloader.py
@@ -96,6 +96,12 @@ class DownloadFailedSpaceNotEnough(DownloadError):
     pass
 
 
+class UnhandledRequestException(DownloadError):
+    """requests exception that we didn't cover.
+    If we get this exc, we should consider handle it.
+    """
+
+
 REQUEST_RECACHE_HEADER: Dict[str, str] = {
     OTAFileCacheControl.header_lower.value: OTAFileCacheControl.retry_caching.value
 }
@@ -325,8 +331,8 @@ class Downloader:
         # exception group 4: any requests error escaped from the above catching
         except requests.exceptions.RequestException as e:
             _msg = f"failed due to unhandled request error: {e!r}"
-            logger.warning(_msg)
-            raise DownloadError(url, dst, _msg) from e
+            logger.error(_msg)
+            raise UnhandledRequestException(url, dst, _msg) from e
         # exception group 5: file saving location not available
         except FileNotFoundError as e:
             _msg = f"failed due to dst not available: {e!r}"

--- a/otaclient/app/downloader.py
+++ b/otaclient/app/downloader.py
@@ -181,6 +181,7 @@ class Downloader:
         self._hash_func = sha256
         self._proxies: Dict[str, str] = {}
         self._cookies: Dict[str, str] = {}
+        self.use_http_if_http_proxy_set = False
         self.shutdowned = threading.Event()
 
         # downloading stats collecting
@@ -268,8 +269,11 @@ class Downloader:
 
             time.sleep(self.DOWNLOAD_STAT_COLLECT_INTERVAL)
 
-    def configure_proxies(self, _proxies: Dict[str, str], /):
+    def configure_proxies(
+        self, _proxies: Dict[str, str], /, use_http_if_http_proxy_set: bool = True
+    ):
         self._proxies = _proxies.copy()
+        self.use_http_if_http_proxy_set = use_http_if_http_proxy_set
 
     def configure_cookies(self, _cookies: Dict[str, str], /):
         self._cookies = _cookies.copy()
@@ -332,15 +336,13 @@ class Downloader:
         cookies: Optional[Dict[str, str]] = None,
         headers: Optional[Dict[str, str]] = None,
         compression_alg: Optional[str] = None,
-        use_http_if_proxy_set: bool = True,
     ) -> Tuple[int, int, int]:
         # NOTE: if proxy is set and use_http_if_proxy_set is true,
         #       unconditionally change scheme to HTTP
         proxies = proxies or self._proxies
-        if use_http_if_proxy_set and "http" in proxies:
+        if self.use_http_if_http_proxy_set and "http" in proxies:
             url = urlsplit(url)._replace(scheme="http").geturl()
 
-        # use input cookies or inst's cookie
         cookies = cookies or self._cookies
 
         _hash_inst = self._hash_func()

--- a/otaclient/app/downloader.py
+++ b/otaclient/app/downloader.py
@@ -118,8 +118,9 @@ def _transfer_invalid_retrier(retries: int, backoff_factor: float, backoff_max: 
         to indicate the otaproxy to redo the cache for this corrupted file.
 
     NOTE: this retry decorator expects the input func to have 'headers' kwarg.
-    NOTE: only retry on errors during/after data transfering, which are ChunkStreamingError
+    NOTE: retry on errors during/after data transfering, which are ChunkStreamingError
         and HashVerificationError.
+    NOTE: also cover the unhandled requests errors.
     """
 
     def _decorator(func: Callable[P, T]) -> Callable[P, T]:
@@ -129,7 +130,11 @@ def _transfer_invalid_retrier(retries: int, backoff_factor: float, backoff_max: 
             while True:
                 try:
                     return func(*args, **kwargs)
-                except (HashVerificaitonError, ChunkStreamingError):
+                except (
+                    HashVerificaitonError,
+                    ChunkStreamingError,
+                    UnhandledRequestException,
+                ):
                     _retry_count += 1
                     _backoff = min(
                         backoff_max,

--- a/otaclient/app/downloader.py
+++ b/otaclient/app/downloader.py
@@ -326,7 +326,7 @@ class Downloader:
         # exception group 3: raise on unhandled HTTP error(403, 404, etc.)
         except requests.exceptions.HTTPError as e:
             _msg = f"failed to download due to unhandled HTTP error: {e.strerror}"
-            logger.warning(_msg)
+            logger.error(_msg)
             raise UnhandledHTTPError(url, dst, _msg) from e
         # exception group 4: any requests error escaped from the above catching
         except requests.exceptions.RequestException as e:
@@ -336,7 +336,7 @@ class Downloader:
         # exception group 5: file saving location not available
         except FileNotFoundError as e:
             _msg = f"failed due to dst not available: {e!r}"
-            logger.warning(_msg)
+            logger.error(_msg)
             raise DestinationNotAvailableError(url, dst, _msg) from e
         # exception group 6: Disk out-of-space
         except OSError as e:

--- a/otaclient/app/downloader.py
+++ b/otaclient/app/downloader.py
@@ -53,6 +53,8 @@ logger = log_setting.get_logger(
     __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)
 )
 
+EMPTY_FILE_SHA256 = r"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
 
 class DownloadError(Exception):
     def __init__(self, url: str, dst: Any, *args: object) -> None:
@@ -156,9 +158,6 @@ class ZstdDecompressionAdapter(DecompressionAdapterProtocol):
 
 
 class Downloader:
-    EMPTY_STR_SHA256 = (
-        r"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-    )
     MAX_DOWNLOAD_THREADS = cfg.MAX_DOWNLOAD_THREAD
     MAX_CONCURRENT_DOWNLOAD = cfg.DOWNLOADER_CONNPOOL_SIZE_PER_THREAD
     CHUNK_SIZE = cfg.CHUNK_SIZE
@@ -299,12 +298,6 @@ class Downloader:
         compression_alg: Optional[str] = None,
         use_http_if_proxy_set: bool = True,
     ) -> Tuple[int, int, int]:
-        # special treatment for empty file
-        if digest == self.EMPTY_STR_SHA256:
-            if not (dst_p := Path(dst)).is_file():
-                dst_p.write_bytes(b"")
-            return 0, 0, 0
-
         # NOTE: if proxy is set and use_http_if_proxy_set is true,
         #       unconditionally change scheme to HTTP
         _proxies = proxies or self._proxies

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -26,6 +26,7 @@ from urllib.parse import urlsplit, urljoin
 
 from otaclient.app.common import file_sha256, urljoin_ensure_base
 from otaclient.app.downloader import (
+    DownloadError,
     Downloader,
     DestinationNotAvailableError,
     ChunkStreamingError,
@@ -186,10 +187,10 @@ class TestDownloader:
         "inject_requests_err, expected_ota_download_err",
         (
             (requests.exceptions.ChunkedEncodingError, ChunkStreamingError),
-            (requests.exceptions.ConnectionError, ChunkStreamingError),
+            (requests.exceptions.ConnectionError, ExceedMaxRetryError),
             (requests.exceptions.HTTPError, UnhandledHTTPError),
             (FileNotFoundError, DestinationNotAvailableError),
-            (requests.exceptions.RequestException, ExceedMaxRetryError),
+            (requests.exceptions.RequestException, DownloadError),
         ),
     )
     def test_download_errors_handling(

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -62,7 +62,7 @@ class _SimpleDummyApp:
         await send({"type": "http.response.body", "body": _input_status_code.encode()})
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def launch_dummy_server(host: str = "127.0.0.1", port: int = 9999):
     _should_exit = threading.Event()
 


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. 

For better understanding, adding reason/motivation of this PR are also recommended.
-->

With the [implementation document](https://tier4.atlassian.net/l/cp/HTKBH3Yo) ready, this PR aligns `downloader` module's behavior as document, and introduce many internal refinements for improved implementation/code readability, better error handlings, minor mechanism/workflow refinement, etc.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file(s) that covers the change(s) is implemented.
- [x] local test is passed. 

## Changes

<!-- A list of code change(s) that introduced by this PR. -->

1. `_utils`: implement a type hinting helper method `copy_callable_typehint`, which copies one callable's paras annotation to another callable,
2. `downloader`: simplify `Downloader` active detection logic, remove unused related code,
3. `downloader`, `otaclient`: now special treatment for downloading empty file is handled in `otaclient` side(skip downloading empty file on otaclient side),
4. `downloader`: define new error type `UnhandledRequestException` for exceptions from `requests` that doesn't handle by our exception catching group,
5. `downloader`: reimplement outer retrier(rename to `_transfer_invalid_retrier`), outer retrier now only retries on invalid data transfer(`HashVerificaitonError`, `ChunkStreamingError`) and unhandled exceptions from `requests` (`UnhandledRequestException`, as last resort),
6. `downloader`: refine the way of gathering `downloaded_bytes`, simplify the implementation,
7. `downloader`: `use_http_if_http_proxy_set` now only configured once, via `configure_proxies` method,
8. `downloader`: exceptions handling logic is split from `download_task` method into a standalone `_downloading_exception_mapping` helper context manager to improve code readability and reduce code cognitive complexity,
9. `downloader`: exception handling is refined according to the implementation document, also previously exceptions that logged with `warning` is now logged as `error`,
10. `downloader`: for `download` and `download_retry_inf`, use the helper `copy_callable_typehint` to type hint the params instead,
11. implement test files that covers the changes(new error handling, proxy and cookie settings),
12. refine `test_downloader`, reduce test time cost.

## Behavior changes

Does this PR introduce behavior change(s)?

- [x] Yes, internal behaivor (will not impact user experience).

### Behavior with this PR

<!-- Behavior after the PR is introduced -->

1. special treatment for empty file is now fully handled in `otaclient` module instead, `downloader` no-longer handles this,
2. `use_http_if_http_proxy_is_set` flag is now `Downloader` instance scope, only configured once via `configure_proxies`,
3. exception catching group is refined according to document, check implementation document for more details,
4. no extra mechanism is implemented for active detection, now downloader active tracking is done by checking if `downloaded_bytes` increased or not,
5. outer retrier now only retries on invalid data transfer(`HashVerificaitonError`, `ChunkStreamingError`) and unhandled exceptions from `requests` (`UnhandledRequestException`, as last resort).

## Breaking change

Does this PR introduce breaking change?
- [x] No.

<!-- List the breaking change(s) -->

## Related links & tickets

<!-- List of tickets or links related to this PR -->

1. [downloader module implementation document](https://tier4.atlassian.net/l/cp/HTKBH3Yo) 