### PR TITLE
[Refinement] boot_control.grub: improve robustness against boot load/init, split out ota_status control and slot mount logic

### DIFF
--- a/otaclient/app/boot_control/_common.py
+++ b/otaclient/app/boot_control/_common.py
@@ -777,6 +777,7 @@ class SlotMountHelper:
         standby_slot_mount_point: Union[str, Path],
         active_slot_dev: Union[str, Path],
         active_slot_mount_point: Union[str, Path],
+        standby_boot_dir: Union[str, Path],
     ) -> None:
         # dev
         self.standby_slot_dev = str(standby_slot_dev)
@@ -787,7 +788,7 @@ class SlotMountHelper:
         self.standby_slot_mount_point.mkdir(exist_ok=True, parents=True)
         self.active_slot_mount_point.mkdir(exist_ok=True, parents=True)
         # standby slot /boot dir
-        self.standby_boot_dir = self.standby_slot_mount_point / "boot"
+        self.standby_boot_dir = Path(standby_boot_dir)
 
     def mount_standby(self, *, raise_exc: bool = True) -> bool:
         """Mount standby slot dev to <standby_slot_mount_point>.

--- a/otaclient/app/boot_control/_common.py
+++ b/otaclient/app/boot_control/_common.py
@@ -424,8 +424,7 @@ FinalizeSwitchBootFunc = Callable[[], bool]
 
 
 class OTAStatusFilesControl:
-    """Logics for controlling otaclient's behavior using ota_status files,
-    including status, slot_in_use and version.
+    """Logics for controlling otaclient's OTA status with corresponding files.
 
     OTAStatus files:
         status: current slot's OTA status
@@ -470,13 +469,12 @@ class OTAStatusFilesControl:
                 "this might indicate a failed finalization at first reboot after update/rollback"
             )
 
-        # initializing ota_status control
-        self._init_ota_status_files()
+        self._load_ota_status_files()
         logger.info(
             f"ota_status files parsing completed, ota_status is {self._ota_status}"
         )
 
-    def _init_ota_status_files(self):
+    def _load_ota_status_files(self):
         """Check and/or init ota_status files for current slot."""
         self.current_ota_status_dir.mkdir(exist_ok=True, parents=True)
 
@@ -637,15 +635,11 @@ class OTAStatusFilesControl:
         self._store_standby_status(wrapper.StatusOta.ROLLBACKING)
 
     def load_active_slot_version(self) -> str:
-        _version = read_str_from_file(
+        return read_str_from_file(
             self.current_ota_status_dir / cfg.OTA_VERSION_FNAME,
             missing_ok=True,
-            default="",
+            default=cfg.DEFAULT_VERSION_STR,
         )
-        if not _version:
-            logger.warning("version file not found, return empty version string")
-
-        return _version
 
     def on_failure(self):
         """Store FAILURE to status file on failure."""

--- a/otaclient/app/boot_control/_common.py
+++ b/otaclient/app/boot_control/_common.py
@@ -656,8 +656,14 @@ class OTAStatusFilesControl:
             self._store_standby_status(wrapper.StatusOta.FAILURE)
 
     @property
-    def ota_status(self) -> wrapper.StatusOta:
-        """Read only ota_status property."""
+    def booted_ota_status(self) -> wrapper.StatusOta:
+        """Loaded current slot's ota_status during boot control starts.
+
+        NOTE: distinguish between the live ota_status maintained by otaclient.
+
+        This property is only meant to be used once when otaclient starts up,
+        switch to use live_ota_status by otaclient after otaclient is running.
+        """
         return self._ota_status
 
 

--- a/otaclient/app/boot_control/_common.py
+++ b/otaclient/app/boot_control/_common.py
@@ -443,6 +443,7 @@ class OTAStatusFilesControl:
         current_ota_status_dir: Union[str, Path],
         standby_ota_status_dir: Union[str, Path],
         finalize_switching_boot: FinalizeSwitchBootFunc,
+        force_initialize: bool = False,
     ) -> None:
         self.active_slot = active_slot
         self.standby_slot = standby_slot
@@ -450,6 +451,7 @@ class OTAStatusFilesControl:
         self.standby_ota_status_dir = Path(standby_ota_status_dir)
         self.finalize_switching_boot = finalize_switching_boot
 
+        self._force_initialize = force_initialize
         self.current_ota_status_dir.mkdir(exist_ok=True, parents=True)
         self._load_slot_in_use_file()
         self._load_status_file()
@@ -460,6 +462,8 @@ class OTAStatusFilesControl:
     def _load_status_file(self):
         """Check and/or init ota_status files for current slot."""
         _loaded_ota_status = self._load_current_status()
+        if self._force_initialize:
+            _loaded_ota_status = None
 
         # initialize ota_status files if not presented/incompleted/invalid
         if not _loaded_ota_status:
@@ -519,6 +523,9 @@ class OTAStatusFilesControl:
 
     def _load_slot_in_use_file(self):
         _loaded_slot_in_use = self._load_current_slot_in_use()
+        if self._force_initialize:
+            _loaded_slot_in_use = None
+
         if not _loaded_slot_in_use:
             # NOTE(20230831): this can also resolve the backward compatibility issue
             #                 in is_switching_boot method when old otaclient doesn't create

--- a/otaclient/app/boot_control/_common.py
+++ b/otaclient/app/boot_control/_common.py
@@ -474,6 +474,7 @@ class OTAStatusFilesControl:
             self._store_current_status(wrapper.StatusOta.INITIALIZED)
             self._ota_status = wrapper.StatusOta.INITIALIZED
             return
+        logger.info(f"status loaded from file: {_loaded_ota_status.name}")
 
         # status except UPDATING and ROLLBACKING(like SUCCESS/FAILURE/ROLLBACK_FAILURE)
         # are remained as it
@@ -532,6 +533,7 @@ class OTAStatusFilesControl:
             #                 slot_in_use file.
             self._store_current_slot_in_use(self.active_slot)
             return
+        logger.info(f"slot_in_use loaded from file: {_loaded_slot_in_use}")
 
         # check potential failed switching boot
         if _loaded_slot_in_use and _loaded_slot_in_use != self.active_slot:

--- a/otaclient/app/boot_control/_common.py
+++ b/otaclient/app/boot_control/_common.py
@@ -777,7 +777,6 @@ class SlotMountHelper:
         standby_slot_mount_point: Union[str, Path],
         active_slot_dev: Union[str, Path],
         active_slot_mount_point: Union[str, Path],
-        standby_boot_dir: Union[str, Path],
     ) -> None:
         # dev
         self.standby_slot_dev = str(standby_slot_dev)
@@ -788,7 +787,12 @@ class SlotMountHelper:
         self.standby_slot_mount_point.mkdir(exist_ok=True, parents=True)
         self.active_slot_mount_point.mkdir(exist_ok=True, parents=True)
         # standby slot /boot dir
-        self.standby_boot_dir = Path(standby_boot_dir)
+        # NOTE(20230907): this will always be <standby_slot_mp>/boot,
+        #                 in the future this attribute will not be used by
+        #                 standby slot creater.
+        self.standby_boot_dir = self.standby_slot_mount_point / Path(
+            cfg.BOOT_DIR
+        ).relative_to("/")
 
     def mount_standby(self, *, raise_exc: bool = True) -> bool:
         """Mount standby slot dev to <standby_slot_mount_point>.

--- a/otaclient/app/boot_control/_common.py
+++ b/otaclient/app/boot_control/_common.py
@@ -712,7 +712,7 @@ class OTAStatusMixin:
             except KeyError:
                 pass  # invalid status string
 
-    def get_ota_status(self) -> wrapper.StatusOta:
+    def get_booted_ota_status(self) -> wrapper.StatusOta:
         return self.ota_status
 
 

--- a/otaclient/app/boot_control/_common.py
+++ b/otaclient/app/boot_control/_common.py
@@ -450,45 +450,23 @@ class OTAStatusFilesControl:
         self.standby_ota_status_dir = Path(standby_ota_status_dir)
         self.finalize_switching_boot = finalize_switching_boot
 
-        # NOTE: pre-assign live ota_status with the loaded ota_status,
-        #       and then update live ota_status in below.
-        #       The reason is for some platform, like raspberry pi 4B,
-        #       the finalize_switching_boot might be slow, so we first provide
-        #       live ota_status the same as loaded ota_status(or INITIALIZED),
-        #       then update it after the init_ota_status_files finished.
-        _loaded_ota_status = self._load_current_status()
-        self._ota_status = (
-            _loaded_ota_status if _loaded_ota_status else wrapper.StatusOta.INITIALIZED
-        )
-
-        _loaded_slot_in_use = self._load_current_slot_in_use()
-        if _loaded_slot_in_use and _loaded_slot_in_use != self.active_slot:
-            logger.warning(
-                f"boot into old slot {self.active_slot}, "
-                f"but slot_in_use indicates it should boot into {_loaded_slot_in_use}, "
-                "this might indicate a failed finalization at first reboot after update/rollback"
-            )
-
-        self._load_ota_status_files()
-        logger.info(
-            f"ota_status files parsing completed, ota_status is {self._ota_status}"
-        )
-
-    def _load_ota_status_files(self):
-        """Check and/or init ota_status files for current slot."""
         self.current_ota_status_dir.mkdir(exist_ok=True, parents=True)
+        self._load_slot_in_use_file()
+        self._load_status_file()
+        logger.info(
+            f"ota_status files parsing completed, ota_status is {self._ota_status.name}"
+        )
 
-        # load ota_status and slot_in_use file
+    def _load_status_file(self):
+        """Check and/or init ota_status files for current slot."""
         _loaded_ota_status = self._load_current_status()
-        _loaded_slot_in_use = self._load_current_slot_in_use()
 
         # initialize ota_status files if not presented/incompleted/invalid
-        if not (_loaded_ota_status and _loaded_slot_in_use):
+        if not _loaded_ota_status:
             logger.info(
                 "ota_status files incompleted/not presented, "
-                "initializing and set/store status to INITIALIZED..."
+                f"initializing and set/store status to {wrapper.StatusOta.INITIALIZED.name}..."
             )
-            self._store_current_slot_in_use(self.active_slot)
             self._store_current_status(wrapper.StatusOta.INITIALIZED)
             self._ota_status = wrapper.StatusOta.INITIALIZED
             return
@@ -503,8 +481,11 @@ class OTAStatusFilesControl:
             return
 
         # updating or rollbacking,
+        # NOTE: pre-assign live ota_status with the loaded ota_status before entering finalizing_switch_boot,
+        #       as some of the platform might have slow finalizing process(like raspberry).
+        self._ota_status = _loaded_ota_status
         # if is_switching_boot, execute the injected finalize_switching_boot function from
-        #   boot controller, transit the ota_status according to the execution result.
+        # boot controller, transit the ota_status according to the execution result.
         # NOTE(20230614): for boot controller during multi-stage reboot(like rpi_boot),
         #                 calling finalize_switching_boot might result in direct reboot,
         #                 in such case, otaclient will terminate and ota_status will not be updated.
@@ -526,7 +507,7 @@ class OTAStatusFilesControl:
         else:
             logger.error(
                 f"we are in {_loaded_ota_status.name} ota_status, "
-                f"but {_loaded_slot_in_use=} doesn't match {self.active_slot=}, "
+                "but ota_status files indicate that we are not in switching boot mode, "
                 "this indicates a failed first reboot"
             )
             self._ota_status = (
@@ -535,6 +516,23 @@ class OTAStatusFilesControl:
                 else wrapper.StatusOta.FAILURE
             )
             self._store_current_status(self._ota_status)
+
+    def _load_slot_in_use_file(self):
+        _loaded_slot_in_use = self._load_current_slot_in_use()
+        if not _loaded_slot_in_use:
+            # NOTE(20230831): this can also resolve the backward compatibility issue
+            #                 in is_switching_boot method when old otaclient doesn't create
+            #                 slot_in_use file.
+            self._store_current_slot_in_use(self.active_slot)
+            return
+
+        # check potential failed switching boot
+        if _loaded_slot_in_use and _loaded_slot_in_use != self.active_slot:
+            logger.warning(
+                f"boot into old slot {self.active_slot}, "
+                f"but slot_in_use indicates it should boot into {_loaded_slot_in_use}, "
+                "this might indicate a failed finalization at first reboot after update/rollback"
+            )
 
     # slot_in_use control
 

--- a/otaclient/app/boot_control/_grub.py
+++ b/otaclient/app/boot_control/_grub.py
@@ -338,27 +338,6 @@ class GrubABPartitionDetecter:
         return slot_name, dev_path
 
 
-def detect_previous_active_slot_by_symlink() -> str:
-    """Detect the previous active partition by symlink.
-
-    NOTE: deprecated by slot_in_use file, but still use it in prior due to
-          backward compatibility reason.
-
-    Get the active slot by reading the symlink target of /boot/ota-partition.
-    if ota-partition -> ota-partition.sda3, then active slot is sda3.
-
-    If there are ota-partition.sda2 and ota-partition.sda3 exist under /boot, and
-    ota-partition -> ota-partition.sda3, then sda2 is the standby slot.
-    """
-    try:
-        ota_partition_symlink = Path(cfg.BOOT_DIR) / cfg.BOOT_OTA_PARTITION_FILE
-        active_ota_partition_file = os.readlink(ota_partition_symlink)
-
-        return Path(active_ota_partition_file).suffix.strip(".")
-    except FileNotFoundError:
-        raise _errors.ABPartitionError("ota-partition symlink is broken")
-
-
 class _GrubControl:
     """Implementation of ota-partition switch boot mechanism."""
 

--- a/otaclient/app/boot_control/_grub.py
+++ b/otaclient/app/boot_control/_grub.py
@@ -424,10 +424,16 @@ class _GrubControl:
             kernel_booted, initrd_booted = vmlinuz_active_slot, initrd_active_slot
             not_booted_with_ota_mechanism = True
 
-        if not_booted_with_ota_mechanism or active_slot_ota_boot_files_missing:
+        ota_partition_symlink_missing = not self.ota_partition_symlink.is_symlink()
+
+        if (
+            not_booted_with_ota_mechanism
+            or active_slot_ota_boot_files_missing
+            or ota_partition_symlink_missing
+        ):
             logger.warning(
                 "system is not booted with ota mechanism("
-                f"{not_booted_with_ota_mechanism=}, {active_slot_ota_boot_files_missing=}), "
+                f"{not_booted_with_ota_mechanism=}, {active_slot_ota_boot_files_missing=}, {ota_partition_symlink_missing=}), "
                 f"migrating and initializing ota-partition files for {self.active_slot}@{self.active_root_dev}..."
             )
 

--- a/otaclient/app/boot_control/_grub.py
+++ b/otaclient/app/boot_control/_grub.py
@@ -402,10 +402,19 @@ class _GrubControl:
         )
 
         try:
-            kernel_booted, initrd_booted = self._get_current_booted_files()
-            not_booted_with_ota_mechanism = (
-                kernel_booted != vmlinuz_active_slot.name
-                or initrd_booted != initrd_active_slot.name
+            kernel_booted_fpath, initrd_booted_fpath = self._get_current_booted_files()
+            kernel_booted, initrd_booted = (
+                Path(kernel_booted_fpath).name,
+                Path(initrd_booted_fpath).name,
+            )
+
+            # NOTE: current slot might be booted with ota(normal), or ota.standby(during update)
+            not_booted_with_ota_mechanism = kernel_booted not in (
+                GrubHelper.KERNEL_OTA,
+                GrubHelper.KERNEL_OTA_STANDBY,
+            ) or initrd_booted not in (
+                GrubHelper.INITRD_OTA,
+                GrubHelper.INITRD_OTA_STANDBY,
             )
         except ValueError as e:
             logger.error(

--- a/otaclient/app/boot_control/_grub.py
+++ b/otaclient/app/boot_control/_grub.py
@@ -365,7 +365,7 @@ class _GrubControl:
         self.standby_ota_partition_folder.mkdir(exist_ok=True)
 
         # NOTE: standby slot will be prepared in an OTA, GrubControl init will not check
-        #       standby slot's ota-partition files.
+        #       standby slot's ota-partition folder.
         self._grub_control_initialized = False
         self._check_active_slot_ota_partition_file()
 
@@ -448,7 +448,12 @@ class _GrubControl:
                 )
 
             # recreate all ota-partition files for active slot
-            self.reprepare_active_ota_partition_file(abort_on_standby_missed=False)
+            self._prepare_kernel_initrd_links(self.active_ota_partition_folder)
+            self._ensure_ota_partition_symlinks(active_slot=self.active_slot)
+            self._ensure_standby_slot_boot_files_symlinks(
+                standby_slot=self.standby_slot
+            )
+            self._grub_update_on_booted_slot()
             self._grub_control_initialized = True
 
         logger.info(f"ota-partition files for {self.active_slot} are ready")

--- a/otaclient/app/boot_control/_grub.py
+++ b/otaclient/app/boot_control/_grub.py
@@ -650,15 +650,12 @@ class GrubController(BootControllerProtocol):
     def __init__(self) -> None:
         try:
             self._boot_control = _GrubControl()
-            # mount point prepare
             self._mp_control = SlotMountHelper(
                 standby_slot_dev=self._boot_control.standby_root_dev,
                 standby_slot_mount_point=cfg.MOUNT_POINT,
                 active_slot_dev=self._boot_control.active_root_dev,
                 active_slot_mount_point=cfg.ACTIVE_ROOT_MOUNT_POINT,
             )
-
-            # load ota-status files
             self._ota_status_control = OTAStatusFilesControl(
                 active_slot=self._boot_control.active_slot,
                 standby_slot=self._boot_control.standby_slot,
@@ -752,7 +749,7 @@ class GrubController(BootControllerProtocol):
         standby_ota_partition_dir = self._ota_status_control.standby_ota_status_dir
         for f in self._mp_control.standby_boot_dir.iterdir():
             if f.is_file() and not f.is_symlink():
-                shutil.copyfile(f, standby_ota_partition_dir)
+                shutil.copy(f, standby_ota_partition_dir)
 
     ###### public methods ######
 

--- a/otaclient/app/boot_control/_grub.py
+++ b/otaclient/app/boot_control/_grub.py
@@ -506,12 +506,12 @@ class _GrubControl:
         re_symlink_atomic(initrd_ota, initrd)
         logger.info(f"finished generate ota symlinks under {target_folder}")
 
-    def _grub_update(self, *, abort_on_standby_missed=True):
-        """Generate and update grub.cfg for current booted slot.
+    def _grub_update_on_booted_slot(self, *, abort_on_standby_missed=True):
+        """Update grub_default and generate grub.cfg for current booted slot.
 
         NOTE:
-        1. this method only ensures the entry existence for current active slot.
-        2. this method ensures the default entry to be the current active slot.
+        1. this method only ensures the entry existence for current booted slot.
+        2. this method ensures the default entry to be the current booted slot.
         """
         grub_default_file = Path(cfg.ACTIVE_ROOTFS_PATH) / Path(
             cfg.DEFAULT_GRUB_PATH
@@ -521,10 +521,10 @@ class _GrubControl:
         #       whether the symlink points to an existing file or directory.
         active_vmlinuz = self.boot_dir / GrubHelper.KERNEL_OTA
         active_initrd = self.boot_dir / GrubHelper.INITRD_OTA
-        if not (active_vmlinuz.exists() and active_initrd.exists()):
+        if not (active_vmlinuz.is_file() and active_initrd.is_file()):
             msg = (
-                "vmlinuz and/or initrd for active slot is not available, "
-                "refuse to update_grub"
+                "/boot/vmlinuz-ota and/or /boot/initrd.img-ota are broken, "
+                "refuse to do grub-update"
             )
             logger.error(msg)
             raise ValueError(msg)
@@ -572,7 +572,7 @@ class _GrubControl:
             logger.debug(f"generated grub_cfg: {pformat(grub_cfg_updated)}")
         else:
             msg = (
-                "boot entry for standby slot not found, "
+                "/boot/vmlinuz-ota.standby and/or /boot/initrd.img-ota.standby not found, "
                 "only current active slot's entry is populated."
             )
             if abort_on_standby_missed:

--- a/otaclient/app/boot_control/_grub.py
+++ b/otaclient/app/boot_control/_grub.py
@@ -656,6 +656,7 @@ class GrubController(BootControllerProtocol):
                 standby_slot_mount_point=cfg.MOUNT_POINT,
                 active_slot_dev=self._boot_control.active_root_dev,
                 active_slot_mount_point=cfg.ACTIVE_ROOT_MOUNT_POINT,
+                standby_boot_dir=self._boot_control.standby_ota_partition_folder,
             )
 
             # load ota-status files

--- a/otaclient/app/boot_control/_grub.py
+++ b/otaclient/app/boot_control/_grub.py
@@ -777,8 +777,8 @@ class GrubController(BootControllerProtocol):
     def load_version(self) -> str:
         return self._ota_status_control.load_active_slot_version()
 
-    def get_ota_status(self) -> wrapper.StatusOta:
-        return self._ota_status_control.ota_status
+    def get_booted_ota_status(self) -> wrapper.StatusOta:
+        return self._ota_status_control.booted_ota_status
 
     def on_operation_failure(self):
         """Failure registering and cleanup at failure."""

--- a/otaclient/app/boot_control/_grub.py
+++ b/otaclient/app/boot_control/_grub.py
@@ -663,9 +663,13 @@ class _GrubControl:
 
     def grub_reboot_to_standby(self):
         """Temporarily boot to standby slot after OTA applied to standby slot."""
+        # ensure all required symlinks for standby slot are presented and valid
         self._prepare_kernel_initrd_links(self.standby_ota_partition_folder)
         self._ensure_standby_slot_boot_files_symlinks(standby_slot=self.standby_slot)
 
+        # ensure all required symlinks for active slot are presented and valid
+        # NOTE: reboot after post-update is still using the current active slot's
+        #       ota-partition symlinks(not yet switch boot).
         self._prepare_kernel_initrd_links(self.active_ota_partition_folder)
         self._ensure_ota_partition_symlinks(active_slot=self.active_slot)
         self._grub_update_on_booted_slot(abort_on_standby_missed=True)

--- a/otaclient/app/boot_control/_grub.py
+++ b/otaclient/app/boot_control/_grub.py
@@ -363,7 +363,6 @@ class _GrubControl:
     """Implementation of ota-partition switch boot mechanism."""
 
     def __init__(self) -> None:
-        """NOTE: init only, no changes will be made in the __init__."""
         ab_detecter = GrubABPartitionDetecter()
         self.active_root_dev = ab_detecter.active_dev
         self.standby_root_dev = ab_detecter.standby_dev
@@ -378,7 +377,6 @@ class _GrubControl:
         ).relative_to("/")
 
         self.ota_partition_symlink = self.boot_dir / cfg.BOOT_OTA_PARTITION_FILE
-
         self.active_ota_partition_folder = (
             self.boot_dir / cfg.BOOT_OTA_PARTITION_FILE
         ).with_suffix(f".{self.active_slot}")
@@ -514,7 +512,7 @@ class _GrubControl:
         """Generate current active grub_file from the view of current active slot.
 
         NOTE:
-        1. this method only ensures the entry existence for ota(current active slot).
+        1. this method only ensures the entry existence for current active slot.
         2. this method ensures the default entry to be the current active slot.
         """
         # NOTE: If the path points to a symlink, exists() returns

--- a/otaclient/app/boot_control/_grub.py
+++ b/otaclient/app/boot_control/_grub.py
@@ -554,11 +554,6 @@ class _GrubControl:
             logger.info(f"generated grub_cfg: {pformat(grub_cfg)}")
             write_str_to_file_sync(self.active_grub_file, grub_cfg)
 
-        # finally, symlink /boot/grub.cfg to ../ota-partition/grub.cfg
-        re_symlink_atomic(  # /boot/grub/grub.cfg -> ../ota-partition/grub.cfg
-            self.grub_file,
-            Path("../") / cfg.BOOT_OTA_PARTITION_FILE / "grub.cfg",
-        )
         logger.info(f"update_grub for {self.active_slot} finished.")
 
     def _ensure_ota_partition_symlinks(self):
@@ -590,6 +585,10 @@ class _GrubControl:
             self.boot_dir / GrubHelper.INITRD_OTA_STANDBY,
             ota_partition_folder.with_suffix(f".{self.standby_slot}")
             / GrubHelper.INITRD_OTA,
+        )
+        re_symlink_atomic(  # /boot/grub/grub.cfg -> ../ota-partition/grub.cfg
+            self.grub_file,
+            Path("../") / cfg.BOOT_OTA_PARTITION_FILE / "grub.cfg",
         )
 
     ###### public methods ######

--- a/otaclient/app/boot_control/_grub.py
+++ b/otaclient/app/boot_control/_grub.py
@@ -656,7 +656,6 @@ class GrubController(BootControllerProtocol):
                 standby_slot_mount_point=cfg.MOUNT_POINT,
                 active_slot_dev=self._boot_control.active_root_dev,
                 active_slot_mount_point=cfg.ACTIVE_ROOT_MOUNT_POINT,
-                standby_boot_dir=self._boot_control.standby_ota_partition_folder,
             )
 
             # load ota-status files

--- a/otaclient/app/boot_control/_grub.py
+++ b/otaclient/app/boot_control/_grub.py
@@ -680,6 +680,9 @@ class GrubController(BootControllerProtocol):
                     self._boot_control.finalize_update_switch_boot,
                     abort_on_standby_missed=True,
                 ),
+                # NOTE(20230904): if boot control is initialized(i.e., migrate from non-ota booted system),
+                #                 force initialize the ota_status files.
+                force_initialize=self._boot_control.initialized,
             )
         except Exception as e:
             logger.error(f"failed on init boot controller: {e!r}")

--- a/otaclient/app/boot_control/_grub.py
+++ b/otaclient/app/boot_control/_grub.py
@@ -264,8 +264,8 @@ class GrubHelper:
             raise
 
 
-class GrubABPartitionDetecter:
-    """A/B partition detecter for ota-partition on grub booted system.
+class GrubABPartitionDetector:
+    """A/B partition detector for ota-partition on grub booted system.
 
     Expected layout:
     (system boots with legacy BIOS)
@@ -345,11 +345,11 @@ class _GrubControl:
     """Implementation of ota-partition switch boot mechanism."""
 
     def __init__(self) -> None:
-        ab_detecter = GrubABPartitionDetecter()
-        self.active_root_dev = ab_detecter.active_dev
-        self.standby_root_dev = ab_detecter.standby_dev
-        self.active_slot = ab_detecter.active_slot
-        self.standby_slot = ab_detecter.standby_slot
+        ab_detector = GrubABPartitionDetector()
+        self.active_root_dev = ab_detector.active_dev
+        self.standby_root_dev = ab_detector.standby_dev
+        self.active_slot = ab_detector.active_slot
+        self.standby_slot = ab_detector.standby_slot
         logger.info(f"{self.active_slot=}, {self.standby_slot=}")
 
         self.boot_dir = Path(cfg.BOOT_DIR)

--- a/otaclient/app/boot_control/_grub.py
+++ b/otaclient/app/boot_control/_grub.py
@@ -16,7 +16,6 @@
 import re
 import shutil
 from dataclasses import dataclass
-from functools import partial
 from subprocess import CalledProcessError
 from typing import ClassVar, Dict, Generator, List, Optional, Tuple
 from pathlib import Path
@@ -686,10 +685,7 @@ class GrubController(BootControllerProtocol):
                 standby_slot=self._boot_control.standby_slot,
                 current_ota_status_dir=self._boot_control.active_ota_partition_folder,
                 standby_ota_status_dir=self._boot_control.standby_ota_partition_folder,
-                finalize_switching_boot=partial(
-                    self._boot_control.finalize_update_switch_boot,
-                    abort_on_standby_missed=True,
-                ),
+                finalize_switching_boot=self._boot_control.finalize_update_switch_boot,
                 # NOTE(20230904): if boot control is initialized(i.e., migrate from non-ota booted system),
                 #                 force initialize the ota_status files.
                 force_initialize=self._boot_control.initialized,

--- a/otaclient/app/boot_control/_rpi_boot.py
+++ b/otaclient/app/boot_control/_rpi_boot.py
@@ -383,6 +383,8 @@ class RPIBootController(BootControllerProtocol):
             standby_slot_mount_point=cfg.MOUNT_POINT,
             active_slot_dev=self._rpiboot_control.active_slot_dev,
             active_slot_mount_point=cfg.ACTIVE_ROOT_MOUNT_POINT,
+            standby_boot_dir=Path(cfg.MOUNT_POINT)
+            / Path(cfg.BOOT_DIR).relative_to("/"),
         )
         # init ota-status files
         self._ota_status_control = OTAStatusFilesControl(

--- a/otaclient/app/boot_control/_rpi_boot.py
+++ b/otaclient/app/boot_control/_rpi_boot.py
@@ -397,7 +397,7 @@ class RPIBootController(BootControllerProtocol):
         )
 
         # 20230613: remove any leftover flag file if ota_status is not UPDATING/ROLLBACKING
-        if self._ota_status_control.ota_status not in (
+        if self._ota_status_control.booted_ota_status not in (
             wrapper.StatusOta.UPDATING,
             wrapper.StatusOta.ROLLBACKING,
         ):
@@ -556,5 +556,5 @@ class RPIBootController(BootControllerProtocol):
     def load_version(self) -> str:
         return self._ota_status_control.load_active_slot_version()
 
-    def get_ota_status(self) -> wrapper.StatusOta:
-        return self._ota_status_control.ota_status
+    def get_booted_ota_status(self) -> wrapper.StatusOta:
+        return self._ota_status_control.booted_ota_status

--- a/otaclient/app/boot_control/_rpi_boot.py
+++ b/otaclient/app/boot_control/_rpi_boot.py
@@ -383,8 +383,6 @@ class RPIBootController(BootControllerProtocol):
             standby_slot_mount_point=cfg.MOUNT_POINT,
             active_slot_dev=self._rpiboot_control.active_slot_dev,
             active_slot_mount_point=cfg.ACTIVE_ROOT_MOUNT_POINT,
-            standby_boot_dir=Path(cfg.MOUNT_POINT)
-            / Path(cfg.BOOT_DIR).relative_to("/"),
         )
         # init ota-status files
         self._ota_status_control = OTAStatusFilesControl(

--- a/otaclient/app/boot_control/configs.py
+++ b/otaclient/app/boot_control/configs.py
@@ -55,6 +55,7 @@ class GrubControlConfig(BaseConfig):
     BOOTLOADER: BootloaderType = BootloaderType.GRUB
     FSTAB_FILE_PATH: str = "/etc/fstab"
     GRUB_DIR: str = "/boot/grub"
+    GRUB_CFG_FNAME: str = "grub.cfg"
     GRUB_CFG_PATH: str = "/boot/grub/grub.cfg"
     DEFAULT_GRUB_PATH: str = "/etc/default/grub"
     BOOT_OTA_PARTITION_FILE: str = "ota-partition"

--- a/otaclient/app/boot_control/protocol.py
+++ b/otaclient/app/boot_control/protocol.py
@@ -33,10 +33,15 @@ class BootControllerProtocol(Protocol):
 
     @abstractmethod
     def get_standby_boot_dir(self) -> Path:
-        """Get the Path points to the standby boot folder.
+        """Get the Path points to the standby slot's boot folder.
 
-        NOTE: this folder is meant to be the place to store kernel and initrd.img,
-              it is not neccessary to always be /boot folder.
+        NOTE(20230907): this will always return the path to
+                        <standby_slots_mount_point>/boot.
+        DEPRECATED(20230907): standby slot creator doesn't need to
+                        treat the files under /boot specially, it is
+                        boot controller's responsibility to get the
+                        kernel/initrd.img from standby slot and prepare
+                        them to actual boot dir.
         """
 
     @abstractmethod

--- a/otaclient/app/boot_control/protocol.py
+++ b/otaclient/app/boot_control/protocol.py
@@ -33,7 +33,11 @@ class BootControllerProtocol(Protocol):
 
     @abstractmethod
     def get_standby_boot_dir(self) -> Path:
-        """Get the Path points to the standby boot folder."""
+        """Get the Path points to the standby boot folder.
+
+        NOTE: this folder is meant to be the place to store kernel and initrd.img,
+              it is not neccessary to always be /boot folder.
+        """
 
     @abstractmethod
     def pre_update(self, version: str, *, standby_as_ref: bool, erase_standby: bool):

--- a/otaclient/app/boot_control/protocol.py
+++ b/otaclient/app/boot_control/protocol.py
@@ -24,8 +24,12 @@ class BootControllerProtocol(Protocol):
     """Boot controller protocol for otaclient."""
 
     @abstractmethod
-    def get_ota_status(self) -> wrapper.StatusOta:
-        """Get the stored ota_status of current active slot."""
+    def get_booted_ota_status(self) -> wrapper.StatusOta:
+        """Get the ota_status loaded from status file during otaclient starts up.
+
+        This value is meant to be used only once during otaclient starts up,
+            to init the live_ota_status maintained by otaclient.
+        """
 
     @abstractmethod
     def get_standby_slot_path(self) -> Path:

--- a/otaclient/app/configs.py
+++ b/otaclient/app/configs.py
@@ -182,7 +182,7 @@ class BaseConfig(_InternalSettings):
     EXTERNAL_CACHE_SRC_PATH = "/mnt/external_cache_src/data"
 
     # default version string to be reported in status API response
-    DEFAULT_VERSION_STR = "unknown_version"
+    DEFAULT_VERSION_STR = ""
 
 
 # init cfgs

--- a/otaclient/app/configs.py
+++ b/otaclient/app/configs.py
@@ -181,6 +181,9 @@ class BaseConfig(_InternalSettings):
     EXTERNAL_CACHE_DEV_MOUNTPOINT = "/mnt/external_cache_src"
     EXTERNAL_CACHE_SRC_PATH = "/mnt/external_cache_src/data"
 
+    # default version string to be reported in status API response
+    DEFAULT_VERSION_STR = "unknown_version"
+
 
 # init cfgs
 server_cfg = OtaClientServerConfig()

--- a/otaclient/app/ota_client.py
+++ b/otaclient/app/ota_client.py
@@ -493,7 +493,9 @@ class OTAClient(OTAClientProtocol):
 
         self.boot_controller = boot_control_cls()
         self.create_standby_cls = create_standby_cls
-        self.live_ota_status = LiveOTAStatus(self.boot_controller.get_ota_status())
+        self.live_ota_status = LiveOTAStatus(
+            self.boot_controller.get_booted_ota_status()
+        )
 
         self.current_version = (
             self.boot_controller.load_version() or self.DEFAULT_FIRMWARE_VERSION

--- a/tests/test_boot_control/test_grub.py
+++ b/tests/test_boot_control/test_grub.py
@@ -219,7 +219,7 @@ class TestGrubControl:
         mocker: pytest_mock.MockerFixture,
         grub_ab_slot,
     ):
-        from otaclient.app.boot_control._grub import GrubABPartitionDetecter
+        from otaclient.app.boot_control._grub import GrubABPartitionDetector
         from otaclient.app.boot_control._common import CMDHelperFuncs, SlotMountHelper
 
         # ------ start fsm ------ #
@@ -244,7 +244,7 @@ class TestGrubControl:
         )
 
         # ------ mock GrubABPartitionDetector ------ #
-        _mocked_ab_partition_detector = mocker.MagicMock(spec=GrubABPartitionDetecter)
+        _mocked_ab_partition_detector = mocker.MagicMock(spec=GrubABPartitionDetector)
         type(_mocked_ab_partition_detector).active_slot = mocker.PropertyMock(
             wraps=self._fsm.get_active_slot
         )
@@ -293,12 +293,12 @@ class TestGrubControl:
         _CMDHelper_at_grub_path = f"{cfg.GRUB_MODULE_PATH}.CMDHelperFuncs"
         mocker.patch(_CMDHelper_at_common_path, _CMDHelper_mock)
         mocker.patch(_CMDHelper_at_grub_path, _CMDHelper_mock)
-        # patch _GrubABPartitionDetecter
-        _GrubABPartitionDetecter_path = (
-            f"{cfg.GRUB_MODULE_PATH}.GrubABPartitionDetecter"
+        # patch _GrubABPartitionDetector
+        _GrubABPartitionDetector_path = (
+            f"{cfg.GRUB_MODULE_PATH}.GrubABPartitionDetector"
         )
         mocker.patch(
-            _GrubABPartitionDetecter_path, return_value=_mocked_ab_partition_detector
+            _GrubABPartitionDetector_path, return_value=_mocked_ab_partition_detector
         )
         # patch SlotMountHelper
         _SlotMountHelper_path = f"{cfg.GRUB_MODULE_PATH}.SlotMountHelper"

--- a/tests/test_boot_control/test_grub.py
+++ b/tests/test_boot_control/test_grub.py
@@ -35,6 +35,8 @@ class GrubFSM:
         self._standby_slot = cfg.SLOT_B_ID_GRUB
         self._current_slot_mp = Path(slot_a_mp)
         self._standby_slot_mp = Path(slot_b_mp)
+        self._current_slot_dev_uuid = f"UUID={cfg.SLOT_A_UUID}"
+        self._standby_slot_dev_uuid = f"UUID={cfg.SLOT_B_UUID}"
         self.current_slot_bootable = True
         self.standby_slot_bootable = True
 
@@ -59,19 +61,23 @@ class GrubFSM:
         return self._standby_slot_mp
 
     def get_standby_boot_dir(self) -> Path:
-        return Path(os.path.join(self._standby_slot_mp, "boot"))
+        return self._standby_slot_mp / "boot"
 
     def get_uuid_str_by_dev(self, dev: str):
         if dev == self.get_standby_slot_dev():
-            return f"UUID={cfg.SLOT_B_UUID}"
+            return self._standby_slot_dev_uuid
         else:
-            return f"UUID={cfg.SLOT_A_UUID}"
+            return self._current_slot_dev_uuid
 
     def switch_boot(self):
         self._current_slot, self._standby_slot = self._standby_slot, self._current_slot
         self._current_slot_mp, self._standby_slot_mp = (
             self._standby_slot_mp,
             self._current_slot_mp,
+        )
+        self._current_slot_dev_uuid, self._standby_slot_dev_uuid = (
+            self._standby_slot_dev_uuid,
+            self._current_slot_dev_uuid,
         )
         self.is_boot_switched = True
 

--- a/tests/test_boot_control/test_grub.py
+++ b/tests/test_boot_control/test_grub.py
@@ -171,9 +171,7 @@ class TestGrubControl:
         self.slot_a = Path(ab_slots.slot_a)
         self.slot_b = Path(ab_slots.slot_b)
         self.boot_dir = tmp_path / Path(cfg.BOOT_DIR).relative_to("/")
-        self.slot_a_boot_dir = self.slot_a / "boot"
         self.slot_b_boot_dir = self.slot_b / "boot"
-        self.slot_a_boot_dir.mkdir(parents=True, exist_ok=True)
         self.slot_b_boot_dir.mkdir(parents=True, exist_ok=True)
 
         self.slot_a_ota_partition_dir = (
@@ -189,6 +187,7 @@ class TestGrubControl:
             self.boot_dir,
             dirs_exist_ok=True,
         )
+
         # NOTE: dummy ota-image doesn't have grub installed,
         #       so we need to prepare /etc/default/grub by ourself
         default_grub = self.slot_a / Path(cfg.DEFAULT_GRUB_FILE).relative_to("/")

--- a/tests/test_boot_control/test_ota_status_control.py
+++ b/tests/test_boot_control/test_ota_status_control.py
@@ -1,0 +1,270 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import logging
+import threading
+import pytest
+from functools import partial
+from pathlib import Path
+from typing import Optional, Union
+
+from otaclient.app.common import read_str_from_file, write_str_to_file
+from otaclient.app.proto import wrapper
+from otaclient.app.boot_control.configs import BaseConfig as cfg
+from otaclient.app.boot_control._common import OTAStatusFilesControl
+
+logger = logging.getLogger(__name__)
+
+
+def _dummy_finalize_switch_boot(
+    flag: threading.Event, boot_control_switch_boot_result: bool
+):
+    flag.set()
+    return boot_control_switch_boot_result
+
+
+class TestOTAStatusFilesControl:
+    SLOT_A_ID, SLOT_B_ID = "slot_a", "slot_b"
+
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path: Path):
+        self.slot_a, self.slot_b = self.SLOT_A_ID, self.SLOT_B_ID
+        self.slot_a_ota_status_dir = tmp_path / "slot_a_ota_status_dir"
+        self.slot_a_ota_status_dir.mkdir()
+        self.slot_b_ota_status_dir = tmp_path / "slot_b_ota_status_dir"
+        self.slot_b_ota_status_dir.mkdir()
+
+        self.slot_a_status_file = self.slot_a_ota_status_dir / cfg.OTA_STATUS_FNAME
+        self.slot_b_status_file = self.slot_b_ota_status_dir / cfg.OTA_STATUS_FNAME
+        self.slot_a_slot_in_use_file = (
+            self.slot_a_ota_status_dir / cfg.SLOT_IN_USE_FNAME
+        )
+        self.slot_b_slot_in_use_file = (
+            self.slot_b_ota_status_dir / cfg.SLOT_IN_USE_FNAME
+        )
+
+        self.finalize_switch_boot_flag = threading.Event()
+        self.finalize_switch_boot_func = partial(
+            _dummy_finalize_switch_boot, self.finalize_switch_boot_flag
+        )
+
+    @pytest.mark.parametrize(
+        (
+            "test_case,input_slot_a_status,input_slot_a_slot_in_use,force_initialize,"
+            "output_slot_a_status,output_slot_a_slot_in_use"
+        ),
+        (
+            (
+                "test_initialize",
+                # input
+                None,
+                "",
+                False,
+                # output
+                wrapper.StatusOta.INITIALIZED,
+                SLOT_A_ID,
+            ),
+            (
+                "test_force_initialize",
+                # input
+                wrapper.StatusOta.SUCCESS,
+                SLOT_A_ID,
+                True,
+                # output
+                wrapper.StatusOta.INITIALIZED,
+                SLOT_A_ID,
+            ),
+            (
+                "test_normal_boot",
+                # input
+                wrapper.StatusOta.SUCCESS,
+                SLOT_A_ID,
+                False,
+                # output
+                wrapper.StatusOta.SUCCESS,
+                SLOT_A_ID,
+            ),
+        ),
+    )
+    def test_ota_status_files_loading(
+        self,
+        test_case: str,
+        input_slot_a_status: Optional[wrapper.StatusOta],
+        input_slot_a_slot_in_use: str,
+        force_initialize: bool,
+        output_slot_a_status: wrapper.StatusOta,
+        output_slot_a_slot_in_use: str,
+    ):
+        logger.info(f"{test_case=}")
+        # ------ setup ------ #
+        write_str_to_file(
+            self.slot_a_status_file,
+            input_slot_a_status.name if input_slot_a_status else "",
+        )
+        write_str_to_file(self.slot_a_slot_in_use_file, input_slot_a_slot_in_use)
+
+        # ------ execution ------ #
+        status_control = OTAStatusFilesControl(
+            active_slot=self.slot_a,
+            standby_slot=self.slot_b,
+            current_ota_status_dir=self.slot_a_ota_status_dir,
+            standby_ota_status_dir=self.slot_b_ota_status_dir,
+            finalize_switching_boot=partial(self.finalize_switch_boot_func, True),
+            force_initialize=force_initialize,
+        )
+
+        # ------ assertion ------ #
+        assert not self.finalize_switch_boot_flag.is_set()
+        # check slot a
+        assert read_str_from_file(self.slot_a_status_file) == output_slot_a_status.name
+        assert status_control.booted_ota_status == output_slot_a_status
+        assert (
+            read_str_from_file(self.slot_a_slot_in_use_file)
+            == status_control._load_current_slot_in_use()
+            == output_slot_a_slot_in_use
+        )
+
+    def test_pre_update(self):
+        """Test update from slot_a to slot_b."""
+        # ------ direct init ------ #
+        status_control = OTAStatusFilesControl(
+            active_slot=self.slot_a,
+            standby_slot=self.slot_b,
+            current_ota_status_dir=self.slot_a_ota_status_dir,
+            standby_ota_status_dir=self.slot_b_ota_status_dir,
+            finalize_switching_boot=partial(self.finalize_switch_boot_func, True),
+            force_initialize=False,
+        )
+
+        # ------ execution ------ #
+        status_control.pre_update_current()
+        status_control.pre_update_standby(version="dummy_version")
+
+        # ------ assertion ------ #
+        assert not self.finalize_switch_boot_flag.is_set()
+        # slot_a: current slot
+        assert (
+            read_str_from_file(self.slot_a_status_file)
+            == wrapper.StatusOta.FAILURE.name
+        )
+        assert (
+            read_str_from_file(self.slot_a_slot_in_use_file)
+            == status_control._load_current_slot_in_use()
+            == self.slot_b
+        )
+        # slot_b: standby slot
+        assert (
+            read_str_from_file(self.slot_b_status_file)
+            == wrapper.StatusOta.UPDATING.name
+        )
+        assert read_str_from_file(self.slot_b_slot_in_use_file) == self.slot_b
+
+    @pytest.mark.parametrize(
+        ("test_case,finalizing_result"),
+        (
+            (
+                "test_finalizing_failed",
+                False,
+            ),
+            (
+                "test_finalizing_succeeded",
+                True,
+            ),
+        ),
+    )
+    def test_switching_boot(
+        self,
+        test_case: str,
+        finalizing_result: bool,
+    ):
+        """First reboot after OTA from slot_a to slot_b."""
+        logger.info(f"{test_case=}")
+        # ------ setup ------ #
+        write_str_to_file(self.slot_a_status_file, wrapper.StatusOta.FAILURE.name)
+        write_str_to_file(self.slot_a_slot_in_use_file, self.slot_b)
+        write_str_to_file(self.slot_b_status_file, wrapper.StatusOta.UPDATING.name)
+        write_str_to_file(self.slot_b_slot_in_use_file, self.slot_b)
+
+        # ------ execution ------ #
+        # otaclient boots on slot_b
+        status_control = OTAStatusFilesControl(
+            active_slot=self.slot_b,
+            standby_slot=self.slot_a,
+            current_ota_status_dir=self.slot_b_ota_status_dir,
+            standby_ota_status_dir=self.slot_a_ota_status_dir,
+            finalize_switching_boot=partial(
+                self.finalize_switch_boot_func, finalizing_result
+            ),
+            force_initialize=False,
+        )
+
+        # ------ assertion ------ #
+        # ensure finalizing is called
+        assert self.finalize_switch_boot_flag.is_set()
+
+        # check slot a
+        assert (
+            read_str_from_file(self.slot_a_status_file)
+            == wrapper.StatusOta.FAILURE.name
+        )
+        assert (
+            read_str_from_file(self.slot_a_slot_in_use_file)
+            == status_control._load_current_slot_in_use()
+            == self.slot_b
+        )
+        assert (
+            read_str_from_file(self.slot_b_slot_in_use_file)
+            == status_control._load_current_slot_in_use()
+            == self.slot_b
+        )
+
+        # finalizing succeeded
+        if finalizing_result:
+            assert status_control.booted_ota_status == wrapper.StatusOta.SUCCESS
+            assert (
+                read_str_from_file(self.slot_b_status_file)
+                == wrapper.StatusOta.SUCCESS.name
+            )
+
+        else:
+            assert status_control.booted_ota_status == wrapper.StatusOta.FAILURE
+            assert (
+                read_str_from_file(self.slot_b_status_file)
+                == wrapper.StatusOta.FAILURE.name
+            )
+
+    def test_accidentally_boots_back_to_standby(self):
+        """slot_a should be active slot but boots back to slot_b."""
+        # ------ setup ------ #
+        write_str_to_file(self.slot_a_status_file, wrapper.StatusOta.SUCCESS.name)
+        write_str_to_file(self.slot_a_slot_in_use_file, self.slot_a)
+        write_str_to_file(self.slot_b_status_file, wrapper.StatusOta.FAILURE.name)
+        write_str_to_file(self.slot_b_slot_in_use_file, self.slot_a)
+
+        # ------ execution ------ #
+        # otaclient accidentally boots on slot_b
+        status_control = OTAStatusFilesControl(
+            active_slot=self.slot_b,
+            standby_slot=self.slot_a,
+            current_ota_status_dir=self.slot_b_ota_status_dir,
+            standby_ota_status_dir=self.slot_a_ota_status_dir,
+            finalize_switching_boot=partial(self.finalize_switch_boot_func, True),
+            force_initialize=False,
+        )
+
+        # ------ assertion ------ #
+        assert not self.finalize_switch_boot_flag.is_set()
+        # slot_b's status is read
+        assert status_control.booted_ota_status == wrapper.StatusOta.FAILURE

--- a/tests/test_boot_control/test_rpi_boot.py
+++ b/tests/test_boot_control/test_rpi_boot.py
@@ -319,7 +319,9 @@ class TestRPIBootControl:
         # 1. make sure ota_status is SUCCESS
         # 2. make sure the flag file is cleared
         # 3. make sure the config.txt is still for slot_b
-        assert rpi_boot_controller4_2.get_ota_status() == wrapper.StatusOta.SUCCESS
+        assert (
+            rpi_boot_controller4_2.get_booted_ota_status() == wrapper.StatusOta.SUCCESS
+        )
         assert (
             self.slot_b_ota_status_dir / rpi_boot_cfg.OTA_STATUS_FNAME
         ).read_text() == wrapper.StatusOta.SUCCESS.name

--- a/tests/test_ota_client.py
+++ b/tests/test_ota_client.py
@@ -231,7 +231,9 @@ class Test_OTAClient:
         )
         # patch boot_controller for otaclient initializing
         self.boot_controller.load_version.return_value = self.CURRENT_FIRMWARE_VERSION
-        self.boot_controller.get_ota_status.return_value = wrapper.StatusOta.SUCCESS
+        self.boot_controller.get_booted_ota_status.return_value = (
+            wrapper.StatusOta.SUCCESS
+        )
 
         self.ota_client = OTAClient(
             boot_control_cls=mocker.MagicMock(return_value=self.boot_controller),


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. 

For better understanding, adding reason/motivation of this PR are also recommended.
-->

This PR introduces several internal refinements to grub boot_control implementation as follow. With this PR, grub boot_control implementation aligns with [grub boot control design](https://tier4.atlassian.net/l/cp/7XMJ6fEN) documentation.

### Robustness improved over boot control load/init

This PR refines the grub boot_control procedures, aligns the behavior with the design document. Comparing to the previous implementation, it handles the condition of ota-partition symlink broken and migration from non-ota-partition booted system properly during boot_control loading, please check **Behavior changes** for more details.

Also, during finalizing switch boot, previously otaclient will do the ota-partition symlink switching **before** doing `grub-update`, this potentially breaks the atomic switching boot. This PR fixes this issue.

### `OTAStatusFilesControl` and `SlotMountHelper`

These two classes are common shared helper classes that implement **ota_status files control** and **slots preparing/mounting**, which can be used by any detailed boot_control implementation(previously only used by `rpi_boot`, this PR make `grub_boot` also use these classes). They are introduced since #182 .

The goal for introducing these classes is to abstract **ota_status files control** and **slots preparing/mounting** from detailed boot_control implementation, improve boot_control implementation's cohesive, reduce code duplication and ease maintaining.
Especially, the `OTAStatusFilesControl` class aligns with [ota_status control design](https://tier4.atlassian.net/l/cp/81k0fLky). 

### Split out ota_status files control and slot preparing/mounting from boot_control implementation 

This PR splits and removes the ota_status files control logic from grub boot_control implementation,  using `OTAStatusFilesControl` and `SlotMountHelper` instead of mixins combination (`OTAStatusMixin, VersionControlMixin, PrepareMountMixin`, these mixins are deprecated in flavor of `OTAStatusFilesControl` and `SlotMountHelper` classes). 

Now grub boot_control doesn't implement the ota_status files control and slot preparing/mounting, but using APIs from `OTAStatusFilesControl` and `SlotMountHelper`, making grub boot_control implementation more focuses on grub control logic, reduce code duplication and ease the maintaining.

## Related documents

1. [ota_status control design](https://tier4.atlassian.net/l/cp/81k0fLky)
4. [grub boot control design](https://tier4.atlassian.net/l/cp/7XMJ6fEN)

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] related documents are provided.
- [x] test file(s) that covers the change(s) is implemented.
- [x] local test is passed. 
- [x] VM test: boot migrate from non-ota-partition booted system test.
- [x] VM test: try to fix ota-partition symlink missing/corrupted. 
- [x] VM test: normal OTA.

## Changes

<!-- A list of code change(s) that introduced by this PR. -->

1. `common.OTAStatusFilesControl`: split loading and parsing `status` and `slot_in_use` file into two methods,
2. `common.OTAStatusFilesControl`: takes `force_initialize` param in `__init__`, ota_status will initialize if boot_control is initialized, 
3. `common.SlotMountHelper`: `standby_boot_dir` is always `<standby_slot_mp>/boot`, standby_slot creator no-longer needs to care about where the kernel/initrd.img should be placed, this will be handled by boot_controller,
4. `protocol`: rename `get_ota_status` to `get_booted_ota_status` to distinguish this ota_status with live_ota_status maintained by otaclient,
5. `grub_boot`: remove `_SymlinkABPartitionDetecter`, only detect AB partition by partition information(`GrubABPartitionDetecter`),
6. `grub_boot`: use `OTAStatusFilesControl` to handle ota_status files control, switch boot detecting, etc, remove superseded/overridden codes, 
7. `grub_boot`: use `SlotMountHelper` to handle slots preparing/mounting in each update phases, remove superseded/overridden codes, 
8. `grub_boot`: refine boot loading procedures, checking the present of ota-partition files during loading, handles the case of ota-partition symlink corrupted, in such case a full boot_control initializing will engage and all ota-partition files will be recreated,
9. `grub_boot`: indicates `OTAStatusFilesControl` to initialize unconditionally if boot_control is initialized,
10. `grub_boot`: `_get_current_booted_kernel_and_initrd` now use standard way to detect booted initrd.img,
11. `grub_boot`: `_prepare_kernel_initrd_links` now uses first found kernel, and try to find the corresponding initrd.img with the same version string,
12. `grub_boot`: split `ensure_ota_partition_symlinks` into two new methods `_ensure_ota_partition_symlinks` and `_ensure_standby_slot_boot_files_symlinks`,
13. `grub_boot`: remove `reprepare_standby_ota_partition_file` and `reprepare_active_ota_partition_file` methods, now `grub_reboot_to_standby` and `finalizing_switch_boot` implements boot control with helper methods on their own,
14. `grub_boot`: `grub_reboot_to_standby` and `finalizing_switch_boot` now ensure the present of all ota-partition symlinks before grub-update,
15. `grub_boot`: `finalizing_switch_boot` now does switch boot after grub-update, before grub-update all ota-partition symlinks will be ensured,
16. `rpi_boot`: change according to `boot_control.ota_status -> boot_control.booted_ota_status` rename,
17. `config`: add `DEFAULT_VERSION_STR`, value is empty string to align with previous implementation,
18. `ota_client`: change according to `boot_control.get_ota_status -> boot_control.get_booted_ota_status` API rename,
19. fix up `test_grub` to make it work again,
20. add new `test_ota_status_control`,
21. minor fix up to `test_rpi_boot` and `test_ota_client`.

## Behavior changes

Does this PR introduce behavior change(s)?

- [x] Yes, internal behaivor (will not impact user experience).

### Previous behavior

<!-- Behaivor before the PR is introduced -->

1. otaclient will crash on ota-partition symlink missing/corrupted, even the system is booted normally.
2. otaclient cannot correctly migrates non-ota-partition booted system in some cases.
3. grub boot_control implements the detailed ota_status files control, including reading/writing/updating ota_status files during each OTA stages, switch boot mode detection, ota_status transition, etc.
4. grub boot_control prepares slots devices and mounting slots directly using commands provided by `CMDHelperFuncs`.
5. during finalizing switch boot, otaclient does ota-partition symlink switch before doing grub-update. 
6. in `_prepare_kernel_initrd_links`, grub boot_control will use the **first bound** kernel and first found **initrd.img**, but these two files might have different version.

### Behavior with this PR

<!-- Behavior after the PR is introduced -->

1. otaclient now will not crash on ota-partition symlink missing, but instead try to fix it first or migrate.
2. otaclient now can properly migrate from non-ota-partition booted system.
3. grub boot_control no-longer directly managing ota_status files, but calling corresponding APIs from`OTAStatusFilesControl` during each OTA stages.
4. grub boot_control no-longer directly managing slots mounting/preparing, but calling corresponding APIs from `SlotMountHelper` during each OTA stages.
5. behavior of finalizing switch boot now aligns with documentation, which otaclient will do grub-update before switching ota-partition symlink.
6. in `_prepare_kernel_initrd_links`, grub boot control will use the first found kernel, and use its version string to find corresponding initrd.img.

## Breaking change

Does this PR introduce breaking change?
- [x] No.

<!-- List the breaking change(s) -->