### PR TITLE
refactor: DownloaderPool: implement watchdog func for breaking on max idling timeout

### DIFF
--- a/src/otaclient_common/downloader.py
+++ b/src/otaclient_common/downloader.py
@@ -22,10 +22,11 @@ from __future__ import annotations
 import hashlib
 import logging
 import threading
+import time
 from abc import abstractmethod
 from functools import wraps
 from io import IOBase
-from typing import IO, Any, ByteString, Callable, Iterator, Mapping, Protocol
+from typing import IO, Any, ByteString, Callable, Iterator, Mapping, Protocol, TypedDict
 from urllib.parse import urlsplit
 
 import requests
@@ -435,6 +436,11 @@ class Downloader:
         return err_count, downloaded_file_size, traffic_on_wire
 
 
+class DownloadPoolWatchdogFuncContext(TypedDict):
+    downloaded_bytes: int
+    previous_active_timestamp: int
+
+
 class DownloaderPool:
     """A pool of downloader instances for multi-threading environment.
 
@@ -474,6 +480,28 @@ class DownloaderPool:
         if _res := sum(downloader.downloaded_bytes for downloader in self._instances):
             self._total_downloaded_bytes = _res
         return self._total_downloaded_bytes
+
+    def downloading_watchdog(
+        self, *, ctx: DownloadPoolWatchdogFuncContext, max_idle_timeout: int
+    ):
+        """Downloading pool idle timeout watchdog.
+
+        This method is designed to use with ThreadPoolExecutorWithRetry.
+        When configured to use, if the downloading is idle longer than <max_idle_timeout>,
+            call to this function will raise ValueError.
+        """
+        downloaded_bytes = self.total_downloaded_bytes
+
+        current_tiemstamp = int(time.time())
+        if downloaded_bytes > ctx["downloaded_bytes"]:
+            ctx["downloaded_bytes"] = downloaded_bytes
+            ctx["previous_active_timestamp"] = current_tiemstamp
+            return
+
+        if current_tiemstamp - ctx["previous_active_timestamp"] > max_idle_timeout:
+            _err_msg = f"downloader stuck for {max_idle_timeout} seconds, abort"
+            logger.error(_err_msg)
+            raise ValueError(_err_msg)
 
     def get_instance(self) -> Downloader:
         """Get a reference of the downloader instance for the calling thread.

--- a/tests/test_otaclient_common/test_downloader.py
+++ b/tests/test_otaclient_common/test_downloader.py
@@ -35,6 +35,7 @@ from requests.structures import CaseInsensitiveDict as CIDict
 
 from otaclient_common.common import urljoin_ensure_base
 from otaclient_common.downloader import (
+    DownloadPoolWatchdogFuncContext,
     Downloader,
     DownloaderPool,
     HashVerificationError,
@@ -322,6 +323,14 @@ class TestDownloaderPool:
             max_workers=self._thread_num,
             thread_name_prefix="download_ota_files",
             initializer=self._thread_initializer,
+            watchdog_func=partial(
+                self._downloader_pool.downloading_watchdog,
+                ctx=DownloadPoolWatchdogFuncContext(
+                    downloaded_bytes=0,
+                    previous_active_timestamp=int(time.time()),
+                ),
+                max_idle_timeout=6,
+            ),
         ) as _mapper:
             for _fut in _mapper.ensure_tasks(self._download_file, file_info_list):
                 _fut.result()  # expose any possible exception
@@ -411,3 +420,43 @@ def test_check_cache_policy_in_resp(
             resp_headers=_resp_headers,
         )
         assert (compression_alg, digest) == _expected
+
+
+STUCK_AFTER = 6
+MAX_IDLE_TIME = 16
+TEST_DURATION = 30
+
+
+class TestDownloadingPoolWatchdog:
+
+    @pytest.fixture(autouse=True)
+    def setup_test(self):
+        self._test_started_timestamp = 0
+        self._total_downloaded_bytes = 0
+
+    @property
+    def total_downloaded_bytes(self):
+        cur_time = int(time.time())
+        if cur_time - self._test_started_timestamp < STUCK_AFTER:
+            self._total_downloaded_bytes += 1
+        else:
+            logger.info("dummy total_downloaded_bytes property: simulate stuck...")
+        return self._total_downloaded_bytes
+
+    def test_watchdog(self):
+        cur_time = int(time.time())
+        watchdog_func = partial(
+            DownloaderPool.downloading_watchdog.__get__(self),
+            ctx=DownloadPoolWatchdogFuncContext(
+                downloaded_bytes=0,
+                previous_active_timestamp=cur_time,
+            ),
+            max_idle_timeout=MAX_IDLE_TIME,
+        )
+
+        self._test_started_timestamp = cur_time
+        with pytest.raises(ValueError):
+            for t in range(TEST_DURATION):
+                logger.info(f"watchdog check #{t}")
+                watchdog_func()
+                time.sleep(1)

--- a/tests/test_otaclient_common/test_downloader.py
+++ b/tests/test_otaclient_common/test_downloader.py
@@ -35,9 +35,9 @@ from requests.structures import CaseInsensitiveDict as CIDict
 
 from otaclient_common.common import urljoin_ensure_base
 from otaclient_common.downloader import (
-    DownloadPoolWatchdogFuncContext,
     Downloader,
     DownloaderPool,
+    DownloadPoolWatchdogFuncContext,
     HashVerificationError,
     check_cache_policy_in_resp,
 )


### PR DESCRIPTION
## Description

This PR introduces a new watchdog function for using `DownloaderPool` with `ThreadPoolExecutorWithRetry`(#314 ). This watchdog func implements breaking out retry on reaching max idling downloading timeout, typically for breaking out OTA downloading on network disconnected. 
Note that at this PR this new watchdog func is not yet integrated into otaclient, only implementation and tests are provided.

## Tests

- [x] tests cover the changes are implemented.
- [x] local pytest is passed. 