### PR TITLE
[Refinement] otaproxy: remove cache scrubbing, instead only checking over cache db file

### DIFF
--- a/otaclient/app/ota_client.py
+++ b/otaclient/app/ota_client.py
@@ -338,7 +338,6 @@ class _OTAUpdater:
                 f"use {self.proxy=} for local OTA update, "
                 f"wait for otaproxy@{self.proxy} online..."
             )
-            # TODO: make otaproxy scrubing not blocking the otaproxy starts
             ensure_otaproxy_start(self.proxy)
             # NOTE(20221013): check requests document for how to set proxy,
             #                 we only support using http proxy here.

--- a/otaclient/ota_proxy/README.md
+++ b/otaclient/ota_proxy/README.md
@@ -18,7 +18,7 @@ proxy server to serve multiple ECUs' update simultaneously.
 
 ### Static configuration
 
-The behavior of ota-proxy can be adjusted by modifying the config.py. The common use configurations are as follow:
+The behavior of ota-proxy can be adjusted by modifying the `config.py`. The common use configurations are as follow:
 
 1. **BASE_DIR**: the cache folder to store cache entries.
 2. **DISK_USE_LIMIT_SOFT_P**: when reached, ota-proxy will enable LRU cache rotate to reserver space for new cached files.
@@ -27,13 +27,30 @@ The behavior of ota-proxy can be adjusted by modifying the config.py. The common
 
 ### Runtime configuration
 
-Runtime configuration is configured by setting up `ota-cache` instance when launching ota-proxy.
+Runtime configuration can be configured by passing parameters to CLI.
 
-1. **upper_proxy** str: the upper proxy that ota_cache uses to send out request, default is None
-2. **cache_enabled** bool: when set to False, ota_cache will only relay requested data, default is False.
-3. **enable_https** bool: whether the ota_cache should send out the requests with HTTPS, default is False. NOTE: scheme change is applied unconditionally.
-4. **init_cache** bool: whether to clear the existed cache, default is True.
-5. **scrub_cache_event**: optional, an multiprocessing.Event that sync status with the ota-client.
+```python
+usage: ota_proxy [-h] [--host HOST] [--port PORT] [--upper-proxy UPPER_PROXY]
+                 [--enable-cache] [--enable-https] [--init-cache]
+                 [--cache-dir CACHE_DIR] [--cache-db-file CACHE_DB_FILE]
+
+ota_proxy server with local cache feature
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --host HOST           server listen ip (default: 0.0.0.0)
+  --port PORT           server listen port (default: 8080)
+  --upper-proxy UPPER_PROXY
+                        upper proxy that used for requesting remote (default: )
+  --enable-cache        enable local ota cache (default: False)
+  --enable-https        enable HTTPS when retrieving data from remote (default: False)
+  --init-cache          cleanup remaining cache if any (default: False)
+  --cache-dir CACHE_DIR
+                        where to store the cache entries (default: /ota-cache)
+  --cache-db-file CACHE_DB_FILE
+                        the location of cache db sqlite file (default: /ota-
+                        cache/cache_db)
+```
 
 ## Usage
 

--- a/otaclient/ota_proxy/__main__.py
+++ b/otaclient/ota_proxy/__main__.py
@@ -56,12 +56,12 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--cache-dir",
-        helper="where to store the cache entries",
+        help="where to store the cache entries",
         default=cfg.BASE_DIR,
     )
     parser.add_argument(
         "--cache-db-file",
-        helper="the location of cache db sqlite file",
+        help="the location of cache db sqlite file",
         default=cfg.DB_FILE,
     )
     args = parser.parse_args()

--- a/otaclient/ota_proxy/ota_cache.py
+++ b/otaclient/ota_proxy/ota_cache.py
@@ -645,7 +645,6 @@ class OTACache:
         enable_https: whether the ota_cache should send out the requests with HTTPS,
             default is False. NOTE: scheme change is applied unconditionally.
         init_cache: whether to clear the existed cache, default is True.
-        scrub_cache_event: an multiprocessing.Event that sync status with the ota-client.
         base_dir: the location to store cached files.
         db_file: the location to store database file.
     """

--- a/tests/test_ota_proxy/test_cachedb.py
+++ b/tests/test_ota_proxy/test_cachedb.py
@@ -16,9 +16,10 @@
 import logging
 import pytest
 import sqlite3
-import time
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple
+from os import urandom
+from pathlib import Path
+from typing import Any, Dict, Tuple
 from otaclient.ota_proxy.ota_cache import CacheMeta, OTACacheDB
 from otaclient.ota_proxy import config as cfg
 
@@ -168,20 +169,12 @@ class TestORM:
 
 
 class TestOTACacheDB:
-    @pytest.fixture(scope="class")
-    def setup_db(self):
-        """Setup a new conn to a in-memory otacache_db."""
-        try:
-            ota_cache_db = OTACacheDB(":memory:", init=True)
-            time.sleep(0.5)
-            yield ota_cache_db
-        finally:
-            ota_cache_db.close()
+    @pytest.fixture(autouse=True)
+    def prepare_db(self, tmp_path: Path):
+        self.db_f = db_f = tmp_path / "db_f"
+        self.entries = entries = []
 
-    @pytest.fixture(scope="class")
-    def prepare_entries(self):
-
-        entries: List[CacheMeta] = []
+        # prepare data
         for target_size, rotate_num in cfg.BUCKET_FILE_SIZE_DICT.items():
             for _i in range(rotate_num):
                 entries.append(
@@ -191,25 +184,49 @@ class TestOTACacheDB:
                         size=target_size,
                     )
                 )
-        return entries
+        # insert entry into db
+        OTACacheDB.init_db_file(db_f)
+        with OTACacheDB(db_f) as db_conn:
+            db_conn.insert_entry(*self.entries)
 
-    @pytest.fixture(autouse=True)
-    def setup_test(self, setup_db, prepare_entries):
-        self.ota_cache_db: OTACacheDB = setup_db
-        self.entries: List[CacheMeta] = prepare_entries
+        # prepare connection
+        try:
+            self.conn = OTACacheDB(self.db_f)
+            yield
+        finally:
+            self.conn.close()
 
-    def test_insert(self):
-        """
-        insert all prepared entries into the database
-        """
-        assert self.ota_cache_db.insert_entry(*self.entries) == len(self.entries)
+    def test_insert(self, tmp_path: Path):
+        db_f = tmp_path / "db_f2"
+        # first insert
+        OTACacheDB.init_db_file(db_f)
+        with OTACacheDB(db_f) as db_conn:
+            assert db_conn.insert_entry(*self.entries) == len(self.entries)
+        # check the insertion with another connection
+        with OTACacheDB(db_f) as db_conn:
+            _all = db_conn.lookup_all()
+            # should have the same order as insertion
+            assert _all == self.entries
+
+    def test_db_corruption(self, tmp_path: Path):
+        test_db_f = tmp_path / "corrupted_db_f"
+        # intensionally create corrupted db file
+        with open(self.db_f, "rb") as src, open(test_db_f, "wb") as dst:
+            count = 0
+            while data := src.read(32):
+                count += 1
+                dst.write(data)
+                if count % 2 == 0:
+                    dst.write(urandom(8))
+
+        assert not OTACacheDB.check_db_file(test_db_f)
 
     def test_lookup_all(self):
         """
         NOTE: the timestamp update is only executed at lookup method
         """
         entries_set = set(self.entries)
-        checked_entries = self.ota_cache_db.lookup_all()
+        checked_entries = self.conn.lookup_all()
         assert entries_set == set(checked_entries)
 
     def test_lookup(self):
@@ -218,9 +235,9 @@ class TestOTACacheDB:
         """
         target = self.entries[-1]
         # lookup once to update last_acess
-        checked_entry = self.ota_cache_db.lookup_entry(CacheMeta.url, target.url)
+        checked_entry = self.conn.lookup_entry(CacheMeta.url, target.url)
         assert checked_entry == target
-        checked_entry = self.ota_cache_db.lookup_entry(CacheMeta.url, target.url)
+        checked_entry = self.conn.lookup_entry(CacheMeta.url, target.url)
         assert checked_entry and checked_entry.last_access > target.last_access
 
     def test_delete(self):
@@ -229,10 +246,10 @@ class TestOTACacheDB:
         """
         bucket_size = 8 * (1024**2)
         assert (
-            self.ota_cache_db.remove_entries(CacheMeta.bucket_idx, bucket_size)
+            self.conn.remove_entries(CacheMeta.bucket_idx, bucket_size)
             == cfg.BUCKET_FILE_SIZE_DICT[bucket_size]
         )
         assert (
-            len(self.ota_cache_db.lookup_all())
+            len(self.conn.lookup_all())
             == len(self.entries) - cfg.BUCKET_FILE_SIZE_DICT[bucket_size]
         )


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. 

For better understanding, adding reason/motivation of this PR are also recommended.
-->

> **Note**
> This PR is split from #225 . 

This PR removes the ota_cache scrubbing feature from otaproxy subprocess init, instead it introduces the mechanism of checking over the cache db file, and improve handling the case of cache db corrupted.

### Motivation for removing cache scrubbing on startup

Previously, if there are a lot of left-over cache files(from last failed OTA), otaproxy will take a long time to start due to it will scan and validate all cache files against database records(scrubbing) before startup. This will result in blocking other ECUs that requires this otaproxy for a long time.
The original idea is that, it might be damaged files when last OTA failed. But actually the possibility of damaged cache files is low as cache files will only be registered AFTER the caching is finished, interrupted caching will not be registered in cache database.
Moreover, we already have ota_cache control headers, mechanism and otaclient side file validation, otaclient will report to otaproxy if the cache file is invalid, and indicate otaproxy to re-download the file again.
So in conclusion, the benefit of cache scrubbing before otaproxy starts it very limited, comparing to the overhead/delay it introduces, so it is ideal to remove this feature.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file(s) that covers the change(s) is implemented.
- [x] local test is passed. 
- [x] test on single VM passed.

## Changes

<!-- A list of code change(s) that introduced by this PR. -->

1. `otaproxy._subprocess_main`: remove cache scrub.
2. `otaproxy.ota_cache`: remove `OTACacheSrubHelper` and related code, 
3. `otaproxy.db`: use `time.time()` instead of `datetime.now().timestamp()` to query the current UNIX timestamp,
4. `otaproxy.db`: `OTACacheDB` implements 2 new helper methods, `check_db_file` and `init_db_file`, especially, `check_db_file` will check the db files' integrity,
5. `otaproxy.db`: now `db` module doesn't take care of initializing database file if database file is invalid, the caller of `OTACacheDB` should use newly implemented helper methods `check_db_file` and `init_db_file` to check and init db file, raise exception on invalid db file,
6. `otaproxy.ota_cache.OTACache`: implement `_check_cache_db` helper method,  db file checking and initializing on invalid db file is fully handled by `OTACache.start` API,
7. update test files accordingly.

## Behavior changes

Does this PR introduce behavior change(s)?

- [x] Yes, internal behaivor (will not impact user experience).
- [x] Yes, external behavior (user will notice the change). 

### Previous behavior

<!-- Behaivor before the PR is introduced -->

1. (external behavior) if there are entries in `ota_cache` folder(which is left by previous failed OTA update), otaclient will scrub through all the entries before it starts otaproxy server. when there are a lot of entries, user will notice a delay between OTA triggered and OTA actually starts due to otaproxy delayed launching,
2. (internal behavior) `otaproxy.db.OTACacheDB` initializing handles the db file checking and initializing if db file is invalid,

### Behavior with this PR

<!-- Behavior after the PR is introduced -->

1. (external behavior) scrubbing over `ota_cache` is removed, instead only removing unfinished tmp entries. The delay of otaproxy launching is resolved. Corrupted or invalid cache will be notified by otaclient with `OTA-Cache-Control` header, and otaproxy will cleanup those invalid entries.
2. (internal behavior) now `db.OTACacheDB` __init__ method nolonger takes care of initializing new db file on invalid db file, the caller should take the responsibility for it(with using `check_db_file` and `init_db_file` helper methods),
3. (internal behavior) `db.OTACacheDB.check_db_file` method also checks the db file's integrity(by executing `PRAGMA integrity_check;`),
4. (internal behavior) `ota_cache.OTACache` now take fully responsibility for checking and initializing ota_cache on invalid db file, 

## Breaking change

Does this PR introduce breaking change?
- [x] No.

<!-- List the breaking change(s) -->

## Related links & tickets

<!-- List of tickets or links related to this PR -->