### PR TITLE
refactor: rpi_boot: detects slot by partition layout, not by checking slot fslabel

### DIFF
--- a/src/otaclient/app/boot_control/_common.py
+++ b/src/otaclient/app/boot_control/_common.py
@@ -195,6 +195,30 @@ class CMDHelperFuncs:
         return subprocess_check_output(cmd, raise_exception=raise_exception)
 
     @classmethod
+    def get_device_tree(
+        cls, parent_dev: str, *, raise_exception: bool = True
+    ) -> list[str]:
+        """Get the device tree of a parent device.
+
+        For example, for sda with 3 partitions, we will get:
+        ["/dev/sda", "/dev/sda1", "/dev/sda2", "/dev/sda3"]
+
+        This function is implemented by calling:
+            lsblk -lnpo NAME <parent_dev>
+
+        Args:
+            parent_dev (str): The parent device to be checked.
+            raise_exception (bool, optional): raise exception on subprocess call failed.
+                Defaults to True.
+
+        Returns:
+            str: _description_
+        """
+        cmd = ["lsblk", "-lnpo", "NAME", parent_dev]
+        raw_res = subprocess_check_output(cmd, raise_exception=raise_exception)
+        return raw_res.splitlines()
+
+    @classmethod
     def set_ext4_fslabel(cls, dev: str, fslabel: str, *, raise_exception: bool = True):
         """Set <fslabel> to ext4 formatted <dev>.
 

--- a/src/otaclient/app/boot_control/_common.py
+++ b/src/otaclient/app/boot_control/_common.py
@@ -748,7 +748,7 @@ class SlotMountHelper:
         # TODO: in the future if in-place update mode is implemented, do a
         #   fschck over the standby slot file system.
         if fslabel:
-            CMDHelperFuncs.set_ext4_fslabel(self.active_slot_dev, fslabel=fslabel)
+            CMDHelperFuncs.set_ext4_fslabel(self.standby_slot_dev, fslabel=fslabel)
 
     def umount_all(self, *, ignore_error: bool = True):
         logger.debug("unmount standby slot and active slot mount point...")

--- a/src/otaclient/app/boot_control/_rpi_boot.py
+++ b/src/otaclient/app/boot_control/_rpi_boot.py
@@ -33,10 +33,7 @@ from otaclient.app.boot_control._common import (
 from otaclient.app.boot_control.configs import rpi_boot_cfg as cfg
 from otaclient.app.boot_control.protocol import BootControllerProtocol
 from otaclient_api.v2 import types as api_types
-from otaclient_common.common import (
-    replace_atomic,
-    subprocess_call,
-)
+from otaclient_common.common import replace_atomic, subprocess_call
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce.

For better understanding, adding reason/motivation of this PR are also recommended.
-->

Previously, the `rpi_boot` module detects the active slot's slot_id by reading its fslabel, and then use this information to determine the standby slot's id. 

This turns out to be not so robust, as if the slot_id is accidentally altered, assigned with unexpected, the `rpi_boot` module will not be able to detect the problem, and future OTA will break the system as slot_ids are unexpected.

Also, the fslabel comes with file system(not partition), if the file system somehow broken, it will also break otaclient, even if the partition layout is correct.

This PR refines the rpi_boot module to detect slot by examining the partition layout, not relying on reading the fslabel. Now we explicitly require the partition layout to be:
```
    Supported partition layout:
        /dev/sd<x>:
            - sd<x>1: fat32, fslabel=systemb-boot
            - sd<x>2: ext4, fslabel=slot_a
            - sd<x>3: ext4, fslabel=slot_b
```
and `sd<x>2` will be the slot_a, and `sd<x>3` will be the slot_b.

> [!Note]
> Note that partition ID is not required to be strictly corresponding to the physical position of partitions on the disk. For example, you can assign partition ID 1 to the any partition at any location on the disk.  

Also it provides the functionality to automatically correct the active slot's fslabel after the slot_id is determined.

## Other changes

1. now we allow extra partitions existed after the partition 3.

## Tests

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] local test is passed.
- [x] test with raspberry pi device passed, rpli_boot starts up successfully.
- [x] test with raspberry pi device with active slot's fslabel incorrect, rpi_boot fixes the problem successfully.
