### PR TITLE
[Fix] cboot.is_switching_boot: only check ota_status and slot_in_use

### DIFF
--- a/otaclient/app/boot_control/_cboot.py
+++ b/otaclient/app/boot_control/_cboot.py
@@ -352,6 +352,7 @@ class CBootController(
 
         if _ota_status in [wrapper.StatusOta.UPDATING, wrapper.StatusOta.ROLLBACKING]:
             if self._is_switching_boot():
+                logger.info("finalizing switching boot...")
                 # set the current slot(switched slot) as boot successful
                 self._cboot_control.mark_current_slot_boot_successful()
                 # switch ota_status
@@ -408,7 +409,7 @@ class CBootController(
         )
         if _is_switching_boot and not _nvboot_res:
             logger.warning(
-                f"{_ota_status=} and {_is_slot_in_use=}"
+                f"{_ota_status=} and {_is_slot_in_use=} "
                 "show that we should be in finalizing switching boot stage,"
                 f"but this slot is not marked as unbootable."
             )


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->

This PR lifts the conditions check for `is_switching_boot`, as long as the `ota_status` and `slot_in_use` indicates that we are in finalizing switching boot stage, we do the finalizing.

If `ota_status` and `slot_in_use` indicates a successful switching boot, but `nvbootctrl` shows the slot is not `unbootable`, only issue a warning for it. (check the following section about nvbootctl for more details).

### Introduction on cboot switching boot mechanism(related to nvbootctl part)

1. pre-update: set the standby_slot as `unbootable` as we are going to apply update to it,
2. post-update: set the active boot slot to standby slot,
( ... reboot ...)
3. bootctrl_init: check `is_switching_boot` by checking `ota_status`, `slot_in_use` and if this slot is marked as `unbootable`,
4. bootctrl_init: finalizing switching_boot, set this slot as `bootable(successful)`.

Setting standby slot to `unbootable` before applying OTA serves 2 purposes:
1. prevent the ECU from accidentally booting into OTA unfinished standby slot,
2. if after reboot, somehow the OS on the just updated standby slot is not working, next reboot will let the ECU boots back to the previous working active slot.

### Motivation for lift the `is_switching_boot` conditions check

Although in most of the cases, when after reboot and in finalizing switch boot stage, 
1. `ota_status` for this slot is `UPDATING`,
2. `slot_in_use` is this slot,
3. this slot is marked as `unbootable`,
the above conditions are all met, but actually only condition#1 and condition#2 are true is enough, these 2 conditions are already enough to confirm that we boot into new slot successfully and the OS on standby slot is working(at least allowing the otaclient to start).

However, currently we only think switching boot is successful if all 3 conditions are met, this is too strict. If the condition 3 is not met but 1 and 2 are met, only issuing a warning is enough instead of refusing to finalizing the switching boot.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test on real machine

## Bug fix

### Current behavior

1. cboot will refuse to finalize the swiching_boot and resulting in ota_status FAILURE if not all three conditions for checking `is_switching_boot` are met.

### Behaivor after fix

1. cboot will do the switching boot finalizing when condition#1 and condition#2 are met, if condition#3 is not met, only issue a warning for it.

## Related links & ticket

<!-- List of tickets or links related to this PR -->

[RT4-5237](https://tier4.atlassian.net/browse/RT4-5237)

[RT4-5237]: https://tier4.atlassian.net/browse/RT4-5237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ