### PR TITLE
fix: persists file handling should be at PROCESS_POSTUPDATE phase

### DIFF
--- a/tests/test_create_standby.py
+++ b/tests/test_create_standby.py
@@ -87,11 +87,6 @@ class Test_OTAupdate_with_create_standby_RebuildMode:
         from otaclient.app.ota_client import _OTAUpdater, OTAClientControlFlags
         from otaclient.app.create_standby.rebuild_mode import RebuildMode
 
-        # TODO: not test process_persistent currently,
-        #       as we currently directly compare the standby slot
-        #       with the OTA image.
-        RebuildMode._process_persistents = mocker.MagicMock()
-
         # ------ execution ------ #
         otaclient_control_flags = typing.cast(
             OTAClientControlFlags, mocker.MagicMock(spec=OTAClientControlFlags)

--- a/tests/test_create_standby.py
+++ b/tests/test_create_standby.py
@@ -97,6 +97,7 @@ class Test_OTAupdate_with_create_standby_RebuildMode:
             proxy=None,
             control_flags=otaclient_control_flags,
         )
+        _updater._process_persistents = persist_handler = mocker.MagicMock()
         # NOTE: mock the shutdown method as we need to assert before the
         #       updater is closed.
         _updater_shutdown = _updater.shutdown
@@ -110,6 +111,7 @@ class Test_OTAupdate_with_create_standby_RebuildMode:
         time.sleep(2)  # wait for downloader to record stats
 
         # ------ assertions ------ #
+        persist_handler.assert_called_once()
         # --- assert update finished
         _updater.shutdown.assert_called_once()
         otaclient_control_flags.wait_can_reboot_flag.assert_called_once()

--- a/tests/test_ota_client.py
+++ b/tests/test_ota_client.py
@@ -122,13 +122,13 @@ class Test_OTAUpdater:
 
     @pytest.fixture(autouse=True)
     def mock_setup(self, mocker: pytest_mock.MockerFixture, _delta_generate):
-        from otaclient.app.proxy_info import ProxyInfo
         from otaclient.app.configs import BaseConfig
 
         # ------ mock boot_controller ------ #
         self._boot_control = typing.cast(
             BootControllerProtocol, mocker.MagicMock(spec=BootControllerProtocol)
         )
+
         # ------ mock create_standby ------ #
         self._create_standby = typing.cast(
             StandbySlotCreatorProtocol,
@@ -168,6 +168,7 @@ class Test_OTAUpdater:
             proxy=None,
             control_flags=otaclient_control_flags,
         )
+        _updater._process_persistents = process_persists_handler = mocker.MagicMock()
 
         _updater.execute(
             version=cfg.UPDATE_VERSION,
@@ -190,6 +191,7 @@ class Test_OTAUpdater:
         # assert create standby module is used
         self._create_standby.calculate_and_prepare_delta.assert_called_once()
         self._create_standby.create_standby_slot.assert_called_once()
+        process_persists_handler.assert_called_once()
 
 
 class Test_OTAClient:


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->

By design the persist file handling stage should be in PROCESS_POSTUPDATE phase. 

However due to when migrating from old implementation, persist file handling is still implemented as part of create_standby mechanism. In newer otaclient, the create_standby stage is counted as APPLY_UPDATE phase, resulting in mismatch with design and implementation.

In real world condition, this mismatch might cause the following behavior in APPLY_UPDATE phase:
1. all files are processed, but no progress is made and phase is still stuck at APPLY_UPDATE phase,
2. if persist file handling also copying the swapfile(this is improper, it will be handled in another PR), APPLY_UPDATE will be stuck with even longer time.

This PR fixes the issue by move persist file handling out of create_standby package, and implements it in PROCESS_POSTUPDATE phase.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [ ] local test is passed. 
- [ ] vm test is passed.

## Bug fix

### Behaivor after fix

1. now APPLY_UPDATE phase should be finished immediately after all files for new slot are created and processed,
2. persist file handling now is included in PROCESS_POSTUPDATE phase.

## Related links & ticket

<!-- List of tickets or links related to this PR -->

[RT4-8805](https://tier4.atlassian.net/browse/RT4-8805)

[RT4-8805]: https://tier4.atlassian.net/browse/RT4-8805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ