### PR TITLE
[Fix] rpi_boot: call os.sync on all important files replacement

### DIFF
--- a/otaclient/app/boot_control/_rpi_boot.py
+++ b/otaclient/app/boot_control/_rpi_boot.py
@@ -301,8 +301,8 @@ class _RPIBootControl:
                 replace_atomic(self.config_txt_standby_slot, self.tryboot_txt)
                 logger.info(
                     "finalizing boot configuration,"
-                    f"replace {self.config_txt=} with {self.config_txt_active_slot}, "
-                    f"replace {self.tryboot_txt=} with {self.config_txt_standby_slot}"
+                    f"replace {self.config_txt=} with {self.config_txt_active_slot=}, "
+                    f"replace {self.tryboot_txt=} with {self.config_txt_standby_slot=}"
                 )
                 self._update_firmware()
                 # set the flag file
@@ -342,7 +342,7 @@ class _RPIBootControl:
         try:
             replace_atomic(self.config_txt_standby_slot, self.tryboot_txt)
             logger.info(
-                f"replace {self.tryboot_txt=} with {self.config_txt_standby_slot}"
+                f"replace {self.tryboot_txt=} with {self.config_txt_standby_slot=}"
             )
         except Exception as e:
             _err_msg = f"failed to prepare tryboot.txt for {self._standby_slot}"

--- a/otaclient/app/boot_control/_rpi_boot.py
+++ b/otaclient/app/boot_control/_rpi_boot.py
@@ -299,11 +299,17 @@ class _RPIBootControl:
             else:
                 replace_atomic(self.config_txt_active_slot, self.config_txt)
                 replace_atomic(self.config_txt_standby_slot, self.tryboot_txt)
+                logger.info(
+                    "finalizing boot configuration,"
+                    f"replace {self.config_txt=} with {self.config_txt_active_slot}, "
+                    f"replace {self.tryboot_txt=} with {self.config_txt_standby_slot}"
+                )
                 self._update_firmware()
                 # set the flag file
                 write_str_to_file_sync(_flag_file, "")
                 # reboot to the same slot to apply the new firmware
-                logger.info("2stage reboot: apply new firmware...")
+
+                logger.info("reboot to apply new firmware...")
                 CMDHelperFuncs.reboot()
                 return True
         except Exception as e:
@@ -335,6 +341,9 @@ class _RPIBootControl:
         logger.debug("prepare tryboot.txt...")
         try:
             replace_atomic(self.config_txt_standby_slot, self.tryboot_txt)
+            logger.info(
+                f"replace {self.tryboot_txt=} with {self.config_txt_standby_slot}"
+            )
         except Exception as e:
             _err_msg = f"failed to prepare tryboot.txt for {self._standby_slot}"
             logger.error(_err_msg)

--- a/otaclient/app/boot_control/_rpi_boot.py
+++ b/otaclient/app/boot_control/_rpi_boot.py
@@ -222,6 +222,7 @@ class _RPIBootControl:
         logger.info("update firmware with flash-kernel...")
         try:
             subprocess_call("flash-kernel", raise_exception=True)
+            os.sync()
         except Exception as e:
             logger.error(f"flash-kernel failed: {e!r}")
             raise
@@ -236,11 +237,10 @@ class _RPIBootControl:
                 _initrd_img := Path(cfg.SYSTEM_BOOT_MOUNT_POINT) / cfg.INITRD_IMG
             ).is_file():
                 os.replace(_initrd_img, self.initrd_img_active_slot)
+            os.sync()
         except Exception:
             logger.error(f"apply new kernel,initrd.img for {self.active_slot} failed")
             raise
-
-        os.sync()
 
     # exposed API methods/properties
     @property

--- a/otaclient/app/common.py
+++ b/otaclient/app/common.py
@@ -315,9 +315,9 @@ def replace_atomic(src: Union[str, Path], dst: Union[str, Path]):
     try:
         # prepare a copy of src file under dst's parent folder
         shutil.copy(src, _tmp_file, follow_symlinks=True)
-        os.sync()
         # atomically rename/replace the dst file with the copy
         os.replace(_tmp_file, dst)
+        os.sync()
     except Exception:
         _tmp_file.unlink(missing_ok=True)
         raise


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->

There is report that rpi_boot doesn't replace `config.txt` properly in the 1st reboot after firmware update, causing 2nd reboot still boots back to old slot. I read through the source code and found that, in `common.replace_atomic`, `os.sync` is called only after `shutil.copy`, `os.replace` is not covered by `os.sync`. 
This PR fix the `common.replace_atomic` method, while insert more `os.sync` on important file preparing like linux images moving and after firmware update to ensure the changes are write to the disk.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file that covers the bug case(s) is implemented.
- [x] local test is passed. 

## Bug fix

1. `common.replace_atomic`: now `os.sync` is called AFTER `os.replace`, ensure that replace operation is also written to the disk.

## Other changes

1. rpi_boot: add more loggings when important files are prepared.

## Related links & ticket

<!-- List of tickets or links related to this PR -->

[RT4-5266](https://tier4.atlassian.net/browse/RT4-5266)

[RT4-5266]: https://tier4.atlassian.net/browse/RT4-5266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ