### PR TITLE
fix: proxy_info: allow to set string value to local_ota_proxy_listen_port field

### DIFF
--- a/src/otaclient_common/typing.py
+++ b/src/otaclient_common/typing.py
@@ -19,7 +19,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, TypeVar, Union
 
-from pydantic import Field
+from pydantic import BeforeValidator, Field
 from typing_extensions import Annotated, Concatenate, ParamSpec
 
 P = ParamSpec("P")
@@ -31,7 +31,11 @@ StrOrPath = Union[str, Path]
 
 # pydantic helpers
 
-NetworkPort = Annotated[int, Field(ge=1, le=65535)]
+NetworkPort = Annotated[
+    int,
+    BeforeValidator(lambda x: int(x)),
+    Field(ge=1, le=65535),
+]
 
 
 def gen_strenum_validator(

--- a/tests/test_otaclient/test_configs/test_proxy_info.py
+++ b/tests/test_otaclient/test_configs/test_proxy_info.py
@@ -95,6 +95,11 @@ logger = logging.getLogger(__name__)
             "enable_ota_proxy: true\ngateway: false\n",
             DEFAULT_PROXY_INFO,
         ),
+        # ------ case 7(20240626): NetworkPort allow str value ------ #
+        (
+            'local_ota_proxy_listen_port: "8082"',
+            ProxyInfo(local_ota_proxy_listen_port=8082),
+        ),
     ),
 )
 def test_proxy_info(tmp_path: Path, _input_yaml: str, _expected: ProxyInfo):


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->

This PR lifts the type checking on `proxy_info.yaml` file's local_ota_proxy_listen_port, string value is valid now for this field.

Underneath the change, the `NetworkPort` type now will do a force int convert for the raw value to allow port number string. 

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file that covers the bug case(s) is implemented.
- [x] local test is passed.

## Bug fix

otaclient fails to load `proxy_info.yaml` due to string value is used on `local_ota_proxy_listen_port` field.

<!-- List of tickets or links related to this PR -->
