### PR TITLE
refactor: refine log_setting to support new src layout 

### DIFF
--- a/src/otaclient/app/configs.py
+++ b/src/otaclient/app/configs.py
@@ -97,6 +97,7 @@ class BaseConfig(_InternalSettings):
         "otaclient": INFO,
         "otaclient_api": INFO,
         "otaclient_common": INFO,
+        "otaproxy": INFO,
     }
     LOG_FORMAT = (
         "[%(asctime)s][%(levelname)s]-%(name)s:%(funcName)s:%(lineno)d,%(message)s"

--- a/src/otaclient/app/main.py
+++ b/src/otaclient/app/main.py
@@ -29,7 +29,7 @@ import ota_metadata.legacy  # noqa: F401
 from otaclient import __version__
 from otaclient.app.configs import config as cfg
 from otaclient.app.configs import ecu_info, server_cfg
-from otaclient.app.log_setting import configure_logging
+from otaclient.log_setting import configure_logging
 from otaclient.app.ota_client_stub import OTAClientServiceStub
 from otaclient_api.v2 import otaclient_v2_pb2_grpc as v2_grpc
 from otaclient_api.v2.api_stub import OtaClientServiceV2

--- a/src/otaclient/app/main.py
+++ b/src/otaclient/app/main.py
@@ -29,8 +29,8 @@ import ota_metadata.legacy  # noqa: F401
 from otaclient import __version__
 from otaclient.app.configs import config as cfg
 from otaclient.app.configs import ecu_info, server_cfg
-from otaclient.log_setting import configure_logging
 from otaclient.app.ota_client_stub import OTAClientServiceStub
+from otaclient.log_setting import configure_logging
 from otaclient_api.v2 import otaclient_v2_pb2_grpc as v2_grpc
 from otaclient_api.v2.api_stub import OtaClientServiceV2
 from otaclient_common.common import read_str_from_file, write_str_to_file_sync

--- a/src/otaclient/app/ota_client_stub.py
+++ b/src/otaclient/app/ota_client_stub.py
@@ -31,7 +31,7 @@ from typing_extensions import Self
 from ota_proxy import OTAProxyContextProto
 from ota_proxy import config as local_otaproxy_cfg
 from ota_proxy import subprocess_otaproxy_launcher
-from otaclient.app import log_setting
+from otaclient import log_setting
 from otaclient.configs.ecu_info import ECUContact
 from otaclient_api.v2 import types as api_types
 from otaclient_api.v2.api_caller import ECUNoResponse, OTAClientCall

--- a/src/otaclient/log_setting.py
+++ b/src/otaclient/log_setting.py
@@ -25,7 +25,8 @@ from urllib.parse import urljoin
 
 import requests
 
-from otaclient.app.configs import config as cfg, ecu_info, proxy_info
+from otaclient.app.configs import config as cfg
+from otaclient.app.configs import ecu_info, proxy_info
 
 
 class _LogTeeHandler(logging.Handler):

--- a/tests/test_otaclient/test_log_setting.py
+++ b/tests/test_otaclient/test_log_setting.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import logging
 
-from otaclient.app import log_setting
+from otaclient import log_setting
 
 MODULE = log_setting.__name__
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Introduction

This PR fixes otaclient logging upload only covers `otaclient` since project layout restruct phase2, while applies some refinements over the `log_setting` module and move this module directly under `otaclient` package.

## Test
Confirm loggings from other modules rather than `otaclient` are uploaded to the cloud side.
![image](https://github.com/tier4/ota-client/assets/86948717/36999c8f-839e-4977-8b0d-9d6e7ecc5ccd)
