### PR TITLE
[Fix] boot_control.grub: fix update_grub_default

### DIFF
--- a/otaclient/app/boot_control/_grub.py
+++ b/otaclient/app/boot_control/_grub.py
@@ -217,10 +217,16 @@ class GrubHelper:
                 res.append(option_line)
                 continue
 
-            key, _ = option_line.strip().split("=")
-            if key in kvp:
-                option_line = "=".join((key, kvp[key]))
-                del kvp[key]
+            # NOTE(20230619): skip illegal option that
+            #                 is not in key=value form.
+            _raw_split = option_line.strip().split("=", maxsplit=1)
+            if len(_raw_split) != 2:
+                continue
+
+            option_name, _ = _raw_split
+            if option_name in kvp:
+                option_line = "=".join((option_name, kvp[option_name]))
+                del kvp[option_name]
 
             res.append(option_line)
 

--- a/tests/test_boot_control/default_grub
+++ b/tests/test_boot_control/default_grub
@@ -7,7 +7,7 @@ GRUB_DEFAULT=1
 GRUB_TIMEOUT_STYLE=menu
 GRUB_TIMEOUT=10
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
-GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"
+GRUB_CMDLINE_LINUX_DEFAULT="quiet splash pcie_aspm=off"
 GRUB_CMDLINE_LINUX=""
 
 # Uncomment to enable BadRAM filtering, modify to suit your needs


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->

This PR fixes options parsing in `boot_control.grub.update_grub_default` method. Currently implementation expects only one `=` will occur in each line of option, which is wrong as option value might include `=`.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file that covers the bug case(s) is implemented.
- [x] local test is passed. 

## Bug fix

1. `update_grub_default` method will raise exception when grub default contains option that has `=` in option value.