### PR TITLE
[Deps] bumps grpcio to 1.53.1

### DIFF
--- a/otaclient/requirements.txt
+++ b/otaclient/requirements.txt
@@ -1,6 +1,6 @@
 pyOpenSSL==23.0.0
 cryptography>=39.0.1, <40.0.0
-grpcio==1.51.1
+grpcio==1.53.1
 protobuf==4.21.12
 PyYAML>=3.12
 requests==2.31.0


### PR DESCRIPTION
grpcio v1.53.1 fixes serveral CVEs, check
1. https://github.com/tier4/ota-client/security/dependabot/10
2. https://github.com/grpc/grpc/releases/tag/v1.53.1 
for more details.

This PR supersedes #242 , as grpcio==1.53.1 includes more bugs fix after v1.53.0.