### PR TITLE
[Chore] minor update and fix to tools.status_monitor

### DIFF
--- a/tools/status_monitor/configs.py
+++ b/tools/status_monitor/configs.py
@@ -33,7 +33,7 @@ class BasicConfig:
     RENDER_INTERVAL = 0.01
 
     # ------ ECU status box configs ------ #
-    ECU_DISPLAY_BOX_HLINES = 12
+    ECU_DISPLAY_BOX_HLINES = 14
     ECU_DISPLAY_BOX_HCOLS = 60
 
 

--- a/tools/status_monitor/ecu_status_box.py
+++ b/tools/status_monitor/ecu_status_box.py
@@ -87,6 +87,7 @@ class ECUStatusDisplayBox:
                         (
                             f"update_starts_at: {datetime.datetime.fromtimestamp(update_status.update_start_timestamp)}"
                         ),
+                        f"update_firmware_version: {update_status.update_firmware_version}",
                         (
                             f"update_phase: {update_status.phase.name} "
                             f"(elapsed_time: {update_status.total_elapsed_time.seconds}s)"

--- a/tools/status_monitor/ecu_status_box.py
+++ b/tools/status_monitor/ecu_status_box.py
@@ -49,7 +49,7 @@ class ECUStatusDisplayBox:
         self._last_status = proto_wrapper.StatusResponseEcuV2()
         # prevent conflicts between status update and pad update
         self._lock = threading.Lock()
-        self._last_updated = 0
+        self.last_updated = 0
 
     def get_failure_contents(self) -> Tuple[Sequence[str], int]:
         """Getter for failure_contents."""
@@ -144,7 +144,7 @@ class ECUStatusDisplayBox:
         self, pad: curses.window, begin_y: int, begin_x: int
     ) -> bool:
         """Render contents onto the status_box pad."""
-        if int(time.time()) <= self._last_updated:
+        if int(time.time()) <= self.last_updated:
             return False
 
         with self._lock:

--- a/tools/status_monitor/main_win.py
+++ b/tools/status_monitor/main_win.py
@@ -67,7 +67,7 @@ class MainScreen:
             stdscr, header=self.title, footer=self.manual
         )
         pad_hlines, pad_hcols = (
-            ECUStatusDisplayBox.DISPLAY_BOX_HLINES * self.DISPLAY_BOX_ROWS_MAX,
+            config.PAD_ILNIT_HLINES,
             ECUStatusDisplayBox.DISPLAY_BOX_HCOLS * self.DISPLAY_BOX_PER_ROW,
         )
         pad = init_pad(pad_hlines, pad_hcols)

--- a/tools/status_monitor/main_win.py
+++ b/tools/status_monitor/main_win.py
@@ -77,8 +77,10 @@ class MainScreen:
         while True:
             # try to update the contents at current location first
             if self._draw_ecu_status_to_pad(pad):
-                pad_hlines = ECUStatusDisplayBox.DISPLAY_BOX_HLINES * len(
-                    self._display_getter()
+                pad_hlines = (
+                    ECUStatusDisplayBox.DISPLAY_BOX_HLINES
+                    * len(self._display_getter())
+                    // config.MAINWIN_BOXES_PER_ROW
                 )
                 cursor_moved = True
 
@@ -93,6 +95,10 @@ class MainScreen:
                     hcols,
                 )
 
+            # TODO: remove the magic number 8
+            # NOTE: 7 is the value combining the headers and border
+            max_y = pad_hlines - hlines + 8
+
             # wait for key_press event unblockingly
             key = pad.getch()
             if key in PAGE_SCROLL_KEYS:
@@ -102,7 +108,7 @@ class MainScreen:
                     last_cursor_y,
                     last_cursor_x,
                     scroll_len=config.SCROLL_LINES,
-                    contents_area_max_y=pad_hlines,
+                    contents_area_max_y=max_y,
                 )
                 cursor_moved = (
                     last_cursor_y != new_cursor_y or last_cursor_x != new_cursor_x

--- a/tools/status_monitor/utils.py
+++ b/tools/status_monitor/utils.py
@@ -175,7 +175,6 @@ def page_scroll_key_handler(
     Returns:
         A tuple of new cursor's position in (y, x).
     """
-    contents_area_max_y = contents_area_max_y // 4 * 3
 
     new_cursor_y, new_cursor_x = last_cursor_y, last_cursor_x
     if key_pressed == curses.KEY_DOWN or key_pressed == curses.KEY_SR:


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. 

For better understanding, adding reason/motivation of this PR are also recommended.

-->

This PR introduces some fixes and refinements to the status monitor tools.

1. fix artifacts/remaining lines when scrolling down on the main screen,
2. fix ECU index mismatched on the main screen when some of the ECUs temporarily offline(during OTA reboot),
3. fix app crash before app receives any status update from the ECU,
4. refine the scrolling area limitation on the main screen,
5. add `update_firmware_version` line to the ECU status box.