### PR TITLE
refactor: create_standby: add semaphore during delta generating to limit pending tasks in memory

### DIFF
--- a/src/otaclient/app/configs.py
+++ b/src/otaclient/app/configs.py
@@ -133,7 +133,7 @@ class BaseConfig(_InternalSettings):
     # --- create standby setting --- #
     # now only REBUILD mode is available
     STANDBY_CREATION_MODE = CreateStandbyMechanism.REBUILD
-    MAX_CONCURRENT_PROCESS_FILE_TASKS = 256
+    MAX_CONCURRENT_PROCESS_FILE_TASKS = 512
     MAX_PROCESS_FILE_THREAD = 6
     CREATE_STANDBY_RETRY_MAX = 1024
     CREATE_STANDBY_BACKOFF_FACTOR = 1

--- a/src/otaclient/app/configs.py
+++ b/src/otaclient/app/configs.py
@@ -133,7 +133,8 @@ class BaseConfig(_InternalSettings):
     # --- create standby setting --- #
     # now only REBUILD mode is available
     STANDBY_CREATION_MODE = CreateStandbyMechanism.REBUILD
-    MAX_CONCURRENT_PROCESS_FILE_TASKS = 512
+    MAX_CONCURRENT_PROCESS_FILE_TASKS = 256
+    MAX_PROCESS_FILE_THREAD = 6
     CREATE_STANDBY_RETRY_MAX = 1024
     CREATE_STANDBY_BACKOFF_FACTOR = 1
     CREATE_STANDBY_BACKOFF_MAX = 6

--- a/src/otaclient/app/create_standby/common.py
+++ b/src/otaclient/app/create_standby/common.py
@@ -22,7 +22,7 @@ import os
 import random
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
@@ -325,10 +325,18 @@ class DeltaGenerator:
 
         # ------ create the threadpool executor ------ #
         thread_local = threading.local()
+        max_pending_tasks = threading.Semaphore(cfg.MAX_CONCURRENT_PROCESS_FILE_TASKS)
 
         def _initializer():
             thread_local.buffer = buffer = bytearray(cfg.CHUNK_SIZE)
             thread_local.view = memoryview(buffer)
+
+        def _task_done_callback(fut: Future[Any]):
+            if exc := fut.exception():
+                logger.warning(
+                    f"detect error during file preparing, still continue: {exc!r}"
+                )
+            max_pending_tasks.release()
 
         pool = ThreadPoolExecutor(
             thread_name_prefix="scan_slot", initializer=_initializer
@@ -417,11 +425,12 @@ class DeltaGenerator:
                     self._rm.append(str(canonical_fpath))
                     continue
 
+                max_pending_tasks.acquire()
                 pool.submit(
                     self._prepare_local_copy_from_active_slot,
                     delta_src_fpath,
                     thread_local=thread_local,
-                )
+                ).add_done_callback(_task_done_callback)
 
         # wait for all files being processed
         pool.shutdown(wait=True)

--- a/src/otaclient/app/create_standby/common.py
+++ b/src/otaclient/app/create_standby/common.py
@@ -339,7 +339,9 @@ class DeltaGenerator:
             max_pending_tasks.release()
 
         pool = ThreadPoolExecutor(
-            thread_name_prefix="scan_slot", initializer=_initializer
+            max_workers=cfg.MAX_PROCESS_FILE_THREAD,
+            thread_name_prefix="scan_slot",
+            initializer=_initializer,
         )
 
         # scan old slot and generate delta based on path,

--- a/src/otaclient/app/create_standby/common.py
+++ b/src/otaclient/app/create_standby/common.py
@@ -332,11 +332,11 @@ class DeltaGenerator:
             thread_local.view = memoryview(buffer)
 
         def _task_done_callback(fut: Future[Any]):
+            max_pending_tasks.release()  # always release se first
             if exc := fut.exception():
                 logger.warning(
                     f"detect error during file preparing, still continue: {exc!r}"
                 )
-            max_pending_tasks.release()
 
         pool = ThreadPoolExecutor(
             max_workers=cfg.MAX_PROCESS_FILE_THREAD,


### PR DESCRIPTION
## Description

In #308 , the active slot scanning is improved by waiting for all tasks instead of waiting for each folder being scanned, but this brings an issue that if the files processing speed is not fast enough, the pending tasks will pile up. 
This PR implements the limitation of total ongoing files scanning entries, and define the number of thread workers.

## Tests

- [x] local pytest passed.
- [x] test with VM passed. 