### PR TITLE
build(deps): bump cryptography to >=42.0.4, <43.0.0, pyopenssl to 24.1.0 in /otaclient

### DIFF
--- a/otaclient/requirements.txt
+++ b/otaclient/requirements.txt
@@ -1,4 +1,4 @@
-pyOpenSSL==23.0.0
+pyOpenSSL==24.1.0
 cryptography>=42.0.4, <43.0.0
 grpcio>=1.53.2, <1.54.0
 protobuf==4.21.12

--- a/otaclient/requirements.txt
+++ b/otaclient/requirements.txt
@@ -1,5 +1,5 @@
 pyOpenSSL==23.0.0
-cryptography>=39.0.1, <40.0.0
+cryptography>=42.0.4, <43.0.0
 grpcio>=1.53.2, <1.54.0
 protobuf==4.21.12
 PyYAML>=3.12


### PR DESCRIPTION
See https://github.com/tier4/ota-client/security/dependabot/26 for more details.