### PR TITLE
[Fix] cboot: fix wrong usage of mark-boot-successful, add dump-slots-info logging

### DIFF
--- a/otaclient/app/boot_control/_cboot.py
+++ b/otaclient/app/boot_control/_cboot.py
@@ -130,6 +130,12 @@ class Nvbootctrl:
             raise NvbootctrlError
 
     @classmethod
+    def dump_slots_info(cls) -> str:
+        return cls._nvbootctrl(
+            "dump-slots-info", call_only=False, raise_exception=False
+        )
+
+    @classmethod
     def mark_boot_successful(cls, slot: str):
         cls._nvbootctrl(f"mark-boot-successful {slot}")
 
@@ -175,6 +181,7 @@ class _CBootControl:
 
             # initializing dev info
             self._init_dev_info()
+            logger.info(f"finished cboot control init: {Nvbootctrl.dump_slots_info()=}")
         except NotImplementedError as e:
             raise BootControlPlatformUnsupported from e
         except Exception as e:
@@ -530,6 +537,8 @@ class CBootController(
             logger.info("post update finished, rebooting...")
             self._umount_all(ignore_error=True)
             self._cboot_control.switch_boot()
+
+            logger.info(f"[post-update]: {Nvbootctrl.dump_slots_info()=}")
             yield  # hand over control back to otaclient
             CMDHelperFuncs.reboot()
         except _errors.BootControlError as e:

--- a/otaclient/app/boot_control/_cboot.py
+++ b/otaclient/app/boot_control/_cboot.py
@@ -130,14 +130,15 @@ class Nvbootctrl:
             raise NvbootctrlError
 
     @classmethod
-    def dump_slots_info(cls) -> str:
+    def dump_slots_info(cls) -> Optional[str]:
         return cls._nvbootctrl(
             "dump-slots-info", call_only=False, raise_exception=False
         )
 
     @classmethod
-    def mark_boot_successful(cls, slot: str):
-        cls._nvbootctrl(f"mark-boot-successful {slot}")
+    def mark_boot_successful(cls):
+        """Mark current slot as boot successfully."""
+        cls._nvbootctrl("mark-boot-successful")
 
     @classmethod
     def set_active_boot_slot(cls, slot: str, target="rootfs"):
@@ -258,8 +259,8 @@ class _CBootControl:
         return self.is_rootfs_on_external
 
     def mark_current_slot_boot_successful(self):
-        slot = self.current_slot
-        Nvbootctrl.mark_boot_successful(slot)
+        logger.info(f"mark {self.current_slot=} as boot successful")
+        Nvbootctrl.mark_boot_successful()
 
     def set_standby_slot_unbootable(self):
         slot = self.standby_slot

--- a/tests/test_boot_control/test_cboot.py
+++ b/tests/test_boot_control/test_cboot.py
@@ -233,6 +233,7 @@ class TestCBootControl:
         mocker.patch(
             f"{cfg.BOOT_CONTROL_COMMON_MODULE_PATH}.CMDHelperFuncs", _CMDHelper_mock
         )
+        mocker.patch(f"{cfg.CBOOT_MODULE_PATH}.Nvbootctrl")
 
         ###### binding mocked object to test instance ######
         self._CBootControl_mock = _CBootControl_mock


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->

This PR fixes the wrong usage of `nvbootctrl -t rootfs mark-boot-successful`, `mark-boot-successful` doesn't take argument and only works for current slot(although appended argument will be ignored and the command will work). 
For debug purpose, add logging of `dump-slots-info` call at cboot finishing init and post-update.

## Bug fix

1. cboot controller use `mark-boot-successful` incorrectly, this command doesn't take argument and can only mark the current slot as successful.

## Related links & ticket

<!-- List of tickets or links related to this PR -->

1. [RT0-28367](https://tier4.atlassian.net/browse/RT0-28367)
2. investigation report: https://tier4.atlassian.net/l/cp/VZbEuJVV

[RT0-28367]: https://tier4.atlassian.net/browse/RT0-28367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ