### PR TITLE
[Fix] otaclient_stub: fix behavior related available_ecu_ids

### DIFF
--- a/otaclient/app/ecu_info.py
+++ b/otaclient/app/ecu_info.py
@@ -124,8 +124,8 @@ class ECUInfo:
         return BootloaderType.parse_str(self.bootloader)
 
     def get_available_ecu_ids(self) -> List[str]:
-        # onetime fix, if no availabe_ecu_id is specified,
-        # add my_ecu_id into the list
+        # onetime fix, if no availabe_ecu_id is specified, add my_ecu_id into the list
+        # NOTE(20230731): confirm this behavior is expected
         if len(self.available_ecu_ids) == 0:
             self.available_ecu_ids.append(self.ecu_id)
         return self.available_ecu_ids.copy()


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->

This PR fixes unintended behavior related to the `available_ecu_ids` field in the status API response, which my ECU id will always being included in the `available_ecu_ids`. The bug is introduced by #212 .

### Cause of the bug

In #212 , ECU status tracker is implemented by `_ECUTracker`, and all status are stored within `ECUStatusStorage` inst. The problem is caused by `_ECUTracker` by default always tracking local my ECU, no matter whether the local my ECU is listed in `available_ecu_ids` or not. Further, `ECUStatusStorage` will always include all tracked ECU into `available_ecu_ids`, along with merging the `available_ecu_ids` field from `ecu_info.yaml`, causing the problem.

### More about `available_ecu_ids`

**The intention for introducing `available_ecu_ids`, is to define the set of ECUs that should be engaged in OTA update events. Only ECUs listed in this field should be updated, and should be tracked by main ECU's otaclient/web.auto agent.**

For web.auto user, web.auto agent will use `available_ecu_ids` to generate OTA update list, only ECUs included in `available_ecu_ids` will be included in the OTA update request.

For backward compatibility, if `available_ecu_ids` is empty, include my ECU id in the `available_ecu_ids` list. (check `ecu_info.ECUInfo.get_available_ecu_ids` method).

Check doc/README.md and doc/SERVICES.md for more details.

## Code changes related to Bug fix

The fix is to ensure only ECUs listed in `available_ecu_ids` will be tracked by `otaclient_stub`, and status being collected and reported via status API.

1. `otaclient_stub.ECUStatusStorage`: using two different attrs to store `_tracking_ecus`(internal use) and `_available_ecu_ids`(for used in status response), only update `_available_ecu_ids` by merging sub ECU's response and `ecu_info.yaml` to prevent unintended changes to status response.
2. `otaclient_stub.ECUStatusStorage`: do not track and store status from child ECUs that doesn't listed in any `available_ecu_ids`,
3. `otaclient_stub._ECUTracker`: when launching ECU trackers for tracked ECU, check against `available_ecu_ids` list from `ecu_info.yaml`, **only tracking ECUs that listed in available_ecu_ids**.

## Extra confirmation

1. `ecu_info`: confirm the behavior **if available_ecu_ids field is empty or not presented in ecu_info.yaml, add my ECU id into the list** is implemented.

## Bug fix

### Current behavior

1. my ECU id will always being included in the `available_ecu_ids` in status API response, and my ECU status also always being included in status API response, even my ECU is not listed in `available_ecu_ids` and not expected to receive OTA update.

### Behaivor after fix

1. my ecu_id(local ECU id) and my ECU status will not be included in the status API response if my ECU is not listed `available_ecu_ids` and not receiving OTA update.

## Related links & ticket

1. #212 
2. #248 
3. [OTA service API handler design document](https://tier4.atlassian.net/l/cp/5DU9jPuW): document is updated to include new information related to `available_ecu_ids`.

<!-- List of tickets or links related to this PR -->