### PR TITLE
[Chore] action: use coverage.py directly in test CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: test CI
 on: [pull_request]
 
 jobs:
+
   pytest_with_coverage:
     runs-on: ubuntu-20.04
     timeout-minutes: 20
@@ -13,13 +14,19 @@ jobs:
         run: |
           docker-compose -f docker/docker-compose_tests.yml build
       - name: Execute pytest with coverage trace under ota-test_base container
+        # NOTE: test_result folder holds the coverage.xml, check docker-compose_tests.yml for
+        #       coverage execution command line and volumes configurations.
         run: |
           set -o pipefail
-          docker-compose -f docker/docker-compose_tests.yml up --no-log-prefix --abort-on-container-exit | tee pytest-coverage.txt
+          mkdir test_result
+          docker-compose -f docker/docker-compose_tests.yml up --no-log-prefix --abort-on-container-exit
       # export the coverage report to the comment!
       - name: Add coverage report to PR comment
         continue-on-error: true
-        uses: MishaKav/pytest-coverage-comment@v1.1.40
+        uses: MishaKav/pytest-coverage-comment@v1.1.49
+        with:
+          - pytest-xml-coverage-path: ./test_result/coverage.xml
+
   python_lint_check:
     runs-on: ubuntu-20.04
     timeout-minutes: 3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,8 @@ jobs:
         continue-on-error: true
         uses: MishaKav/pytest-coverage-comment@v1.1.49
         with:
-          pytest-xml-coverage-path: ./test_result/coverage.xml
+          pytest-xml-coverage-path: test_result/coverage.xml
+          junitxml-path: test_result/pytest.xml
 
   python_lint_check:
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         continue-on-error: true
         uses: MishaKav/pytest-coverage-comment@v1.1.49
         with:
-          - pytest-xml-coverage-path: ./test_result/coverage.xml
+          pytest-xml-coverage-path: ./test_result/coverage.xml
 
   python_lint_check:
     runs-on: ubuntu-20.04

--- a/docker/docker-compose_tests.yml
+++ b/docker/docker-compose_tests.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: ./docker/test_base/Dockerfile
     image: ota-test_base
     network_mode: bridge
-    command: "bash -c 'coverage run -m pytest tests/test_boot_control && coverage xml -o test_result/coverage.xml'"
+    command: "bash -c 'coverage run -m pytest && coverage xml -o test_result/coverage.xml'"
     container_name: ota-test
     volumes:
       - ../pyproject.toml:/ota-client/pyproject.toml:ro

--- a/docker/docker-compose_tests.yml
+++ b/docker/docker-compose_tests.yml
@@ -6,10 +6,11 @@ services:
       dockerfile: ./docker/test_base/Dockerfile
     image: ota-test_base
     network_mode: bridge
-    command: "python3 -m pytest"
+    command: "bash -c 'coverage run -m pytest tests/test_boot_control && coverage xml -o test_result/coverage.xml'"
     container_name: ota-test
     volumes:
       - ../pyproject.toml:/ota-client/pyproject.toml:ro
       - ../.flake8:/ota-client/.flake8:ro
       - ../otaclient:/ota-client/otaclient:ro
       - ../tests:/ota-client/tests:ro
+      - ../test_result:/ota-client/test_result:rw

--- a/docker/docker-compose_tests.yml
+++ b/docker/docker-compose_tests.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: ./docker/test_base/Dockerfile
     image: ota-test_base
     network_mode: bridge
-    command: "bash -c 'coverage run -m pytest && coverage xml -o test_result/coverage.xml'"
+    command: "bash -c 'coverage run -m pytest --junit-xml=test_result/pytest.xml && coverage xml -o test_result/coverage.xml'"
     container_name: ota-test
     volumes:
       - ../pyproject.toml:/ota-client/pyproject.toml:ro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,20 @@ extend-exclude = '''(
 
 [tool.coverage.run]
 branch = false
+omit = ["**/*_pb2.py*","**/*_pb2_grpc.py*"]
+source = ["otaclient.app", "otaclient.ota_proxy"]
 
 [tool.coverage.report]
-omit = ["**/*_pb2.py*","**/*_pb2_grpc.py*"]
+exclude_also = [
+    "def __repr__",
+    "if cfg.DEBUG_MODE",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "class .*\\bProtocol\\):",
+    "@(abc\\.)?abstractmethod",
+    ]
 show_missing = true
+skip_empty = true
 
 [tool.pyright]
 exclude = ["**/__pycache__"]
@@ -52,7 +62,6 @@ ignore = ["**/*_pb2.py*","**/*_pb2_grpc.py*"]
 pythonVersion = "3.8"
 
 [tool.pytest.ini_options]
-addopts = "--cov=otaclient.app --cov=otaclient.ota_proxy"
 asyncio_mode = "auto"
 log_auto_indent = true
 log_format = "%(asctime)s %(levelname)s %(filename)s %(funcName)s,%(lineno)d %(message)s"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ exclude_also = [
     "@(abc\\.)?abstractmethod",
     ]
 show_missing = true
+skip_covered = true
 skip_empty = true
 
 [tool.pyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ exclude_also = [
     "class .*\\bProtocol\\):",
     "@(abc\\.)?abstractmethod",
     ]
-show_missing = true
 skip_covered = true
 skip_empty = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ exclude_also = [
     "class .*\\bProtocol\\):",
     "@(abc\\.)?abstractmethod",
     ]
+show_missing = true
 skip_covered = true
 skip_empty = true
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 pytest==7.1.2
 pytest-asyncio==0.21.0
 pytest-mock==3.8.2
-pytest-cov==3.0.0
+coverage==7.2.5
 black==22.3.0
 flake8==4.0.1
 requests-mock==1.10.0


### PR DESCRIPTION
## Description

> [!Important]
> This PR is required by #264 , as more fine grained control over how coverage.py is executed is needed.

This PR introduces changes to run test with coverage by directly using `coverage run -m pytest`  instead of using pytest with pytest-cov plugin. 
Also, this PR bumps action `MishaKav/pytest-coverage-comment` to 1.1.49, and exposes test result with junitxml.

Check the test coverage result comment in this PR for more details.

## Motivation

Actually `pytest-cov` is a wrapper plugin that calls `coverage.py` underhook. According to `coverage` [documentation](https://coverage.readthedocs.io/en/latest/):

> Many people choose to use the [pytest-cov](https://pytest-cov.readthedocs.io/) plugin, but for most purposes, it is unnecessary.

Actually we don't need to use `pytest-cov` plugin for our purpose. In contrast, with wrapper `pytest-cov` plugin, we are not able to configure `coverage`'s execution directly. To control `coverage.py`'s execution directly, we should avoid using any wrapper.

Finally, `pytest-cov` plugin is not in active maintain now, while `coverage.py` itself is still actively maintained, we should refer to the upstream instead using a wrapper.