### PR TITLE
[Fix] boot_ctrl.cboot: post_update error handling

### DIFF
--- a/otaclient/app/boot_control/_cboot.py
+++ b/otaclient/app/boot_control/_cboot.py
@@ -510,8 +510,8 @@ class CBootController(
             self._store_standby_slot_in_use(_target_slot)
 
             logger.info("pre-update setting finished")
-        except _errors.BootControlError as e:
-            logger.error(f"failed on pre_update: {e!r}")
+        except Exception as e:
+            logger.exception(f"failed on pre_update: {e!r}")
             raise BootControlPreUpdateFailed from e
 
     def post_update(self) -> Generator[None, None, None]:
@@ -563,14 +563,13 @@ class CBootController(
             # store ROLLBACKING status to standby
             self._store_standby_ota_status(wrapper.StatusOta.ROLLBACKING)
         except Exception as e:
-            logger.error(f"failed on pre_rollback: {e!r}")
-            # TODO: bootcontrol prerollback failure
+            logger.exception(f"failed on pre_rollback: {e!r}")
             raise BootControlPreRollbackFailed from e
 
     def post_rollback(self):
         try:
             self._cboot_control.switch_boot()
             CMDHelperFuncs.reboot()
-        except _errors.BootControlError as e:
-            logger.error(f"failed on post_rollback: {e!r}")
+        except Exception as e:
+            logger.exception(f"failed on post_rollback: {e!r}")
             raise BootControlPostRollbackFailed from e

--- a/otaclient/app/boot_control/_cboot.py
+++ b/otaclient/app/boot_control/_cboot.py
@@ -535,7 +535,6 @@ class CBootController(
 
             # NOTE: we didn't prepare /boot/ota here,
             #       process_persistent does this for us
-
             if self._cboot_control.is_external_rootfs_enabled():
                 logger.info(
                     "rootfs on external storage detected: "
@@ -550,8 +549,8 @@ class CBootController(
             logger.info(f"[post-update]: {Nvbootctrl.dump_slots_info()=}")
             yield  # hand over control back to otaclient
             CMDHelperFuncs.reboot()
-        except _errors.BootControlError as e:
-            logger.error(f"failed on post_update: {e!r}")
+        except Exception as e:
+            logger.exception(f"failed on post_update: {e!r}")
             raise BootControlPostUpdateFailed from e
 
     def pre_rollback(self):

--- a/otaclient/app/boot_control/_common.py
+++ b/otaclient/app/boot_control/_common.py
@@ -58,6 +58,9 @@ class CMDHelperFuncs:
     ):
         """
         mount [-o option1[,option2, ...]]] [args[0] [args[1]...]] <dev> <mount_point>
+
+        Raises:
+            MountError on failed mounting.
         """
         _option_str = ""
         if options:
@@ -259,6 +262,9 @@ class CMDHelperFuncs:
 
         NOTE: pass args = ["--make-private", "--make-unbindable"] to prevent
               mount events propagation to/from this mount point.
+
+        Raises:
+            MountError on failed mounting.
         """
         options = ["rw"]
         args = ["--make-private", "--make-unbindable"]
@@ -270,6 +276,9 @@ class CMDHelperFuncs:
 
         NOTE: pass args = ["--make-private", "--make-unbindable"] to prevent
               mount events propagation to/from this mount point.
+
+        Raises:
+            MountError on failed mounting.
         """
         options = ["bind", "ro"]
         args = ["--make-private", "--make-unbindable"]
@@ -277,6 +286,11 @@ class CMDHelperFuncs:
 
     @classmethod
     def umount(cls, target: Union[Path, str], *, ignore_error=False):
+        """Try to unmount the <target>.
+
+        Raises:
+            If ignore_error is False, raises MountError on failed unmounting.
+        """
         # first try to check whether the target(either a mount point or a dev)
         # is mounted
         if not cls.is_target_mounted(target):
@@ -293,10 +307,15 @@ class CMDHelperFuncs:
             logger.warning(_failure_msg)
 
             if not ignore_error:
-                raise BootControlError(_failure_msg) from None
+                raise MountError(_failure_msg) from None
 
     @classmethod
     def mkfs_ext4(cls, dev: str, *, fslabel: Optional[str] = None):
+        """Call mkfs.ext4 on <dev>.
+
+        Raises:
+            MkfsError on failed ext4 partition formatting.
+        """
         # NOTE: preserve the UUID and FSLABEL(if set)
         _specify_uuid = ""
         try:
@@ -334,6 +353,9 @@ class CMDHelperFuncs:
 
         This method bind mount refroot as ro with make-private flag and make-unbindable flag,
         to prevent ANY accidental writes/changes to the refroot.
+
+        Raises:
+            MountError on failed mounting.
         """
         _refroot_dev = standby_slot_dev if standby_as_ref else active_slot_dev
 
@@ -362,6 +384,9 @@ class CMDHelperFuncs:
 
         This method mount the target as ro with make-private flag and make-unbindable flag,
         to prevent ANY accidental writes/changes to the target.
+
+        Raises:
+            MountError on failed mounting.
         """
         # NOTE: set raise_exception to false to allow not mounted
         #       not mounted dev will have empty return str


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->

This PR fixes boot_ctrl.cboot module's error handling in `post_update` method. With this PR, all exceptions during `post_update`(and `pre_update`, `pre_rollback`, `post_rollback`) will be captured, and `BootControlPostUpdateFailed` OTA failure exception will be raised(otaclient will report OTA failure via status API request with this OTA failure exception) from the captured exception, and also a `logging.exception` will be triggered for the captured exception.

Also, `cboot._populate_boot_folder_to_separate_bootdev` is refined to increase the error handling granularity, now _failure on mounting standby boot dev_ and _failure on boot folder copying_ will be handled and logged separately.

> **Note**
> The cause of reported failure on `_populate_boot_folder_to_separate_bootdev` is not fixed by this PR, but this PR provides logging and makes otaclient reports OTA failure properly on this failure.

## Other minor changes

1. `boot_control.common`: add more docs for mounting related helper methods, these helper methods both use `_mount` helper method, so they both raise `MountError` on failure.

## Bug fix

1. in `cboot.post_update`, unexpected failure on `_populate_boot_folder_to_separate_bootdev` will cause the OTA failed silently without any logging or OTA failure report via status API.

### Behaivor after fix

1. any exceptions during `post_update`(and `pre_update`, `pre_rollback`, `post_rollback`)  will be handled, `BootControlPostUpdateFailed`(and corresponding OTA failure exception) will be raised from the captured exception, logging for this exception will be triggered and otaclient will report OTA failure regarding the exception.

## Related links & ticket

<!-- List of tickets or links related to this PR -->