### PR TITLE
fix(v3.7.x): fix unexpected behavior related to available_ecu_ids

### DIFF
--- a/otaclient/app/ota_client_stub.py
+++ b/otaclient/app/ota_client_stub.py
@@ -516,11 +516,6 @@ class ECUStatusStorage:
         """Update the ECU status storage with child ECU's status report(StatusResponse)."""
         async with self._writer_lock:
             self.storage_last_updated_timestamp = cur_timestamp = int(time.time())
-            _subecu_available_ecu_ids = _OrderedSet(status_resp.available_ecu_ids)
-            # discover further child ECUs from directly connected sub ECUs.
-            self._tracked_active_ecus.update(_subecu_available_ecu_ids)
-            # merge available_ecu_ids from child ECUs resp to include further child ECUs
-            self._available_ecu_ids.update(_subecu_available_ecu_ids)
 
             # NOTE: use v2 if v2 is available, but explicitly support v1 format
             #       for backward-compatible with old otaclient


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->

This PR fixes an unexpected implementation details which prevents the `available_ecu_ids` for actually behaving as expected.

This is caused by: 

1. `ota_client_stub` module merges the `available_ecu_ids` from sub ECU's status response.
2. `ecu_info` parsing logic has an implicit implementation detail for backward compatibility, which when `available_ecu_ids` is not defined in the `ecu_info.yaml`, add this ECU id into this field.

The above effectively disabling the functionality of `available_ecu_ids`, unless the corresponding ECU contacts that don't need OTA also being commented out in `ecu_info.yaml`.

With this PR, now the `available_ecu_ids` field should work as expected, and the behavior aligns with the [documentation](https://tier4.atlassian.net/l/cp/AnLPYQa5), which only `available_ecu_ids` from the main ECU is respected.