### PR TITLE
fix(v3.6.x): otaclient.persist_file_handling: fix incorrect new swapfile fpath

### DIFF
--- a/otaclient/app/ota_client.py
+++ b/otaclient/app/ota_client.py
@@ -310,13 +310,19 @@ class _OTAUpdater:
 
             # NOTE(20240220): fast fix for handling swapfile
             if str(_per_fpath) in ["/swapfile", "/swap.img"]:
+                # NOTE: here we probe the current running system's swapfile at /.
+                if not _per_fpath.is_file():
+                    continue
+
                 _new_swapfile = standby_slot_mp / _per_fpath.relative_to("/")
                 try:
                     _swapfile_size = get_file_size(_per_fpath, units="MiB")
                     assert _swapfile_size is not None, f"{_per_fpath} doesn't exist"
                     create_swapfile(_new_swapfile, _swapfile_size)
                 except Exception as e:
-                    logger.warning(f"failed to create {_per_fpath}, skip: {e!r}")
+                    logger.warning(
+                        f"failed to create swapfile {_per_fpath} to standby slot, skip: {e!r}"
+                    )
                 continue
 
             if (

--- a/otaclient/app/ota_client.py
+++ b/otaclient/app/ota_client.py
@@ -310,7 +310,7 @@ class _OTAUpdater:
 
             # NOTE(20240220): fast fix for handling swapfile
             if str(_per_fpath) in ["/swapfile", "/swap.img"]:
-                _new_swapfile = standby_slot_mp / _per_fpath
+                _new_swapfile = standby_slot_mp / _per_fpath.relative_to("/")
                 try:
                     _swapfile_size = get_file_size(_per_fpath, units="MiB")
                     assert _swapfile_size is not None, f"{_per_fpath} doesn't exist"


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->

This PR fixes an issue when creating new swapfile during persist_file_handling. The new swapfile's fpath is incorrect, resulting in new swapfile not being created.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] vm test passed.
- [x] local test is passed. 