### PR TITLE
fix: image path

### DIFF
--- a/tools/images_packer/build-cache.sh
+++ b/tools/images_packer/build-cache.sh
@@ -23,7 +23,7 @@ if [ $# -ne 2 ]; then
   exit 1
 fi
 
-IMAGE=$1
+IMAGE=$(realpath $1)
 DEVICE=$2
 
 UUID=$(lsblk ${DEVICE} -n -o UUID || true)


### PR DESCRIPTION
## Description

This PR fixes build-external bash script to handle arbitrary directory.

## Check list

- [ ] test file that covers the bug case(s) is implemented.
- [x] local test is passed. 

## Bug fix

### Current behavior

Current implementation can't handle arbitrary rootfs image directory.

### Behaivor after fix

This PR fixes this issue.

## Related links & ticket

<!-- List of tickets or links related to this PR -->