### PR TITLE
[Refinement] refine error handling, error report on status API now covers boot controller startup failure

### DIFF
--- a/otaclient/app/boot_control/_cboot.py
+++ b/otaclient/app/boot_control/_cboot.py
@@ -21,7 +21,7 @@ from subprocess import CalledProcessError
 from typing import Generator, Optional
 
 
-from .. import log_setting
+from .. import log_setting, errors as ota_errors
 from ..common import (
     copytree_identical,
     read_str_from_file,
@@ -30,14 +30,6 @@ from ..common import (
     write_str_to_file_sync,
 )
 
-from ..errors import (
-    BootControlStartupFailed,
-    BootControlPlatformUnsupported,
-    BootControlPostRollbackFailed,
-    BootControlPostUpdateFailed,
-    BootControlPreRollbackFailed,
-    BootControlPreUpdateFailed,
-)
 from ..proto import wrapper
 
 from ._common import (
@@ -339,9 +331,9 @@ class CBootController(
             # init ota-status
             self._init_boot_control()
         except NotImplementedError as e:
-            raise BootControlPlatformUnsupported(module=__name__) from e
+            raise ota_errors.BootControlPlatformUnsupported(module=__name__) from e
         except Exception as e:
-            raise BootControlStartupFailed(
+            raise ota_errors.BootControlStartupFailed(
                 f"unspecific boot controller startup failure: {e!r}", module=__name__
             ) from e
 
@@ -514,7 +506,9 @@ class CBootController(
         except Exception as e:
             _err_msg = f"failed on pre_update: {e!r}"
             logger.exception(_err_msg)
-            raise BootControlPreUpdateFailed(f"{e!r}", module=__name__) from e
+            raise ota_errors.BootControlPreUpdateFailed(
+                f"{e!r}", module=__name__
+            ) from e
 
     def post_update(self) -> Generator[None, None, None]:
         try:
@@ -554,7 +548,9 @@ class CBootController(
         except Exception as e:
             _err_msg = f"failed on post_update: {e!r}"
             logger.exception(_err_msg)
-            raise BootControlPostUpdateFailed(_err_msg, module=__name__) from e
+            raise ota_errors.BootControlPostUpdateFailed(
+                _err_msg, module=__name__
+            ) from e
 
     def pre_rollback(self):
         try:
@@ -568,7 +564,9 @@ class CBootController(
         except Exception as e:
             _err_msg = f"failed on pre_rollback: {e!r}"
             logger.exception(_err_msg)
-            raise BootControlPreRollbackFailed(_err_msg, module=__name__) from e
+            raise ota_errors.BootControlPreRollbackFailed(
+                _err_msg, module=__name__
+            ) from e
 
     def post_rollback(self):
         try:
@@ -577,4 +575,6 @@ class CBootController(
         except Exception as e:
             _err_msg = f"failed on post_rollback: {e!r}"
             logger.exception(_err_msg)
-            raise BootControlPostRollbackFailed(_err_msg, module=__name__) from e
+            raise ota_errors.BootControlPostRollbackFailed(
+                _err_msg, module=__name__
+            ) from e

--- a/otaclient/app/boot_control/_grub.py
+++ b/otaclient/app/boot_control/_grub.py
@@ -56,7 +56,6 @@ from ..errors import (
 )
 from ..proto import wrapper
 
-from . import _errors
 from ._common import (
     CMDHelperFuncs,
     OTAStatusFilesControl,
@@ -70,6 +69,10 @@ from .protocol import BootControllerProtocol
 logger = log_setting.get_logger(
     __name__, cfg.LOG_LEVEL_TABLE.get(__name__, cfg.DEFAULT_LOG_LEVEL)
 )
+
+
+class _GrubBootControllerError(Exception):
+    """Grub boot controller internal used exception."""
 
 
 @dataclass
@@ -327,7 +330,9 @@ class GrubABPartitionDetector:
         parent = CMDHelperFuncs.get_parent_dev(active_dev)
         boot_dev = CMDHelperFuncs.get_dev_by_mount_point("/boot")
         if not boot_dev:
-            raise _errors.ABPartitionError("/boot is not mounted")
+            _err_msg = "/boot is not mounted"
+            logger.error(_err_msg)
+            raise ValueError(_err_msg)
 
         # list children device file from parent device
         cmd = f"-Pp -o NAME,FSTYPE {parent}"
@@ -344,9 +349,9 @@ class GrubABPartitionDetector:
                 ):
                     return m.group(1)
 
-        raise _errors.ABPartitionError(
-            f"{parent=} has unexpected partition layout: {output=}"
-        )
+        _err_msg = f"{parent=} has unexpected partition layout: {output=}"
+        logger.error(_err_msg)
+        raise ValueError(_err_msg)
 
     def _detect_active_slot(self) -> Tuple[str, str]:
         """Get active slot's slot_id.
@@ -455,7 +460,7 @@ class _GrubControl:
                 GrubHelper.INITRD_OTA,
                 GrubHelper.INITRD_OTA_STANDBY,
             )
-        except ValueError as e:
+        except Exception as e:
             logger.error(
                 f"failed to get current booted kernel and initrd.image: {e!r}, "
                 "try to use active slot ota-partition files"
@@ -500,7 +505,8 @@ class _GrubControl:
 
         logger.info(f"ota-partition files for {self.active_slot} are ready")
 
-    def _get_current_booted_files(self) -> Tuple[str, str]:
+    @staticmethod
+    def _get_current_booted_files() -> Tuple[str, str]:
         """Return the name of booted kernel and initrd.
 
         Expected booted kernel and initrd are located under /boot.
@@ -571,7 +577,7 @@ class _GrubControl:
                 "refuse to do grub-update"
             )
             logger.error(msg)
-            raise ValueError(msg)
+            raise _GrubBootControllerError(msg)
 
         # step1: update grub_default file
         _in = grub_default_file.read_text()
@@ -586,7 +592,9 @@ class _GrubControl:
         ):
             active_slot_entry_idx, _ = res
         else:
-            raise ValueError("boot entry for ACTIVE slot not found, abort")
+            _err_msg = "boot entry for ACTIVE slot not found, abort"
+            logger.error(_err_msg)
+            raise _GrubBootControllerError(_err_msg)
 
         # step3: update grub_default again, setting default to <idx>
         # ensure the active slot to be the default
@@ -620,7 +628,8 @@ class _GrubControl:
                 "only current active slot's entry is populated."
             )
             if abort_on_standby_missed:
-                raise ValueError(msg)
+                logger.error(msg)
+                raise _GrubBootControllerError(msg)
 
             logger.warning(msg)
             logger.info(f"generated grub_cfg: {pformat(grub_cfg_content)}")
@@ -683,43 +692,59 @@ class _GrubControl:
             # TODO: check the standby file system status
             #       if not erase the standby slot
         except Exception as e:
-            logger.error(f"failed to prepare standby dev: {e!r}")
-            raise
+            _err_msg = f"failed to prepare standby dev: {e!r}"
+            logger.error(_err_msg)
+            raise _GrubBootControllerError(_err_msg) from e
 
     def finalize_update_switch_boot(self):
         """Finalize switch boot and use boot files from current booted slot."""
         # NOTE: since we have not yet switched boot, the active/standby relationship is
         #       reversed here corresponding to booted slot.
-        self._prepare_kernel_initrd_links(self.standby_ota_partition_folder)
-        self._ensure_ota_partition_symlinks(active_slot=self.standby_slot)
-        self._ensure_standby_slot_boot_files_symlinks(standby_slot=self.active_slot)
+        try:
+            self._prepare_kernel_initrd_links(self.standby_ota_partition_folder)
+            self._ensure_ota_partition_symlinks(active_slot=self.standby_slot)
+            self._ensure_standby_slot_boot_files_symlinks(standby_slot=self.active_slot)
 
-        self._grub_update_on_booted_slot(abort_on_standby_missed=True)
+            self._grub_update_on_booted_slot(abort_on_standby_missed=True)
 
-        # switch ota-partition symlink to current booted slot
-        self._ensure_ota_partition_symlinks(active_slot=self.active_slot)
-        self._ensure_standby_slot_boot_files_symlinks(standby_slot=self.standby_slot)
-        return True
+            # switch ota-partition symlink to current booted slot
+            self._ensure_ota_partition_symlinks(active_slot=self.active_slot)
+            self._ensure_standby_slot_boot_files_symlinks(
+                standby_slot=self.standby_slot
+            )
+            return True
+        except Exception as e:
+            _err_msg = f"grub: failed to finalize switch boot: {e!r}"
+            logger.error(_err_msg)
+            raise _GrubBootControllerError(_err_msg) from e
 
     def grub_reboot_to_standby(self):
         """Temporarily boot to standby slot after OTA applied to standby slot."""
         # ensure all required symlinks for standby slot are presented and valid
-        self._prepare_kernel_initrd_links(self.standby_ota_partition_folder)
-        self._ensure_standby_slot_boot_files_symlinks(standby_slot=self.standby_slot)
+        try:
+            self._prepare_kernel_initrd_links(self.standby_ota_partition_folder)
+            self._ensure_standby_slot_boot_files_symlinks(
+                standby_slot=self.standby_slot
+            )
 
-        # ensure all required symlinks for active slot are presented and valid
-        # NOTE: reboot after post-update is still using the current active slot's
-        #       ota-partition symlinks(not yet switch boot).
-        self._prepare_kernel_initrd_links(self.active_ota_partition_folder)
-        self._ensure_ota_partition_symlinks(active_slot=self.active_slot)
-        self._grub_update_on_booted_slot(abort_on_standby_missed=True)
+            # ensure all required symlinks for active slot are presented and valid
+            # NOTE: reboot after post-update is still using the current active slot's
+            #       ota-partition symlinks(not yet switch boot).
+            self._prepare_kernel_initrd_links(self.active_ota_partition_folder)
+            self._ensure_ota_partition_symlinks(active_slot=self.active_slot)
+            self._grub_update_on_booted_slot(abort_on_standby_missed=True)
 
-        idx, _ = GrubHelper.get_entry(
-            read_str_from_file(self.grub_file),
-            kernel_ver=GrubHelper.SUFFIX_OTA_STANDBY,
-        )
-        GrubHelper.grub_reboot(idx)
-        logger.info(f"system will reboot to {self.standby_slot=}: boot entry {idx}")
+            idx, _ = GrubHelper.get_entry(
+                read_str_from_file(self.grub_file),
+                kernel_ver=GrubHelper.SUFFIX_OTA_STANDBY,
+            )
+            GrubHelper.grub_reboot(idx)
+            logger.info(f"system will reboot to {self.standby_slot=}: boot entry {idx}")
+
+        except Exception as e:
+            _err_msg = f"grub: failed to grub_reboot to standby: {e!r}"
+            logger.error(_err_msg)
+            raise _GrubBootControllerError(_err_msg) from e
 
 
 class GrubController(BootControllerProtocol):

--- a/otaclient/app/boot_control/_grub.py
+++ b/otaclient/app/boot_control/_grub.py
@@ -39,20 +39,13 @@ from typing import ClassVar, Dict, Generator, List, Optional, Tuple
 from pathlib import Path
 from pprint import pformat
 
-from .. import log_setting
+from .. import log_setting, errors as ota_errors
 from ..common import (
     re_symlink_atomic,
     read_str_from_file,
     subprocess_call,
     subprocess_check_output,
     write_str_to_file_sync,
-)
-from ..errors import (
-    BootControlStartupFailed,
-    BootControlPostRollbackFailed,
-    BootControlPostUpdateFailed,
-    BootControlPreRollbackFailed,
-    BootControlPreUpdateFailed,
 )
 from ..proto import wrapper
 
@@ -770,7 +763,7 @@ class GrubController(BootControllerProtocol):
         except Exception as e:
             _err_msg = f"failed on start grub boot controller: {e!r}"
             logger.error(_err_msg)
-            raise BootControlStartupFailed(_err_msg, module=__name__) from e
+            raise ota_errors.BootControlStartupFailed(_err_msg, module=__name__) from e
 
     def _update_fstab(self, *, active_slot_fstab: Path, standby_slot_fstab: Path):
         """Update standby fstab based on active slot's fstab and just installed new stanby fstab.
@@ -889,7 +882,9 @@ class GrubController(BootControllerProtocol):
         except Exception as e:
             _err_msg = f"failed on pre_update: {e!r}"
             logger.error(_err_msg)
-            raise BootControlPreUpdateFailed(_err_msg, module=__name__) from e
+            raise ota_errors.BootControlPreUpdateFailed(
+                _err_msg, module=__name__
+            ) from e
 
     def post_update(self) -> Generator[None, None, None]:
         try:
@@ -918,7 +913,9 @@ class GrubController(BootControllerProtocol):
         except Exception as e:
             _err_msg = f"failed on post_update: {e!r}"
             logger.error(_err_msg)
-            raise BootControlPostUpdateFailed(_err_msg, module=__name__) from e
+            raise ota_errors.BootControlPostUpdateFailed(
+                _err_msg, module=__name__
+            ) from e
 
     def pre_rollback(self):
         try:
@@ -929,7 +926,9 @@ class GrubController(BootControllerProtocol):
         except Exception as e:
             _err_msg = f"failed on pre_rollback: {e!r}"
             logger.error(_err_msg)
-            raise BootControlPreRollbackFailed(_err_msg, module=__name__) from e
+            raise ota_errors.BootControlPreRollbackFailed(
+                _err_msg, module=__name__
+            ) from e
 
     def post_rollback(self):
         try:
@@ -940,4 +939,6 @@ class GrubController(BootControllerProtocol):
         except Exception as e:
             _err_msg = f"failed on pre_rollback: {e!r}"
             logger.error(_err_msg)
-            raise BootControlPostRollbackFailed(_err_msg, module=__name__) from e
+            raise ota_errors.BootControlPostRollbackFailed(
+                _err_msg, module=__name__
+            ) from e

--- a/otaclient/app/boot_control/_rpi_boot.py
+++ b/otaclient/app/boot_control/_rpi_boot.py
@@ -20,14 +20,7 @@ from string import Template
 from pathlib import Path
 from typing import Generator
 
-from .. import log_setting
-from ..errors import (
-    BootControlStartupFailed,
-    BootControlPostRollbackFailed,
-    BootControlPostUpdateFailed,
-    BootControlPreRollbackFailed,
-    BootControlPreUpdateFailed,
-)
+from .. import log_setting, errors as ota_errors
 from ..proto import wrapper
 from ..common import replace_atomic, subprocess_call
 
@@ -419,7 +412,7 @@ class RPIBootController(BootControllerProtocol):
         except Exception as e:
             _err_msg = f"failed to start rpi boot controller: {e!r}"
             logger.error(_err_msg)
-            raise BootControlStartupFailed(_err_msg, module=__name__) from e
+            raise ota_errors.BootControlStartupFailed(_err_msg, module=__name__) from e
 
     def _copy_kernel_for_standby_slot(self):
         """Copy the kernel and initrd_img files from current slot /boot
@@ -519,7 +512,9 @@ class RPIBootController(BootControllerProtocol):
         except Exception as e:
             _err_msg = f"failed on pre_update: {e!r}"
             logger.error(_err_msg)
-            raise BootControlPreUpdateFailed(_err_msg, module=__name__) from e
+            raise ota_errors.BootControlPreUpdateFailed(
+                _err_msg, module=__name__
+            ) from e
 
     def pre_rollback(self):
         try:
@@ -530,7 +525,9 @@ class RPIBootController(BootControllerProtocol):
         except Exception as e:
             _err_msg = f"failed on pre_rollback: {e!r}"
             logger.error(_err_msg)
-            raise BootControlPreRollbackFailed(_err_msg, module=__name__) from e
+            raise ota_errors.BootControlPreRollbackFailed(
+                _err_msg, module=__name__
+            ) from e
 
     def post_rollback(self):
         try:
@@ -541,7 +538,9 @@ class RPIBootController(BootControllerProtocol):
         except Exception as e:
             _err_msg = f"failed on post_rollback: {e!r}"
             logger.error(_err_msg)
-            raise BootControlPostRollbackFailed(_err_msg, module=__name__) from e
+            raise ota_errors.BootControlPostRollbackFailed(
+                _err_msg, module=__name__
+            ) from e
 
     def post_update(self) -> Generator[None, None, None]:
         try:
@@ -556,7 +555,9 @@ class RPIBootController(BootControllerProtocol):
         except Exception as e:
             _err_msg = f"failed on post_update: {e!r}"
             logger.error(_err_msg)
-            raise BootControlPostUpdateFailed(_err_msg, module=__name__) from e
+            raise ota_errors.BootControlPostUpdateFailed(
+                _err_msg, module=__name__
+            ) from e
 
     def on_operation_failure(self):
         """Failure registering and cleanup at failure."""

--- a/otaclient/app/boot_control/_rpi_boot.py
+++ b/otaclient/app/boot_control/_rpi_boot.py
@@ -243,7 +243,9 @@ class _RPIBootControl:
                 os.replace(_initrd_img, self.initrd_img_active_slot)
             os.sync()
         except Exception as e:
-            _err_msg = f"apply new kernel,initrd.img for {self.active_slot} failed"
+            _err_msg = (
+                f"apply new kernel,initrd.img for {self.active_slot} failed: {e!r}"
+            )
             logger.error(_err_msg)
             raise _RPIBootControllerError(_err_msg)
 

--- a/otaclient/app/configs.py
+++ b/otaclient/app/configs.py
@@ -184,6 +184,8 @@ class BaseConfig(_InternalSettings):
     # default version string to be reported in status API response
     DEFAULT_VERSION_STR = ""
 
+    DEBUG_MODE = False
+
 
 # init cfgs
 server_cfg = OtaClientServerConfig()

--- a/otaclient/app/errors.py
+++ b/otaclient/app/errors.py
@@ -82,7 +82,7 @@ class OTAError(Exception):
     def failure_errcode_str(self) -> str:
         return f"{self.ERROR_PREFIX}{self.failure_errcode.to_errcode_str()}"
 
-    def get_failure_traceback(self, *, splitter="") -> str:
+    def get_failure_traceback(self, *, splitter="\n") -> str:
         return splitter.join(
             traceback.format_exception(type(self), self, self.__traceback__)
         )
@@ -91,16 +91,19 @@ class OTAError(Exception):
         """Return failure_reason str."""
         return f"{self.failure_errcode_str}: {self.failure_description}"
 
-    def get_error_report(self, title: str) -> str:
-        _traceback = self.get_failure_traceback(splitter="\n")
+    def get_error_report(self, title: str = "") -> str:
+        """The detailed failure report for debug use."""
         return (
             f"\n{title}\n"
             "\n------ failure_reason ------\n"
             f"{self.get_failure_reason()}"
             "\n------ end of failure_reason ------\n"
-            "\n------ failure traceback ------\n"
-            f"failure_traceback: {_traceback}"
-            "\n------ end of failure traceback ------\n"
+            "\n------ exception informaton ------\n"
+            f"{self!r}"
+            "\n------ end of exception informaton ------\n"
+            "\n------ exception traceback ------\n"
+            f"{self.get_failure_traceback()}"
+            "\n------ end of exception traceback ------\n"
         )
 
 

--- a/otaclient/app/errors.py
+++ b/otaclient/app/errors.py
@@ -111,9 +111,7 @@ class OTAError(Exception):
 # ------ Network related error ------
 #
 
-_NETWORK_ERR_DEFAULT_DESC = (
-    "network connection unstable, please check the connection and try again"
-)
+_NETWORK_ERR_DEFAULT_DESC = "network unstable, please check the network connection"
 
 
 class NetworkError(OTAError):
@@ -162,7 +160,7 @@ class InvalidStatusForOTARollback(OTAErrorRecoverable):
 #
 
 _UNRECOVERABLE_DEFAULT_DESC = (
-    "unrecoverable OTA error detected, please contact technical support"
+    "unrecoverable OTA error, please contact technical support"
 )
 
 
@@ -174,50 +172,58 @@ class OTAErrorUnRecoverable(OTAError):
 
 class BootControlPlatformUnsupported(OTAErrorUnRecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_BOOTCONTROL_PLATFORM_UNSUPPORTED
-    failure_description: str = f"{_UNRECOVERABLE_DEFAULT_DESC}: current ECU platform is not supported by the boot controller module"
+    failure_description: str = (
+        f"{_UNRECOVERABLE_DEFAULT_DESC}: bootloader for this ECU is not supported"
+    )
 
 
 class BootControlStartupFailed(OTAErrorUnRecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_BOOTCONTROL_STARTUP_ERR
-    failure_description: str = f"{_UNRECOVERABLE_DEFAULT_DESC}: failed to start boot controller module for this device"
+    failure_description: str = (
+        f"{_UNRECOVERABLE_DEFAULT_DESC}: boot controller startup failed"
+    )
 
 
 class BootControlPreUpdateFailed(OTAErrorUnRecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_BOOTCONTROL_PREUPDATE_FAILED
     failure_description: str = (
-        f"{_UNRECOVERABLE_DEFAULT_DESC}: boot control pre_update process failed"
+        f"{_UNRECOVERABLE_DEFAULT_DESC}: boot_control pre_update process failed"
     )
 
 
 class BootControlPostUpdateFailed(OTAErrorUnRecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_BOOTCONTROL_POSTUPDATE_FAILED
     failure_description: str = (
-        f"{_UNRECOVERABLE_DEFAULT_DESC}: boot control post_update process failed"
+        f"{_UNRECOVERABLE_DEFAULT_DESC}: boot_control post_update process failed"
     )
 
 
 class BootControlPreRollbackFailed(OTAErrorUnRecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_BOOTCONTROL_PREROLLBACK_FAILED
     failure_description: str = (
-        f"{_UNRECOVERABLE_DEFAULT_DESC}: pre_rollback process failed"
+        f"{_UNRECOVERABLE_DEFAULT_DESC}: boot_control pre_rollback process failed"
     )
 
 
 class BootControlPostRollbackFailed(OTAErrorUnRecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_BOOTCONTROL_POSTROLLBACK_FAILED
     failure_description: str = (
-        f"{_UNRECOVERABLE_DEFAULT_DESC}: post_rollback process failed"
+        f"{_UNRECOVERABLE_DEFAULT_DESC}: boot_control post_rollback process failed"
     )
 
 
 class StandbySlotInsufficientSpace(OTAErrorUnRecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_STANDBY_SLOT_INSUFFICIENT_SPACE
-    failure_description: str = f"{_UNRECOVERABLE_DEFAULT_DESC}: standby slot has insufficient space to apply update"
+    failure_description: str = (
+        f"{_UNRECOVERABLE_DEFAULT_DESC}: insufficient space at standby slot"
+    )
 
 
 class InvalidUpdateRequest(OTAErrorUnRecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_INVALID_OTAUPDATE_REQUEST
-    failure_description: str = f"{_UNRECOVERABLE_DEFAULT_DESC}: incoming OTA update request's content is invalid"
+    failure_description: str = (
+        f"{_UNRECOVERABLE_DEFAULT_DESC}: incoming OTA update request is invalid"
+    )
 
 
 class MetadataJWTInvalid(OTAErrorUnRecoverable):

--- a/otaclient/app/errors.py
+++ b/otaclient/app/errors.py
@@ -165,96 +165,96 @@ _UNRECOVERABLE_DEFAULT_DESC = (
 )
 
 
-class OTAErrorUnRecoverable(OTAError):
+class OTAErrorUnrecoverable(OTAError):
     failure_type: wrapper.FailureType = wrapper.FailureType.RECOVERABLE
     failure_errcode: OTAErrorCode = OTAErrorCode.E_OTA_ERR_UNRECOVERABLE
     failure_description: str = _UNRECOVERABLE_DEFAULT_DESC
 
 
-class BootControlPlatformUnsupported(OTAErrorUnRecoverable):
+class BootControlPlatformUnsupported(OTAErrorUnrecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_BOOTCONTROL_PLATFORM_UNSUPPORTED
     failure_description: str = (
         f"{_UNRECOVERABLE_DEFAULT_DESC}: bootloader for this ECU is not supported"
     )
 
 
-class BootControlStartupFailed(OTAErrorUnRecoverable):
+class BootControlStartupFailed(OTAErrorUnrecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_BOOTCONTROL_STARTUP_ERR
     failure_description: str = (
         f"{_UNRECOVERABLE_DEFAULT_DESC}: boot controller startup failed"
     )
 
 
-class BootControlPreUpdateFailed(OTAErrorUnRecoverable):
+class BootControlPreUpdateFailed(OTAErrorUnrecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_BOOTCONTROL_PREUPDATE_FAILED
     failure_description: str = (
         f"{_UNRECOVERABLE_DEFAULT_DESC}: boot_control pre_update process failed"
     )
 
 
-class BootControlPostUpdateFailed(OTAErrorUnRecoverable):
+class BootControlPostUpdateFailed(OTAErrorUnrecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_BOOTCONTROL_POSTUPDATE_FAILED
     failure_description: str = (
         f"{_UNRECOVERABLE_DEFAULT_DESC}: boot_control post_update process failed"
     )
 
 
-class BootControlPreRollbackFailed(OTAErrorUnRecoverable):
+class BootControlPreRollbackFailed(OTAErrorUnrecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_BOOTCONTROL_PREROLLBACK_FAILED
     failure_description: str = (
         f"{_UNRECOVERABLE_DEFAULT_DESC}: boot_control pre_rollback process failed"
     )
 
 
-class BootControlPostRollbackFailed(OTAErrorUnRecoverable):
+class BootControlPostRollbackFailed(OTAErrorUnrecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_BOOTCONTROL_POSTROLLBACK_FAILED
     failure_description: str = (
         f"{_UNRECOVERABLE_DEFAULT_DESC}: boot_control post_rollback process failed"
     )
 
 
-class StandbySlotInsufficientSpace(OTAErrorUnRecoverable):
+class StandbySlotInsufficientSpace(OTAErrorUnrecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_STANDBY_SLOT_INSUFFICIENT_SPACE
     failure_description: str = (
         f"{_UNRECOVERABLE_DEFAULT_DESC}: insufficient space at standby slot"
     )
 
 
-class InvalidUpdateRequest(OTAErrorUnRecoverable):
+class InvalidUpdateRequest(OTAErrorUnrecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_INVALID_OTAUPDATE_REQUEST
     failure_description: str = (
         f"{_UNRECOVERABLE_DEFAULT_DESC}: incoming OTA update request is invalid"
     )
 
 
-class MetadataJWTInvalid(OTAErrorUnRecoverable):
+class MetadataJWTInvalid(OTAErrorUnrecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_METADATAJWT_INVALID
     failure_description: str = f"{_UNRECOVERABLE_DEFAULT_DESC}: verfication for metadata.jwt is OK but metadata.jwt's content is invalid"
 
 
-class MetadataJWTVerficationFailed(OTAErrorUnRecoverable):
+class MetadataJWTVerficationFailed(OTAErrorUnrecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_METADATAJWT_CERT_VERIFICATION_FAILED
     failure_description: str = f"{_UNRECOVERABLE_DEFAULT_DESC}: certificate verification failed for OTA metadata.jwt"
 
 
-class OTAProxyFailedToStart(OTAErrorUnRecoverable):
+class OTAProxyFailedToStart(OTAErrorUnrecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_OTAPROXY_FAILED_TO_START
     failure_description: str = f"{_UNRECOVERABLE_DEFAULT_DESC}: otaproxy is required for multiple ECU update but otaproxy failed to start"
 
 
-class UpdateDeltaGenerationFailed(OTAErrorUnRecoverable):
+class UpdateDeltaGenerationFailed(OTAErrorUnrecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_UPDATEDELTA_GENERATION_FAILED
     failure_description: str = f"{_UNRECOVERABLE_DEFAULT_DESC}: failed to calculate and/or prepare update delta"
 
 
-class ApplyOTAUpdateFailed(OTAErrorUnRecoverable):
+class ApplyOTAUpdateFailed(OTAErrorUnrecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_APPLY_OTAUPDATE_FAILED
     failure_description: str = (
         f"{_UNRECOVERABLE_DEFAULT_DESC}: failed to apply OTA update to standby slot"
     )
 
 
-class OTAClientStartupFailed(OTAErrorUnRecoverable):
+class OTAClientStartupFailed(OTAErrorUnrecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_OTACLIENT_STARTUP_FAILED
     failure_description: str = (
         f"{_UNRECOVERABLE_DEFAULT_DESC}: failed to start otaclient instance"

--- a/otaclient/app/errors.py
+++ b/otaclient/app/errors.py
@@ -101,6 +101,18 @@ class OTAError(Exception):
             f"\n{_failure_info}"
         )
 
+    def get_error_report(self, title: str) -> str:
+        _traceback = self.get_failure_traceback(splitter="\n")
+        return (
+            f"\n{title}\n"
+            "\n------ failure_reason ------\n"
+            f"{self.get_failure_reason()}"
+            "\n------ end of failure_reason ------\n"
+            "\n------ failure traceback ------\n"
+            f"failure_traceback: {_traceback}"
+            "\n------ end of failure traceback ------\n"
+        )
+
 
 #
 # ------ Network related error ------

--- a/otaclient/app/errors.py
+++ b/otaclient/app/errors.py
@@ -87,19 +87,9 @@ class OTAError(Exception):
             traceback.format_exception(type(self), self, self.__traceback__)
         )
 
-    def get_failure_reason(self, *, append_traceback=False) -> str:
+    def get_failure_reason(self) -> str:
         """Return failure_reason str."""
-        _failure_info = {
-            "module": self.module,
-            "exec_args": self.args,
-        }
-        if append_traceback:
-            _failure_info["failure_traceback"] = self.get_failure_traceback()
-
-        return (
-            f"{self.failure_errcode_str}: {self.failure_description}"
-            f"\n{_failure_info}"
-        )
+        return f"{self.failure_errcode_str}: {self.failure_description}"
 
     def get_error_report(self, title: str) -> str:
         _traceback = self.get_failure_traceback(splitter="\n")

--- a/otaclient/app/errors.py
+++ b/otaclient/app/errors.py
@@ -95,6 +95,7 @@ class OTAError(Exception):
         """The detailed failure report for debug use."""
         return (
             f"\n{title}\n"
+            f"@module: {self.module}"
             "\n------ failure_reason ------\n"
             f"{self.get_failure_reason()}"
             "\n------ end of failure_reason ------\n"

--- a/otaclient/app/errors.py
+++ b/otaclient/app/errors.py
@@ -55,6 +55,7 @@ class OTAErrorCode(int, Enum):
     E_OTAPROXY_FAILED_TO_START = 311
     E_UPDATEDELTA_GENERATION_FAILED = 312
     E_APPLY_OTAUPDATE_FAILED = 313
+    E_OTACLIENT_STARTUP_FAILED = 314
 
     def to_errcode_str(self) -> str:
         return f"{self.value:0>3}"
@@ -86,7 +87,7 @@ class OTAError(Exception):
             traceback.format_exception(type(self), self, self.__traceback__)
         )
 
-    def failure_reason(self, *, append_traceback=False) -> str:
+    def get_failure_reason(self, *, append_traceback=False) -> str:
         """Return failure_reason str."""
         _failure_info = {
             "module": self.module,
@@ -238,4 +239,11 @@ class ApplyOTAUpdateFailed(OTAErrorUnRecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_APPLY_OTAUPDATE_FAILED
     failure_description: str = (
         f"{_UNRECOVERABLE_DEFAULT_DESC}: failed to apply OTA update to standby slot"
+    )
+
+
+class OTAClientStartupFailed(OTAErrorUnRecoverable):
+    failure_errcode: OTAErrorCode = OTAErrorCode.E_OTACLIENT_STARTUP_FAILED
+    failure_description: str = (
+        f"{_UNRECOVERABLE_DEFAULT_DESC}: failed to start otaclient instance"
     )

--- a/otaclient/app/ota_client.py
+++ b/otaclient/app/ota_client.py
@@ -532,7 +532,9 @@ class OTAClient(OTAClientProtocol):
             self.last_failure_type = exc.failure_type
             self.last_failure_reason = exc.get_failure_reason()
             self.last_failure_traceback = exc.get_failure_traceback()
-            logger.error(f"{ota_status.name}, traceback: {self.last_failure_traceback}")
+            logger.error(
+                exc.get_error_report(f"OTA failed with {ota_status.name}: {exc!r}")
+            )
         finally:
             exc = None  # type: ignore , prevent ref cycle
 

--- a/otaclient/app/ota_client.py
+++ b/otaclient/app/ota_client.py
@@ -603,6 +603,7 @@ class OTAServicer:
     ) -> None:
         self.ecu_id = ecu_info.ecu_id
         self.otaclient_version = otaclient_version
+        self.local_used_proxy_url = proxy
 
         # default boot startup failure if boot_controller/otaclient_core crashed without
         # raising specific error
@@ -661,6 +662,10 @@ class OTAServicer:
                 failure_traceback=e.get_failure_traceback(),
             )
             return
+
+    @property
+    def is_busy(self) -> bool:
+        return self._update_rollback_lock.locked()
 
     async def dispatch_update(
         self, request: wrapper.UpdateRequestEcu

--- a/otaclient/app/ota_client.py
+++ b/otaclient/app/ota_client.py
@@ -604,6 +604,7 @@ class OTAServicer:
         self.ecu_id = ecu_info.ecu_id
         self.otaclient_version = otaclient_version
         self.local_used_proxy_url = proxy
+        self.last_operation: Optional[wrapper.StatusOta] = None
 
         # default boot startup failure if boot_controller/otaclient_core crashed without
         # raising specific error
@@ -618,7 +619,6 @@ class OTAServicer:
         self._run_in_executor = partial(
             asyncio.get_running_loop().run_in_executor, executor
         )
-        self._last_operation: Optional[wrapper.StatusOta] = None
 
         #
         # ------ compose otaclient ------

--- a/otaclient/app/ota_client.py
+++ b/otaclient/app/ota_client.py
@@ -363,7 +363,7 @@ class _OTAUpdater:
         except downloader.DestinationNotAvailableError as e:
             _err_msg = f"downloader: failed to save ota metafiles: {e!r}"
             logger.error(_err_msg)
-            raise ota_errors.OTAErrorUnRecoverable(_err_msg, module=__name__) from e
+            raise ota_errors.OTAErrorUnrecoverable(_err_msg, module=__name__) from e
         except ota_metadata.MetadataJWTVerificationFailed as e:
             _err_msg = f"failed to verify metadata.jwt: {e!r}"
             logger.error(_err_msg)

--- a/otaclient/app/ota_client.py
+++ b/otaclient/app/ota_client.py
@@ -520,7 +520,7 @@ class OTAClient(OTAClientProtocol):
             self.last_failure_type = exc.failure_type
             self.last_failure_reason = exc.get_failure_reason()
             self.last_failure_traceback = exc.get_failure_traceback()
-            logger.error(f"on {ota_status=}: {self.last_failure_traceback=}")
+            logger.error(f"{ota_status.name}, traceback: {self.last_failure_traceback}")
         finally:
             exc = None  # type: ignore , prevent ref cycle
 
@@ -633,13 +633,16 @@ class OTAServicer:
         try:
             _bootctrl_inst = _bootctrl_cls()
         except ota_errors.OTAError as e:
+            logger.error(
+                e.get_error_report(title=f"boot controller startup failed: {e!r}")
+            )
             self._otaclient_startup_failed_status = wrapper.StatusResponseEcuV2(
                 ecu_id=ecu_info.ecu_id,
                 otaclient_version=otaclient_version,
                 ota_status=wrapper.StatusOta.FAILURE,
                 failure_type=wrapper.FailureType.UNRECOVERABLE,
                 failure_reason=e.get_failure_reason(),
-                failure_traceback=e.get_failure_traceback(),
+                failure_traceback=e.get_failure_traceback(splitter="\n"),
             )
             return
 
@@ -653,13 +656,16 @@ class OTAServicer:
                 proxy=proxy,
             )
         except ota_errors.OTAError as e:
+            logger.error(
+                e.get_error_report(title=f"otaclient core startup failed: {e!r}")
+            )
             self._otaclient_startup_failed_status = wrapper.StatusResponseEcuV2(
                 ecu_id=ecu_info.ecu_id,
                 otaclient_version=otaclient_version,
                 ota_status=wrapper.StatusOta.FAILURE,
                 failure_type=wrapper.FailureType.UNRECOVERABLE,
                 failure_reason=e.get_failure_reason(),
-                failure_traceback=e.get_failure_traceback(),
+                failure_traceback=e.get_failure_traceback(splitter="\n"),
             )
             return
 


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. 

For better understanding, adding reason/motivation of this PR are also recommended.
-->

> [!NOTE]
> This PR is based on previous PR #258.

### Error handling refinements

This PR introduces refinements to otaclient's error handling, including:
1. error report now covers boot controller startup failure, boot controller startup failed will not crash the otaclient anymore, and error information is available via status API,
2. simplify and flatten the error handling structure, regulate the error handling policy regarding each otaclient components,
3. refine and redefine the OTA errors definition, refine error description,
4. refine the logging when OTA error occurs.

### otaclient startup procedure refinements

otaclient core(`otaclient.OTAClient`) and boot controller are launched separately, exceptions during these two components startup is handled and captured, so that the whole otaclient startup procedure can finish and grpc server can be launched.
The error information during startup is recorded and available via status API.

### DEBUG_MODE and `failure_traceback` in status API response

Also, previously `failure_traceback` is always included into the status API response, considering the traffic caused by unpredictable amount of bytes from `failure_traceback` field, this PR introduces a new config option `DEBUG_MODE`(default is False), and `failure_traceback` is only included when `DEBUG_MODE` is on. 

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file(s) that covers the change(s) is implemented.
- [x] local test is passed. 
- [x] VM test is passed. 

## Changes

<!-- A list of code change(s) that introduced by this PR. -->

### OTA errors handling structure change

Check [documentation](https://tier4.atlassian.net/l/cp/bXyzLG0i) for OTA errors handling design for more details.

### OTA errors definition change and descriptions update

Most of the errors are changed to `unrecoverable OTA error` now, only `E_NETWORK, E_OTAMETA_DOWNLOAD_FAILED` and `E_OTA_BUSY, E_INVALID_STATUS_FOR_OTAROLLBACK` are still recoverable errors.

Error descriptions are simpler and include necessary basic information for better understanding what is going on.

### otaclient startup workflow change

Previously, otaclient core `OTAClient` launches boot controller when it is launching, but not handling the error raised by boot controller.

With this PR,  a new `otaclient.OTAServicer` is introduced as "otaclient composer". It is in charge of launch boot controller and otaclient core(`otaclient.OTAClient`) separately, and then compose then together as a fully functional otaclient instance.

Exceptions during launching otaclient core and boot controller are captured and handled, and error information is available via status API.


## Behavior changes

Does this PR introduce behavior change(s)?

- [x] Yes, internal behaivor (will not impact user experience).
- [x] Yes, external behaivor (will impact user experience).

### Previous behavior

<!-- Behaivor before the PR is introduced -->

1. otaclient will crash if boot controller startup failed, grpc server and otaclient core will not start,
2. `failure_traceback` is always included into status API response.

### Behavior with this PR

<!-- Behavior after the PR is introduced -->

1. otaclient will not crash on boot controller startup failed, otaclient grpc server will still launch and error information can be queried from status API,
2. `failure_traceback` is included into the status API response only when DEBUG_MODE is on.

## Breaking change

Does this PR introduce breaking change?
- [X] No.

## Related links & tickets

<!-- List of tickets or links related to this PR -->

[RT4-7473](https://tier4.atlassian.net/browse/RT4-7473)

[RT4-7473]: https://tier4.atlassian.net/browse/RT4-7473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ