### PR TITLE
fix: properly handling swapfile during persist file handling

### DIFF
--- a/otaclient/_utils/__init__.py
+++ b/otaclient/_utils/__init__.py
@@ -52,8 +52,8 @@ def copy_callable_typehint_to_method(_source: Callable[P, Any]):
 _MultiUnits = Literal["GiB", "MiB", "KiB", "Bytes", "KB", "MB", "GB"]
 # fmt: off
 _multiplier: dict[_MultiUnits, int] = {
-    "GiB": (1024 ** 3), "MiB": (1024 ** 2), "KiB": (1024 ** 1),
-    "GB": (1000 **3), "MB": (1000 ** 2), "KB": (1000 ** 1),
+    "GiB": 1024 ** 3, "MiB": 1024 ** 2, "KiB": 1024 ** 1,
+    "GB": 1000 ** 3, "MB": 1000 ** 2, "KB": 1000 ** 1,
     "Bytes": 1,
 }
 # fmt: on

--- a/otaclient/_utils/__init__.py
+++ b/otaclient/_utils/__init__.py
@@ -11,8 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Callable, TypeVar
-from typing_extensions import ParamSpec, Concatenate
+
+
+from __future__ import annotations
+from math import ceil
+from pathlib import Path
+from typing import Any, Callable, Optional, TypeVar
+from typing_extensions import Literal, ParamSpec, Concatenate
 
 P = ParamSpec("P")
 
@@ -42,3 +47,22 @@ def copy_callable_typehint_to_method(_source: Callable[P, Any]):
         return target  # type: ignore
 
     return _decorator
+
+
+_MultiUnits = Literal["GiB", "MiB", "KiB", "Bytes", "KB", "MB", "GB"]
+# fmt: off
+_multiplier: dict[_MultiUnits, int] = {
+    "GiB": (1024 ** 3), "MiB": (1024 ** 2), "KiB": (1024 ** 1),
+    "GB": (1000 **3), "MB": (1000 ** 2), "KB": (1000 ** 1),
+    "Bytes": 1,
+}
+# fmt: on
+
+
+def get_file_size(
+    swapfile_fpath: str | Path, units: _MultiUnits = "Bytes"
+) -> Optional[int]:
+    """Helper for get file size with <units>."""
+    swapfile_fpath = Path(swapfile_fpath)
+    if swapfile_fpath.is_file():
+        return ceil(swapfile_fpath.stat().st_size / _multiplier[units])

--- a/otaclient/_utils/linux.py
+++ b/otaclient/_utils/linux.py
@@ -1,0 +1,85 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+from math import ceil
+from pathlib import Path
+from subprocess import check_output, check_call
+from typing import Optional
+
+
+def create_swapfile(
+    swapfile_fpath: str | Path, size_in_MiB: int, *, timeout=600
+) -> Path:
+    """Create swapfile at <swapfile_fpath> with <size_in_MiB>MiB.
+
+    Reference: https://wiki.archlinux.org/title/swap#Swap_file_creation
+
+    Args:
+        swapfile_fpath(StrOrPath): the path to place the created swapfile.
+        size_in_MiB(int): the size of to-be-created swapfile.
+        timeout: timeout of swapfile creating, default is 600 seconds.
+
+    Returns:
+        The Path object to the newly created swapfile.
+
+    Raises:
+        ValueError on file already exists at <swapfile_fpath>, SubprocessCallFailed
+            on failed swapfile creation.
+    """
+    swapfile_fpath = Path(swapfile_fpath)
+    if swapfile_fpath.exists():
+        raise ValueError(f"{swapfile_fpath=} exists, skip")
+
+    # create a new file with <size_in_MiB>MiB size
+    # executes:
+    #   dd if=/dev/zero of=/swapfile bs=1M count=8k
+    #   chmod 0600 /swapfile
+    check_call(
+        [
+            "dd",
+            "if=/dev/zero",
+            f"of={str(swapfile_fpath)}",
+            "bs=1M",
+            f"count={size_in_MiB}",
+        ],
+        timeout=timeout,
+    )
+    swapfile_fpath.chmod(0o600)
+
+    # prepare the created file as swapfile
+    # executes:
+    #   mkswap /swapfile
+    check_call(["mkswap", str(swapfile_fpath)], timeout=timeout)
+
+    return swapfile_fpath
+
+
+def detect_swapfile_size(swapfile_fpath: str | Path, *, timeout=120) -> Optional[int]:
+    """Get the size of <swapfile_fpath> in MiB."""
+    swapfile_fpath = Path(swapfile_fpath)
+    if not swapfile_fpath.is_file():
+        return
+
+    _cmd = [
+        "swapon",
+        "--show=SIZE",
+        "--noheadings",
+        "--raw",
+        "--bytes",
+        str(swapfile_fpath),
+    ]
+    _raw_size = check_output(_cmd, timeout=timeout).decode().strip()
+    return ceil(int(_raw_size) / 1024**2)

--- a/otaclient/_utils/linux.py
+++ b/otaclient/_utils/linux.py
@@ -19,7 +19,7 @@ from subprocess import check_call
 
 
 def create_swapfile(
-    swapfile_fpath: str | Path, size_in_MiB: int, *, timeout=600
+    swapfile_fpath: str | Path, size_in_MiB: int, *, timeout=900
 ) -> Path:
     """Create swapfile at <swapfile_fpath> with <size_in_MiB>MiB.
 
@@ -28,7 +28,7 @@ def create_swapfile(
     Args:
         swapfile_fpath(StrOrPath): the path to place the created swapfile.
         size_in_MiB(int): the size of to-be-created swapfile.
-        timeout: timeout of swapfile creating, default is 600 seconds.
+        timeout: timeout of swapfile creating, default is 15mins.
 
     Returns:
         The Path object to the newly created swapfile.

--- a/otaclient/_utils/linux.py
+++ b/otaclient/_utils/linux.py
@@ -14,10 +14,8 @@
 
 
 from __future__ import annotations
-from math import ceil
 from pathlib import Path
-from subprocess import check_output, check_call
-from typing import Optional
+from subprocess import check_call
 
 
 def create_swapfile(
@@ -65,21 +63,3 @@ def create_swapfile(
     check_call(["mkswap", str(swapfile_fpath)], timeout=timeout)
 
     return swapfile_fpath
-
-
-def detect_swapfile_size(swapfile_fpath: str | Path, *, timeout=120) -> Optional[int]:
-    """Get the size of <swapfile_fpath> in MiB."""
-    swapfile_fpath = Path(swapfile_fpath)
-    if not swapfile_fpath.is_file():
-        return
-
-    _cmd = [
-        "swapon",
-        "--show=SIZE",
-        "--noheadings",
-        "--raw",
-        "--bytes",
-        str(swapfile_fpath),
-    ]
-    _raw_size = check_output(_cmd, timeout=timeout).decode().strip()
-    return ceil(int(_raw_size) / 1024**2)

--- a/otaclient/app/ota_client.py
+++ b/otaclient/app/ota_client.py
@@ -46,7 +46,8 @@ from .update_stats import (
 )
 from . import log_setting
 
-from otaclient._utils.linux import create_swapfile, detect_swapfile_size
+from otaclient._utils import get_file_size
+from otaclient._utils.linux import create_swapfile
 
 try:
     from otaclient import __version__  # type: ignore
@@ -312,11 +313,11 @@ class _OTAUpdater:
             if str(_per_fpath) in ["/swapfile", "/swap.img"]:
                 _new_swapfile = standby_slot_mp / _per_fpath
                 try:
-                    _swapfile_size = detect_swapfile_size(_per_fpath)  # in MiB
-                    assert _swapfile_size is not None
+                    _swapfile_size = get_file_size(_per_fpath, units="MiB")
+                    assert _swapfile_size is not None, f"{_per_fpath} doesn't exist"
                     create_swapfile(_new_swapfile, _swapfile_size)
                 except Exception as e:
-                    logger.warning(f"failed to create {_per_fpath}: {e!r}")
+                    logger.warning(f"failed to create {_per_fpath}, skip: {e!r}")
                 continue
 
             if (


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->

This PR implements the proper way to create swapfile, and provides a workaround fix in persist file handling to handle swapfile creating.

At the time when persist file mechanism design was proposed by the original developer, handling swapfile was not considered but is wildly used in real world to create swapfile in new slot. 
By default direct copy is used to persist file from active slot to standby slot, however for swapfile, direct copy is improper(see https://wiki.archlinux.org/title/swap for the proper way of creating a swapfile) and will cost unnecessary time if the swapfile is huge.

> [!NOTE]
> In the upcoming new OTA image spec, we will no-longer handle swapfile in persist file handling hook, but handle it at dedicated hook.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file that covers the bug case(s) is implemented.
- [x] local test is passed. 

## Bug fix

### Behaivor after fix

1. persist file handling(in PROCESS_POSTUPDATE phase) will not take long time if swapfile is huge.
2. swapfile is created by proper method.

## Related links & ticket

<!-- List of tickets or links related to this PR -->

[RT4-8553](https://tier4.atlassian.net/browse/RT4-8553)

[RT4-8553]: https://tier4.atlassian.net/browse/RT4-8553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ