### PR TITLE
[Feature] extend ota-file-cache-control header

### DIFF
--- a/otaclient/_utils/__init__.py
+++ b/otaclient/_utils/__init__.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Callable
-from typing_extensions import ParamSpec
+from typing import Any, Callable, TypeVar
+from typing_extensions import ParamSpec, Concatenate
 
 P = ParamSpec("P")
 
@@ -28,5 +28,17 @@ def copy_callable_typehint(_source: Callable[P, Any]):
 
     def _decorator(target) -> Callable[P, Any]:
         return target
+
+    return _decorator
+
+
+RT = TypeVar("RT")
+
+
+def copy_callable_typehint_to_method(_source: Callable[P, Any]):
+    """Works the same as copy_callable_typehint, but omit the first arg."""
+
+    def _decorator(target: Callable[..., RT]) -> Callable[Concatenate[Any, P], RT]:
+        return target  # type: ignore
 
     return _decorator

--- a/otaclient/app/common.py
+++ b/otaclient/app/common.py
@@ -18,7 +18,6 @@ import itertools
 import os
 import shlex
 import shutil
-import enum
 import threading
 import requests
 import subprocess
@@ -46,30 +45,6 @@ from .log_setting import get_logger
 from .configs import config as cfg
 
 logger = get_logger(__name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL))
-
-
-class OTAFileCacheControl(enum.Enum):
-    """Custom header for ota file caching control policies.
-
-    format:
-        Ota-File-Cache-Control: <directive>
-    directives:
-        retry_cache: indicates that ota_proxy should clear cache entry for <URL>
-            and retry caching
-        no_cache: indicates that ota_proxy should not use cache for <URL>
-        use_cache: implicitly applied default value, conflicts with no_cache directive
-            no need(and no effect) to add this directive into the list
-
-    NOTE: using retry_cache and no_cache together will not work as expected,
-        only no_cache will be respected, already cached file will not be deleted as retry_cache indicates.
-    """
-
-    use_cache = "use_cache"
-    no_cache = "no_cache"
-    retry_caching = "retry_caching"
-
-    header = "Ota-File-Cache-Control"
-    header_lower = "ota-file-cache-control"
 
 
 def get_backoff(n: int, factor: float, _max: float) -> float:

--- a/otaclient/app/downloader.py
+++ b/otaclient/app/downloader.py
@@ -47,7 +47,7 @@ from urllib3.util.retry import Retry
 from urllib3.response import HTTPResponse
 
 from otaclient._utils import copy_callable_typehint
-from otaclient.ota_proxy import OTAFileCacheControl
+from otaclient.ota_proxy import OTAFileCacheControl, HEADER_LOWERCASE
 from .configs import config as cfg
 from .common import wait_with_backoff
 from . import log_setting
@@ -163,13 +163,11 @@ def _transfer_invalid_retrier(retries: int, backoff_factor: float, backoff_max: 
                         _parsed_header.update(_popped_headers)
 
                     # preserve the already set policies, while add retry_caching policy
-                    _cache_policy = _parsed_header.pop(
-                        OTAFileCacheControl.HEADER_LOWERCASE, ""
-                    )
+                    _cache_policy = _parsed_header.pop(HEADER_LOWERCASE, "")
                     _cache_policy = OTAFileCacheControl.update_header_str(
                         _cache_policy, retry_caching=True
                     )
-                    _parsed_header[OTAFileCacheControl.HEADER_LOWERCASE] = _cache_policy
+                    _parsed_header[HEADER_LOWERCASE] = _cache_policy
 
                     # replace with updated header
                     kwargs["headers"] = _parsed_header
@@ -403,11 +401,11 @@ class Downloader:
             res.update(input_header)
 
         # inject digest and compression_alg into ota-file-cache-control-header
-        _cache_policy = res.pop(OTAFileCacheControl.HEADER_LOWERCASE, "")
+        _cache_policy = res.pop(HEADER_LOWERCASE, "")
         _cache_policy = OTAFileCacheControl.update_header_str(
             _cache_policy, file_sha256=digest, file_compression_alg=compression_alg
         )
-        res[OTAFileCacheControl.HEADER_LOWERCASE] = _cache_policy
+        res[HEADER_LOWERCASE] = _cache_policy
         return res
 
     def _check_against_cache_policy_in_resp(
@@ -426,11 +424,7 @@ class Downloader:
         Returns:
             A tuple of file_sha256 and file_compression_alg for the requested resources.
         """
-        if not (
-            cache_policy_str := resp_headers.get(
-                OTAFileCacheControl.HEADER_LOWERCASE, None
-            )
-        ):
+        if not (cache_policy_str := resp_headers.get(HEADER_LOWERCASE, None)):
             return digest, compression_alg
 
         cache_policy = OTAFileCacheControl.parse_header(cache_policy_str)

--- a/otaclient/app/downloader.py
+++ b/otaclient/app/downloader.py
@@ -47,7 +47,7 @@ from urllib3.util.retry import Retry
 from urllib3.response import HTTPResponse
 
 from otaclient._utils import copy_callable_typehint
-from otaclient.ota_proxy import OTAFileCacheControl, HEADER_LOWERCASE
+from otaclient.ota_proxy import OTAFileCacheControl
 from .configs import config as cfg
 from .common import wait_with_backoff
 from . import log_setting
@@ -163,11 +163,13 @@ def _transfer_invalid_retrier(retries: int, backoff_factor: float, backoff_max: 
                         _parsed_header.update(_popped_headers)
 
                     # preserve the already set policies, while add retry_caching policy
-                    _cache_policy = _parsed_header.pop(HEADER_LOWERCASE, "")
+                    _cache_policy = _parsed_header.pop(
+                        OTAFileCacheControl.HEADER_LOWERCASE, ""
+                    )
                     _cache_policy = OTAFileCacheControl.update_header_str(
                         _cache_policy, retry_caching=True
                     )
-                    _parsed_header[HEADER_LOWERCASE] = _cache_policy
+                    _parsed_header[OTAFileCacheControl.HEADER_LOWERCASE] = _cache_policy
 
                     # replace with updated header
                     kwargs["headers"] = _parsed_header
@@ -401,11 +403,11 @@ class Downloader:
             res.update(input_header)
 
         # inject digest and compression_alg into ota-file-cache-control-header
-        _cache_policy = res.pop(HEADER_LOWERCASE, "")
+        _cache_policy = res.pop(OTAFileCacheControl.HEADER_LOWERCASE, "")
         _cache_policy = OTAFileCacheControl.update_header_str(
             _cache_policy, file_sha256=digest, file_compression_alg=compression_alg
         )
-        res[HEADER_LOWERCASE] = _cache_policy
+        res[OTAFileCacheControl.HEADER_LOWERCASE] = _cache_policy
         return res
 
     def _check_against_cache_policy_in_resp(
@@ -424,7 +426,11 @@ class Downloader:
         Returns:
             A tuple of file_sha256 and file_compression_alg for the requested resources.
         """
-        if not (cache_policy_str := resp_headers.get(HEADER_LOWERCASE, None)):
+        if not (
+            cache_policy_str := resp_headers.get(
+                OTAFileCacheControl.HEADER_LOWERCASE, None
+            )
+        ):
             return digest, compression_alg
 
         cache_policy = OTAFileCacheControl.parse_header(cache_policy_str)

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -68,9 +68,10 @@ from typing import (
 )
 from typing_extensions import Self
 
+from otaclient.ota_proxy.cache_control import OTAFileCacheControl
+
 from .configs import config as cfg
 from .common import (
-    OTAFileCacheControl,
     RetryTaskMap,
     get_backoff,
     urljoin_ensure_base,
@@ -630,7 +631,9 @@ class OTAMetadata:
                 _downloaded_meta_f,
                 # NOTE: do not use cache when fetching metadata.jwt
                 headers={
-                    OTAFileCacheControl.header_lower.value: OTAFileCacheControl.no_cache.value,
+                    OTAFileCacheControl.HEADER_LOWERCASE: OTAFileCacheControl.export_as_header(
+                        no_cache=True
+                    )
                 },
             )
 
@@ -650,7 +653,9 @@ class OTAMetadata:
                 cert_file,
                 digest=cert_hash,
                 headers={
-                    OTAFileCacheControl.header_lower.value: OTAFileCacheControl.no_cache.value,
+                    OTAFileCacheControl.HEADER_LOWERCASE: OTAFileCacheControl.export_as_header(
+                        no_cache=True
+                    )
                 },
             )
             _parser.verify_metadata(cert_file.read_bytes())
@@ -671,7 +676,9 @@ class OTAMetadata:
                     _metafile_fpath,
                     digest=_metafile.hash,
                     headers={
-                        OTAFileCacheControl.header_lower.value: OTAFileCacheControl.no_cache.value
+                        OTAFileCacheControl.HEADER_LOWERCASE: OTAFileCacheControl.export_as_header(
+                            no_cache=True
+                        )
                     },
                 )
                 # convert to internal used version and store as binary files

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -68,7 +68,7 @@ from typing import (
 )
 from typing_extensions import Self
 
-from otaclient.ota_proxy import OTAFileCacheControl
+from otaclient.ota_proxy import OTAFileCacheControl, HEADER_LOWERCASE
 
 from .configs import config as cfg
 from .common import (
@@ -631,7 +631,7 @@ class OTAMetadata:
                 _downloaded_meta_f,
                 # NOTE: do not use cache when fetching metadata.jwt
                 headers={
-                    OTAFileCacheControl.HEADER_LOWERCASE: OTAFileCacheControl.export_kwargs_as_header(
+                    HEADER_LOWERCASE: OTAFileCacheControl.export_kwargs_as_header(
                         no_cache=True
                     )
                 },
@@ -653,7 +653,7 @@ class OTAMetadata:
                 cert_file,
                 digest=cert_hash,
                 headers={
-                    OTAFileCacheControl.HEADER_LOWERCASE: OTAFileCacheControl.export_kwargs_as_header(
+                    HEADER_LOWERCASE: OTAFileCacheControl.export_kwargs_as_header(
                         no_cache=True
                     )
                 },
@@ -676,7 +676,7 @@ class OTAMetadata:
                     _metafile_fpath,
                     digest=_metafile.hash,
                     headers={
-                        OTAFileCacheControl.HEADER_LOWERCASE: OTAFileCacheControl.export_kwargs_as_header(
+                        HEADER_LOWERCASE: OTAFileCacheControl.export_kwargs_as_header(
                             no_cache=True
                         )
                     },

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -68,7 +68,7 @@ from typing import (
 )
 from typing_extensions import Self
 
-from otaclient.ota_proxy.cache_control import OTAFileCacheControl
+from otaclient.ota_proxy import OTAFileCacheControl
 
 from .configs import config as cfg
 from .common import (

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -68,7 +68,7 @@ from typing import (
 )
 from typing_extensions import Self
 
-from otaclient.ota_proxy import OTAFileCacheControl, HEADER_LOWERCASE
+from otaclient.ota_proxy import OTAFileCacheControl
 
 from .configs import config as cfg
 from .common import (
@@ -631,7 +631,7 @@ class OTAMetadata:
                 _downloaded_meta_f,
                 # NOTE: do not use cache when fetching metadata.jwt
                 headers={
-                    HEADER_LOWERCASE: OTAFileCacheControl.export_kwargs_as_header(
+                    OTAFileCacheControl.HEADER_LOWERCASE: OTAFileCacheControl.export_kwargs_as_header(
                         no_cache=True
                     )
                 },
@@ -653,7 +653,7 @@ class OTAMetadata:
                 cert_file,
                 digest=cert_hash,
                 headers={
-                    HEADER_LOWERCASE: OTAFileCacheControl.export_kwargs_as_header(
+                    OTAFileCacheControl.HEADER_LOWERCASE: OTAFileCacheControl.export_kwargs_as_header(
                         no_cache=True
                     )
                 },
@@ -676,7 +676,7 @@ class OTAMetadata:
                     _metafile_fpath,
                     digest=_metafile.hash,
                     headers={
-                        HEADER_LOWERCASE: OTAFileCacheControl.export_kwargs_as_header(
+                        OTAFileCacheControl.HEADER_LOWERCASE: OTAFileCacheControl.export_kwargs_as_header(
                             no_cache=True
                         )
                     },

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -482,7 +482,7 @@ _dir_pa = re.compile(r"(?P<mode>\d+),(?P<uid>\d+),(?P<gid>\d+),(?P<path>.*)")
 _symlink_pa = re.compile(
     r"(?P<mode>\d+),(?P<uid>\d+),(?P<gid>\d+),'(?P<link>.+)((?<!\')',')(?P<target>.+)'"
 )
-_persist_pa = re.compile(r"'(?P<path>)'")
+_persist_pa = re.compile(r"'(?P<path>.*)'")
 # NOTE(20221013): support previous regular_inf cvs version
 #                 that doesn't contain size, inode and compressed_alg fields.
 _reginf_pa = re.compile(

--- a/otaclient/app/ota_metadata.py
+++ b/otaclient/app/ota_metadata.py
@@ -631,7 +631,7 @@ class OTAMetadata:
                 _downloaded_meta_f,
                 # NOTE: do not use cache when fetching metadata.jwt
                 headers={
-                    OTAFileCacheControl.HEADER_LOWERCASE: OTAFileCacheControl.export_as_header(
+                    OTAFileCacheControl.HEADER_LOWERCASE: OTAFileCacheControl.export_kwargs_as_header(
                         no_cache=True
                     )
                 },
@@ -653,7 +653,7 @@ class OTAMetadata:
                 cert_file,
                 digest=cert_hash,
                 headers={
-                    OTAFileCacheControl.HEADER_LOWERCASE: OTAFileCacheControl.export_as_header(
+                    OTAFileCacheControl.HEADER_LOWERCASE: OTAFileCacheControl.export_kwargs_as_header(
                         no_cache=True
                     )
                 },
@@ -676,7 +676,7 @@ class OTAMetadata:
                     _metafile_fpath,
                     digest=_metafile.hash,
                     headers={
-                        OTAFileCacheControl.HEADER_LOWERCASE: OTAFileCacheControl.export_as_header(
+                        OTAFileCacheControl.HEADER_LOWERCASE: OTAFileCacheControl.export_kwargs_as_header(
                             no_cache=True
                         )
                     },

--- a/otaclient/ota_proxy/__init__.py
+++ b/otaclient/ota_proxy/__init__.py
@@ -20,7 +20,7 @@ from functools import partial
 from multiprocessing.context import SpawnProcess
 from typing import Callable
 
-from .cache_control import OTAFileCacheControl, HEADER_LOWERCASE
+from .cache_control import OTAFileCacheControl
 from .server_app import App
 from .ota_cache import OTACache
 from .config import config
@@ -32,7 +32,6 @@ __all__ = (
     "App",
     "OTACache",
     "OTAFileCacheControl",
-    "HEADER_LOWERCASE",
     "config",
     "subprocess_start_otaproxy",
 )

--- a/otaclient/ota_proxy/__init__.py
+++ b/otaclient/ota_proxy/__init__.py
@@ -20,7 +20,7 @@ from functools import partial
 from multiprocessing.context import SpawnProcess
 from typing import Callable
 
-from .cache_control import OTAFileCacheControl, CacheControlPolicy
+from .cache_control import OTAFileCacheControl
 from .server_app import App
 from .ota_cache import OTACache
 from .config import config
@@ -32,7 +32,6 @@ __all__ = (
     "App",
     "OTACache",
     "OTAFileCacheControl",
-    "CacheControlPolicy",
     "config",
     "subprocess_start_otaproxy",
 )

--- a/otaclient/ota_proxy/__init__.py
+++ b/otaclient/ota_proxy/__init__.py
@@ -20,7 +20,7 @@ from functools import partial
 from multiprocessing.context import SpawnProcess
 from typing import Callable
 
-from .cache_control import OTAFileCacheControl
+from .cache_control import OTAFileCacheControl, HEADER_LOWERCASE
 from .server_app import App
 from .ota_cache import OTACache
 from .config import config
@@ -32,6 +32,7 @@ __all__ = (
     "App",
     "OTACache",
     "OTAFileCacheControl",
+    "HEADER_LOWERCASE",
     "config",
     "subprocess_start_otaproxy",
 )

--- a/otaclient/ota_proxy/__init__.py
+++ b/otaclient/ota_proxy/__init__.py
@@ -20,7 +20,7 @@ from functools import partial
 from multiprocessing.context import SpawnProcess
 from typing import Callable
 
-from .cache_control import OTAFileCacheControl
+from .cache_control import OTAFileCacheControl, CacheControlPolicy
 from .server_app import App
 from .ota_cache import OTACache
 from .config import config
@@ -32,6 +32,7 @@ __all__ = (
     "App",
     "OTACache",
     "OTAFileCacheControl",
+    "CacheControlPolicy",
     "config",
     "subprocess_start_otaproxy",
 )

--- a/otaclient/ota_proxy/cache_control.py
+++ b/otaclient/ota_proxy/cache_control.py
@@ -13,39 +13,132 @@
 # limitations under the License.
 
 
+from dataclasses import dataclass
 from enum import Enum
-from typing import Set
+from typing import List, Optional, Union
+from typing_extensions import Self
 
 
-class OTAFileCacheControl(Enum):
+class DIRECTIVE(str, Enum):
+    no_cache = "no_cache"
+    retry_caching = "retry_caching"
+    file_sha256 = "file_sha256"
+    file_compression_alg = "file_compression_alg"
+
+    @classmethod
+    def check_key(cls, _input: str) -> Optional[Self]:
+        try:
+            return cls[_input]
+        except KeyError:
+            pass
+
+
+@dataclass
+class CacheControlPolicy:
+    no_cache: bool = False
+    retry_caching: bool = False
+    # added in revision 2:
+    file_sha256: str = ""
+    file_compression_alg: str = ""
+
+    def update_from_header_str(self, _input: str) -> Self:
+        """Update itself from raw ota-file-cache-control header string."""
+        if not _input:
+            return self
+
+        for _raw_directive in _input.split(OTAFileCacheControl.SEPARATOR):
+            if not (_parsed := _raw_directive.split("=", maxsplit=1)):
+                continue
+
+            key = _parsed[0].strip()
+            if not DIRECTIVE.check_key(key):
+                continue
+
+            if len(_parsed) == 1:
+                setattr(self, key, True)
+            elif len(_parsed) == 2 and (value := _parsed[1]):
+                setattr(self, key, value.strip())
+        return self
+
+    def update_from_directives(self, **kwargs: Union[str, bool]) -> Self:
+        """Update itself from a list of directives pairs."""
+        for key, value in kwargs.items():
+            if DIRECTIVE.check_key(key):
+                setattr(self, key, value)
+        return self
+
+
+class OTAFileCacheControl:
     """Custom header for ota file caching control policies.
 
     format:
-        Ota-File-Cache-Control: <directive>
-    directives:
-        retry_cache: indicates that ota_proxy should clear cache entry for <URL>
-            and retry caching
-        no_cache: indicates that ota_proxy should not use cache for <URL>
-        use_cache: implicitly applied default value, conflicts with no_cache directive
-            no need(and no effect) to add this directive into the list
+        Ota-File-Cache-Control: <directive or directive_kv_pair>[, <directive or directive_kv_pair>,[...]]
 
-    NOTE: using retry_cache and no_cache together will not work as expected,
-        only no_cache will be respected, already cached file will not be deleted as retry_cache indicates.
+    directives:
+        no_cache: indicates that ota_proxy should not use cache for <URL>,
+            this will void all other directives when presented,
+        retry_caching: indicates that ota_proxy should clear cache entry for <URL>
+            and retry caching
+        file_sha256: the hash value of the original requested OTA file
+        file_compression_alg: the compression alg used for the OTA file
     """
 
-    use_cache = "use_cache"
-    no_cache = "no_cache"
-    retry_caching = "retry_caching"
-
-    header = "Ota-File-Cache-Control"
-    header_lower = "ota-file-cache-control"
+    # NOTE: according to RFC7230, the header name is case-insensitive,
+    #       so for convenience during code implementation, we always use lower-case
+    #       header name.
+    HEADER_LOWERCASE = "ota-file-cache-control"
+    SEPARATOR = ","
 
     @classmethod
-    def parse_to_enum_set(cls, input: str) -> Set["OTAFileCacheControl"]:
-        res = set()
-        for policy in input.split(","):
-            try:
-                res.add(OTAFileCacheControl[policy.strip()])
-            except KeyError:
-                pass
-        return res
+    def parse_header(cls, _input: str) -> CacheControlPolicy:
+        return CacheControlPolicy().update_from_header_str(_input)
+
+    @classmethod
+    def export_as_header(cls, **kwargs) -> str:
+        """Directly export header str from a list of directive pairs.
+
+        Check DIRECTIVE for directives definition.
+        Only set/True policy will be exported, empty or False policy will be skipped.
+        """
+        _directives: List[str] = []
+        for key, value in kwargs.items():
+            if not DIRECTIVE.check_key(key):
+                continue
+
+            if isinstance(value, bool) and value:
+                _directives.append(key)
+            elif value:
+                _directives.append(f"{key}={value}")
+        return cls.SEPARATOR.join(_directives)
+
+    @classmethod
+    def update_header_str(cls, _input: str, **kwargs) -> str:
+        """Update input header string with input directive pairs.
+
+        Current used directives:
+        1. no_cache
+        2. retry_caching
+        3. file_sha256
+        4. file_compression_alg
+        """
+        _parsed_directives = {}
+        for _raw_directive in _input.split(OTAFileCacheControl.SEPARATOR):
+            if not (_parsed := _raw_directive.split("=", maxsplit=1)):
+                continue
+
+            key = _parsed[0].strip()
+            if not DIRECTIVE.check_key(key):
+                continue
+            _parsed_directives[key] = _raw_directive
+
+        for _key, value in kwargs.items():
+            if not DIRECTIVE.check_key(_key):
+                continue
+
+            if isinstance(value, str):
+                _parsed_directives[_key] = f"{_key}={value}"
+            elif value:
+                _parsed_directives[_key] = _key
+            else:  # remove False or empty directives
+                _parsed_directives.pop(_key, None)
+        return cls.SEPARATOR.join(_parsed_directives.values())

--- a/otaclient/ota_proxy/ota_cache.py
+++ b/otaclient/ota_proxy/ota_cache.py
@@ -42,7 +42,7 @@ from typing import (
 )
 from urllib.parse import SplitResult, quote, urlsplit
 
-from .cache_control import OTAFileCacheControl
+from .cache_control import OTAFileCacheControl, HEADER_LOWERCASE
 from .db import CacheMeta, OTACacheDB, AIO_OTACacheDBProxy
 from .errors import (
     BaseOTACacheError,
@@ -1005,7 +1005,7 @@ class OTACache:
             use_cache = False
         # if there is no upper_ota_proxy, trim the custom headers away
         if self._enable_https:
-            extra_headers.pop(OTAFileCacheControl.HEADER_LOWERCASE, None)
+            extra_headers.pop(HEADER_LOWERCASE, None)
 
         # --- case 1: not using cache, directly download file --- #
         if (

--- a/otaclient/ota_proxy/ota_cache.py
+++ b/otaclient/ota_proxy/ota_cache.py
@@ -42,7 +42,7 @@ from typing import (
 )
 from urllib.parse import SplitResult, quote, urlsplit
 
-from .cache_control import OTAFileCacheControl, HEADER_LOWERCASE
+from .cache_control import OTAFileCacheControl
 from .db import CacheMeta, OTACacheDB, AIO_OTACacheDBProxy
 from .errors import (
     BaseOTACacheError,
@@ -1005,7 +1005,7 @@ class OTACache:
             use_cache = False
         # if there is no upper_ota_proxy, trim the custom headers away
         if self._enable_https:
-            extra_headers.pop(HEADER_LOWERCASE, None)
+            extra_headers.pop(OTAFileCacheControl.HEADER_LOWERCASE, None)
 
         # --- case 1: not using cache, directly download file --- #
         if (

--- a/otaclient/ota_proxy/ota_cache.py
+++ b/otaclient/ota_proxy/ota_cache.py
@@ -36,7 +36,6 @@ from typing import (
     List,
     MutableMapping,
     Optional,
-    Set,
     Tuple,
     TypeVar,
     Union,

--- a/otaclient/ota_proxy/ota_cache.py
+++ b/otaclient/ota_proxy/ota_cache.py
@@ -42,7 +42,7 @@ from typing import (
 )
 from urllib.parse import SplitResult, quote, urlsplit
 
-from .cache_control import CacheControlPolicy, OTAFileCacheControl
+from .cache_control import OTAFileCacheControl
 from .db import CacheMeta, OTACacheDB, AIO_OTACacheDBProxy
 from .errors import (
     BaseOTACacheError,
@@ -968,7 +968,7 @@ class OTACache:
         /,
         cookies: Dict[str, str],
         extra_headers: Dict[str, str],
-        cache_control_policies: CacheControlPolicy,
+        cache_control_policies: OTAFileCacheControl,
     ) -> Optional[Tuple[AsyncIterator[bytes], CacheMeta]]:
         """Retrieve a file descriptor for the requested <raw_url>.
 

--- a/otaclient/ota_proxy/ota_cache.py
+++ b/otaclient/ota_proxy/ota_cache.py
@@ -43,7 +43,7 @@ from typing import (
 )
 from urllib.parse import SplitResult, quote, urlsplit
 
-from .cache_control import OTAFileCacheControl
+from .cache_control import CacheControlPolicy, OTAFileCacheControl
 from .db import CacheMeta, OTACacheDB, AIO_OTACacheDBProxy
 from .errors import (
     BaseOTACacheError,
@@ -969,7 +969,7 @@ class OTACache:
         /,
         cookies: Dict[str, str],
         extra_headers: Dict[str, str],
-        cache_control_policies: Set[OTAFileCacheControl],
+        cache_control_policies: CacheControlPolicy,
     ) -> Optional[Tuple[AsyncIterator[bytes], CacheMeta]]:
         """Retrieve a file descriptor for the requested <raw_url>.
 
@@ -998,15 +998,15 @@ class OTACache:
         # default cache control policy:
         retry_cache, use_cache = False, True
         # parse input policies
-        if OTAFileCacheControl.retry_caching in cache_control_policies:
+        if cache_control_policies.retry_caching:
             retry_cache = True
             logger.warning(f"client indicates that cache for {raw_url=} is invalid")
-        if OTAFileCacheControl.no_cache in cache_control_policies:
+        if cache_control_policies.no_cache:
             logger.info(f"client indicates that do not cache for {raw_url=}")
             use_cache = False
         # if there is no upper_ota_proxy, trim the custom headers away
         if self._enable_https:
-            extra_headers.pop(OTAFileCacheControl.header.value, None)
+            extra_headers.pop(OTAFileCacheControl.HEADER_LOWERCASE, None)
 
         # --- case 1: not using cache, directly download file --- #
         if (

--- a/otaclient/ota_proxy/server_app.py
+++ b/otaclient/ota_proxy/server_app.py
@@ -19,7 +19,7 @@ from http import HTTPStatus
 from typing import Any, Dict, List, Union
 
 from otaclient._utils.logging import BurstSuppressFilter
-from .cache_control import OTAFileCacheControl
+from .cache_control import OTAFileCacheControl, HEADER_LOWERCASE
 from .errors import BaseOTACacheError
 from .ota_cache import OTACache
 
@@ -174,10 +174,7 @@ class App:
             elif header[0] == b"authorization":
                 extra_headers["Authorization"] = header[1].decode()
             # custome header for ota_file, see retrieve_file and OTACache for details
-            elif (
-                header[0] == OTAFileCacheControl.HEADER_LOWERCASE.encode()
-                and len(header) == 2
-            ):
+            elif header[0] == HEADER_LOWERCASE.encode() and len(header) == 2:
                 ota_cache_control_policies = OTAFileCacheControl.parse_header(
                     header[1].decode()
                 )

--- a/otaclient/ota_proxy/server_app.py
+++ b/otaclient/ota_proxy/server_app.py
@@ -19,7 +19,7 @@ from http import HTTPStatus
 from typing import Any, Dict, List, Union
 
 from otaclient._utils.logging import BurstSuppressFilter
-from .cache_control import OTAFileCacheControl, HEADER_LOWERCASE
+from .cache_control import OTAFileCacheControl
 from .errors import BaseOTACacheError
 from .ota_cache import OTACache
 
@@ -174,7 +174,10 @@ class App:
             elif header[0] == b"authorization":
                 extra_headers["Authorization"] = header[1].decode()
             # custome header for ota_file, see retrieve_file and OTACache for details
-            elif header[0] == HEADER_LOWERCASE.encode() and len(header) == 2:
+            elif (
+                header[0] == OTAFileCacheControl.HEADER_LOWERCASE.encode()
+                and len(header) == 2
+            ):
                 ota_cache_control_policies = OTAFileCacheControl.parse_header(
                     header[1].decode()
                 )

--- a/otaclient/ota_proxy/server_app.py
+++ b/otaclient/ota_proxy/server_app.py
@@ -19,7 +19,7 @@ from http import HTTPStatus
 from typing import Any, Dict, List, Union
 
 from otaclient._utils.logging import BurstSuppressFilter
-from .cache_control import CacheControlPolicy, OTAFileCacheControl
+from .cache_control import OTAFileCacheControl
 from .errors import BaseOTACacheError
 from .ota_cache import OTACache
 
@@ -167,7 +167,7 @@ class App:
         extra_headers: Dict[str, str] = dict()
         # currently we only need cookie and/or authorization header
         # also parse OTA-File-Cache-Control header
-        ota_cache_control_policies = CacheControlPolicy()
+        ota_cache_control_policies = OTAFileCacheControl()
         for header in scope["headers"]:
             if header[0] == b"cookie":
                 cookies_dict = self.parse_raw_cookies(header[1])
@@ -178,7 +178,9 @@ class App:
                 header[0] == OTAFileCacheControl.HEADER_LOWERCASE.encode()
                 and len(header) == 2
             ):
-                ota_cache_control_policies.update_from_header_str(header[1])
+                ota_cache_control_policies = OTAFileCacheControl.parse_header(
+                    header[1].decode()
+                )
 
         respond_started = False
         try:

--- a/tests/test_ota_proxy/test_cache_control_header.py
+++ b/tests/test_ota_proxy/test_cache_control_header.py
@@ -14,17 +14,17 @@
 
 
 import pytest
-from otaclient.ota_proxy import OTAFileCacheControl, CacheControlPolicy
+from otaclient.ota_proxy import OTAFileCacheControl
 
 
 @pytest.mark.parametrize(
     "raw_str, expected",
     (
-        ("no_cache", CacheControlPolicy(no_cache=True)),
-        ("retry_caching", CacheControlPolicy(retry_caching=True)),
+        ("no_cache", OTAFileCacheControl(no_cache=True)),
+        ("retry_caching", OTAFileCacheControl(retry_caching=True)),
         (
             "no_cache, file_sha256=sha256value, file_compression_alg=zst",
-            CacheControlPolicy(
+            OTAFileCacheControl(
                 no_cache=True,
                 file_sha256="sha256value",
                 file_compression_alg="zst",

--- a/tests/test_ota_proxy/test_cache_control_header.py
+++ b/tests/test_ota_proxy/test_cache_control_header.py
@@ -14,19 +14,23 @@
 
 
 import pytest
-from otaclient.ota_proxy.cache_control import OTAFileCacheControl
+from otaclient.ota_proxy import OTAFileCacheControl, CacheControlPolicy
 
 
 @pytest.mark.parametrize(
     "raw_str, expected",
     (
-        ("use_cache", {OTAFileCacheControl.use_cache}),
+        ("no_cache", CacheControlPolicy(no_cache=True)),
+        ("retry_caching", CacheControlPolicy(retry_caching=True)),
         (
-            "use_cache,retry_caching",
-            {OTAFileCacheControl.use_cache, OTAFileCacheControl.retry_caching},
+            "no_cache, file_sha256=sha256value, file_compression_alg=zst",
+            CacheControlPolicy(
+                no_cache=True,
+                file_sha256="sha256value",
+                file_compression_alg="zst",
+            ),
         ),
-        ("no_cache", {OTAFileCacheControl.no_cache}),
     ),
 )
 def test_cache_control_header(raw_str, expected):
-    assert OTAFileCacheControl.parse_to_enum_set(raw_str) == expected
+    assert OTAFileCacheControl.parse_header(raw_str) == expected

--- a/tests/test_ota_proxy/test_cache_control_header.py
+++ b/tests/test_ota_proxy/test_cache_control_header.py
@@ -38,21 +38,6 @@ def test__parse_header(raw_str, expected):
 
 
 @pytest.mark.parametrize(
-    "key, expected",
-    (
-        ("no_cache", True),
-        ("retry_caching", True),
-        ("file_sha256", True),
-        ("file_compression_alg", True),
-        ("wrong_key1", False),
-        ("2wrong_key", False),
-    ),
-)
-def test__check_key(key: str, expected: bool):
-    assert OTAFileCacheControl.check_key(key) == expected
-
-
-@pytest.mark.parametrize(
     "kwargs, expected",
     (
         ({"no_cache": True, "retry_caching": False}, "no_cache"),
@@ -96,30 +81,6 @@ def test__export_kwargs_as_header(kwargs: Dict[str, Any], expected: str):
 )
 def test__update_header_str(_input: str, kwargs: Dict[str, Any], expected: str):
     assert OTAFileCacheControl.update_header_str(_input, **kwargs) == expected
-
-
-@pytest.mark.parametrize(
-    "policy, expected",
-    (
-        (
-            OTAFileCacheControl(
-                file_sha256="sha256", file_compression_alg="zst", no_cache=True
-            ),
-            "no_cache,file_sha256=sha256,file_compression_alg=zst",
-        ),
-        (
-            OTAFileCacheControl(
-                file_sha256="sha256",
-                file_compression_alg="zst",
-                no_cache=False,
-                retry_caching=True,
-            ),
-            "retry_caching,file_sha256=sha256,file_compression_alg=zst",
-        ),
-    ),
-)
-def test__export_as_header(policy: OTAFileCacheControl, expected: str):
-    assert policy.export_as_header() == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. 

For better understanding, adding reason/motivation of this PR are also recommended.

-->

> **Note**
> This PR is the first PR in a series of PRs(#244,  #245 , #246 ) that introduce extra feature to otaproxy. Each PR is implemented based on the previous PR, so these PRs should be reviewed and merged into main branch one by one.

> **Note**
> This PR has not yet updated otaproxy to support the extended header but just maintain the forward compatibility for it. Check the #245  for otaproxy feature update.

This PR introduces extension to `ota-file-cache-control header`, implements a set of helper functions and types to use this header in coding, update related otaclient modules (`downloader.py` and `ota_metadata.py`) to support such extension(with the new implemented helper code).

### Revision to header def

Two new directives for `ota-file-cache-control` header are introduced:
1. **file_sha256**: the sha256 hash value of **the original plain requested OTA file**(without any compression).
2. **file_compression_alg**: the compression applied to the OTA file resource, currently only `zst` is valid for this field, or empty(not presented in the header string) if no compression is applied.


## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file(s) that covers the change(s) is implemented.
- [x] local test is passed. 
- [x] design docs/implementation docs are prepared.


## Documents

<!-- For feature PR, design document is required. -->

1. [OTA cache mechanism design for otaproxy](https://tier4.atlassian.net/l/cp/yWPaqr8z)

## Changes

<!-- A list of code change(s) that introduced by this PR. -->

1. `app`: remove `ota-file-cache-control` definition in `otaclient.app.common` module, but directly use the one from `otaproxy` module,
2. `downloader._transfer_invalid_retrier`: use helper funcs from `otaproxy.cache_control` module to handle `ota-file-cache-control` header,
3. `downloader._prepare_header`: split the request header preparing logic as standalone method, inject OTA file digest(and compression_alg) information into request header via `ota-file-cache-control` header,
4. `downloader._check_against_cache_policy_in_resp`: check `ota-file-cache-control` header from upper otaproxy's response, check the following **Behavior with this PR** section for more details,
5. `downloader._prepare_url`: split URL preparing logic as standalone method,
6. `downloader.get_req_retry_counts`: define helper method for getting retry count from `requests.Response`,
7. `ota_metadata`: use helper funcs from `otaproxy.cache_control` module to handle `ota-file-cache-control` header,
8. `ota_metadata`: fix to inform-use-only `_persist_pa`,
9. `ota_proxy.cache_control`: implement new `ota-file-cache-control` header as dataclass, with several helper methods,
10. `ota_proxy.ota_cache, ota_proxy.server_app`: support parsing new header(but the behavior is not extended in this PR, check #245 ) with newly implemented helper methods,
11. `test_cache_control_header`: implement test files for `cache_control` module.

## Behavior changes

Does this PR introduce behavior change(s)?

- [x] Yes, internal behaivor (will not impact user experience).

### Behavior with this PR

<!-- Behavior after the PR is introduced -->

OTA client now will send requested OTA file's information(from `regulars.txt`) via header to upper otaproxy, and inspect corresponding information included in the response from upper otaproxy.

#### otaclient downloader preparing request to upper otaproxy
1. for `file_sha256` directive, otaclient will write this directive in `ota-file-cache-control` header if such information is available in `regulars.txt`, otherwise this directive will not be included in the header string,
2. for `file_compression_alg` directive, otaclient will **ONLY** write this directive when `file_sha256` is also written, and OTA image compression is used for this OTA file.

#### otaclient downloader parsing response from upper otaproxy
1. for `file_sha256` directive, otaclient will compare it to the value in `regulars.txt`, if doesn't match otaclient will abort transferring and raise `HashVerficationError`. The retried downloading should have `retry_caching` directive in `ota-file-cache-control` header set,
2. for `file_compression_alg` directive, if both this directive and valid `file_sha256` directive are presented, otaclient should respect it as upper otaproxy might serves the same OTA file but from other OTA image(which might/might not use the same compression alg),

## Breaking change

Does this PR introduce breaking change?
- [x] No.

## Related links & tickets

1. [RT4-5484](https://tier4.atlassian.net/browse/RT4-5484)

[RT4-5484]: https://tier4.atlassian.net/browse/RT4-5484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ