### PR TITLE
[Deps] requirements.txt: bump cryptography to 41.0.7

### DIFF
--- a/otaclient/requirements.txt
+++ b/otaclient/requirements.txt
@@ -1,5 +1,5 @@
-pyOpenSSL==23.0.0
-cryptography>=39.0.1, <40.0.0
+pyOpenSSL==23.3.0
+cryptography==41.0.7
 grpcio==1.53.1
 protobuf==4.21.12
 PyYAML>=3.12


### PR DESCRIPTION
## Description

`cryptography` below `41.0.6` has a vulnerability, check [cryptography vulnerable to NULL-dereference when loading PKCS7 certificates #19](https://github.com/tier4/ota-client/security/dependabot/19) for more details.

UPDATED(20231213): the vulnerability severity is lower down to 5.0(moderate).

## Changes

1. bump `cryptography` to `41.0.7`.
2. bump `pyopenssl` to `23.3.0`.