### PR TITLE
refactor: re-implement the OTA progress stats collector

### DIFF
--- a/src/otaclient/app/create_standby/common.py
+++ b/src/otaclient/app/create_standby/common.py
@@ -35,11 +35,7 @@ from ota_metadata.legacy.types import DirectoryInf, RegularInf
 from otaclient_common.common import create_tmp_fname
 
 from ..configs import config as cfg
-from ..update_stats import (
-    OTAUpdateStatsCollector,
-    OperationRecord,
-    ProcessOperation,
-)
+from ..update_stats import OperationRecord, OTAUpdateStatsCollector, ProcessOperation
 
 logger = logging.getLogger(__name__)
 

--- a/src/otaclient/app/create_standby/common.py
+++ b/src/otaclient/app/create_standby/common.py
@@ -37,8 +37,8 @@ from otaclient_common.common import create_tmp_fname
 from ..configs import config as cfg
 from ..update_stats import (
     OTAUpdateStatsCollector,
-    RegInfProcessedStats,
-    RegProcessOperation,
+    OperationRecord,
+    ProcessOperation,
 )
 
 logger = logging.getLogger(__name__)
@@ -286,7 +286,6 @@ class DeltaGenerator:
             except KeyError:
                 pass
 
-        start_time = time.thread_time_ns()
         tmp_f = self._local_copy_dir / create_tmp_fname()
         hash_buffer, hash_bufferview = thread_local.buffer, thread_local.view
         try:
@@ -311,11 +310,11 @@ class DeltaGenerator:
             tmp_f.unlink(missing_ok=True)
 
         # report to the ota update stats collector
-        self._stats_collector.report_prepare_local_copy(
-            RegInfProcessedStats(
-                op=RegProcessOperation.PREPARE_LOCAL_COPY,
-                size=fpath.stat().st_size,
-                elapsed_ns=time.thread_time_ns() - start_time,
+        self._stats_collector.report_stat(
+            OperationRecord(
+                op=ProcessOperation.PREPARE_LOCAL_COPY,
+                processed_file_size=fpath.stat().st_size,
+                processed_file_num=1,
             ),
         )
 

--- a/src/otaclient/app/ota_client.py
+++ b/src/otaclient/app/ota_client.py
@@ -271,7 +271,7 @@ class _OTAUpdater:
 
         # ------ start the downloading ------ #
         download_started = threading.Event()
-        watchdog_ctx = {}
+        watchdog_ctx = {"downloaded_bytes": 0, "previous_active_timestamp": 0}
 
         def _thread_initializer():
             self._downloader_mapper[threading.get_native_id()] = (

--- a/src/otaclient/app/ota_client.py
+++ b/src/otaclient/app/ota_client.py
@@ -21,8 +21,8 @@ import errno
 import gc
 import json
 import logging
-import time
 import threading
+import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from functools import partial
 from hashlib import sha256

--- a/src/otaclient/app/update_stats.py
+++ b/src/otaclient/app/update_stats.py
@@ -71,10 +71,6 @@ class OTAUpdateStatsCollector:
         self.processed_files_num: int = 0
         self.processed_files_size: int = 0
 
-        # ------ delta calculation stats ------ #
-        self.delta_collected_files_num: int = 0
-        self.delta_collected_files_size: int = 0
-
         # ------ download stats ------ #
         self.downloaded_files_num: int = 0
         self.downloaded_files_size: int = 0
@@ -82,8 +78,6 @@ class OTAUpdateStatsCollector:
 
         # ------ apply update stats ------ #
         self.removed_files_num: int = 0
-        self.apply_update_files_num: int = 0
-        self.apply_update_files_size: int = 0
 
     @property
     def total_elapsed_time(self) -> int:
@@ -102,7 +96,7 @@ class OTAUpdateStatsCollector:
 
     @property
     def download_elapsed_time(self) -> int:
-        if self._download_finished_timestamp == 0:
+        if self._download_started_timestamp == 0:
             return 0
         if self._download_finished_timestamp == 0:
             return int(time.time()) - self._download_started_timestamp
@@ -130,6 +124,10 @@ class OTAUpdateStatsCollector:
             self.processed_files_size += entry.processed_file_size
             if entry.op == ProcessOperation.DOWNLOAD_REMOTE_COPY:
                 self.downloading_errors += entry.errors
+                self.downloaded_files_num += entry.processed_file_num
+                self.downloaded_files_size += entry.processed_file_size
+            elif entry.op == ProcessOperation.APPLY_REMOVE_DELTA:
+                self.removed_files_num += entry.processed_file_num
 
     # APIs
 

--- a/src/otaclient/app/update_stats.py
+++ b/src/otaclient/app/update_stats.py
@@ -33,8 +33,6 @@ class ProcessOperation(Enum):
     APPLY_DELTA = auto()
     # for in-place update only
     APPLY_REMOVE_DELTA = auto()
-    # special op for download error report
-    DOWNLOAD_ERROR_REPORT = auto()
 
 
 class OperationRecord(BaseModel):
@@ -46,7 +44,7 @@ class OperationRecord(BaseModel):
     errors: int = 0
 
 
-class OTAUpdateStatsCollector2:
+class OTAUpdateStatsCollector:
 
     def __init__(self, *, collect_interval: int = 1) -> None:
         self.collect_interval = collect_interval

--- a/src/otaclient/app/update_stats.py
+++ b/src/otaclient/app/update_stats.py
@@ -53,7 +53,6 @@ class OTAUpdateStatsCollector:
 
         self._shutdown = False
 
-        self._update_started_timestamp = int(time.time())
         self._delta_calculation_started_timestamp = 0
         self._delta_calculation_finished_timestamp = 0
 
@@ -66,6 +65,7 @@ class OTAUpdateStatsCollector:
         #
         # ------ exposed attributes ------ #
         #
+        self.update_started_timestamp = int(time.time())
 
         # ------ summary ------ #
         self.processed_files_num: int = 0
@@ -87,7 +87,7 @@ class OTAUpdateStatsCollector:
 
     @property
     def total_elapsed_time(self) -> int:
-        return int(time.time()) - self._update_started_timestamp
+        return int(time.time()) - self.update_started_timestamp
 
     @property
     def delta_calculation_elapsed_time(self) -> int:
@@ -158,7 +158,7 @@ class OTAUpdateStatsCollector:
         self._collector = Thread(target=self._stats_collector, daemon=True)
         self._collector.start()
 
-    def finish_collecting(self, *, wait_staging=True):
+    def shutdown_collector(self, *, wait_staging=True):
         if not self._collector:
             return  # the collector is not started!
 

--- a/src/otaclient_common/downloader.py
+++ b/src/otaclient_common/downloader.py
@@ -26,16 +26,7 @@ import time
 from abc import abstractmethod
 from functools import wraps
 from io import IOBase
-from typing import (
-    IO,
-    Any,
-    ByteString,
-    Callable,
-    Iterator,
-    Mapping,
-    Protocol,
-    TypedDict,
-)
+from typing import IO, Any, ByteString, Callable, Iterator, Mapping, Protocol, TypedDict
 from urllib.parse import urlsplit
 
 import requests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,7 @@ def run_http_server_subprocess():
         target=run_http_server,
         args=[cfg.OTA_IMAGE_SERVER_ADDR, cfg.OTA_IMAGE_SERVER_PORT],
         kwargs={"directory": cfg.OTA_IMAGE_DIR},
+        daemon=True,
     )
     try:
         _server_p.start()

--- a/tests/test_otaclient/test_create_standby.py
+++ b/tests/test_otaclient/test_create_standby.py
@@ -111,12 +111,12 @@ class Test_OTAupdate_with_create_standby_RebuildMode:
         _updater.shutdown.assert_called_once()
         otaclient_control_flags.wait_can_reboot_flag.assert_called_once()
         # --- ensure the update stats are collected
-        _snapshot = _updater._update_stats_collector.get_snapshot()
-        assert _snapshot.processed_files_num
-        assert _snapshot.processed_files_size
-        assert _snapshot.downloaded_files_num
-        assert _snapshot.downloaded_files_size
-        assert _snapshot.update_applying_elapsed_time.export_pb().ToNanoseconds()
+        collector = _updater._update_stats_collector
+        assert collector.processed_files_num
+        assert collector.processed_files_size
+        assert collector.downloaded_files_num
+        assert collector.downloaded_files_size
+        assert collector.apply_update_elapsed_time
 
         # --- check slot creating result, ensure slot_a and slot_b is the same --- #
         # NOTE: merge contents from slot_b_boot_dir to slot_b

--- a/tests/test_otaclient/test_update_stats.py
+++ b/tests/test_otaclient/test_update_stats.py
@@ -13,105 +13,101 @@
 # limitations under the License.
 
 
+from __future__ import annotations
+
 import logging
+import random
+import time
 from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 
 import pytest
 
 from otaclient.app.update_stats import (
+    OperationRecord,
     OTAUpdateStatsCollector,
-    RegInfProcessedStats,
-    RegProcessOperation,
+    ProcessOperation,
 )
 
 logger = logging.getLogger(__name__)
 
+PREPARE_LOCAL_COPY_TASKS = 20
+DOWNLOAD_REMOTE_COPY_TASKS = 20
+APPLY_DELTA_TASKS = 20
+
 
 class TestOTAUpdateStatsCollector:
-    WORKLOAD_COUNT = 3000
-    TOTAL_SIZE = WORKLOAD_COUNT * 2
-    TOTAL_FILE_NUM = WORKLOAD_COUNT
 
     @pytest.fixture(autouse=True)
-    def update_stats_collector(self):
-        _collector = OTAUpdateStatsCollector()
-        try:
-            self._collector = _collector
-            _collector.start()
-            _collector.store.total_files_num = self.TOTAL_FILE_NUM  # check init
-            _collector.store.total_files_size_uncompressed = (
-                self.TOTAL_SIZE
-            )  # check init
-            yield
-        finally:
-            _collector.stop()
+    def setup_test(self):
+        self._collector = OTAUpdateStatsCollector()
 
-    def workload(self, idx: int):
-        """
-        idx mod 3 == 0 is DOWNLOAD,
-        idx mod 3 == 1 is COPY,
-        idx mod 3 == 2 is APPLY_UPDATE,
+    def _common_worker(self, *, op: ProcessOperation):
+        time.sleep(random.random())
+        self._collector.report_stat(
+            OperationRecord(
+                op=op,
+                processed_file_num=1,
+                processed_file_size=1,
+            )
+        )
 
-        For each op, elapsed_ns is 1, size is 2, download_bytes is 1
-        """
-        _remainder = idx % 3
-        _report = RegInfProcessedStats(elapsed_ns=1, size=2)
-        if _remainder == 0:
-            _report.op = RegProcessOperation.DOWNLOAD_REMOTE_COPY
-            _report.downloaded_bytes = 1
-            self._collector.report_download_ota_files(_report)
-        elif _remainder == 1:
-            _report.op = RegProcessOperation.PREPARE_LOCAL_COPY
-            self._collector.report_prepare_local_copy(_report)
-        else:
-            # NOTE: simulate special treatment for APPLY_DELTA operation.
-            #       check update_stats.py:L116-119 for more details.
-            _report.op = RegProcessOperation.APPLY_DELTA
-            self._collector.report_apply_delta([_report, _report])
+    def test_collecting(self):
+        _prepare_local_copy_worker = partial(
+            self._common_worker, op=ProcessOperation.PREPARE_LOCAL_COPY
+        )
+        _download_remote_copy_worker = partial(
+            self._common_worker, op=ProcessOperation.DOWNLOAD_REMOTE_COPY
+        )
+        _apply_update_worker = partial(
+            self._common_worker, op=ProcessOperation.APPLY_DELTA
+        )
 
-    def test_ota_update_stats_collecting(self):
-        self._collector.store.total_files_num = self.TOTAL_FILE_NUM
-        with ThreadPoolExecutor(max_workers=6) as pool:
-            for idx in range(self.WORKLOAD_COUNT):
-                pool.submit(
-                    self.workload,
-                    idx,
-                )
-        # wait until all reported stats are processed
-        self._collector.wait_staging()
+        collector = self._collector
+        collector.start_collector()
+        logger.info("collector started")
 
-        # check result
-        _snapshot = self._collector.get_snapshot()
-        logger.info(f"{_snapshot=}")
-        # assert static info
-        assert _snapshot.total_files_num == self.TOTAL_FILE_NUM
-        assert _snapshot.total_files_size_uncompressed == self.TOTAL_SIZE
-        # total processed files num/size
-        assert _snapshot.processed_files_num == self.TOTAL_FILE_NUM
-        assert _snapshot.processed_files_size == self.TOTAL_SIZE
-        # download operation
-        assert _snapshot.downloaded_files_num == self.TOTAL_FILE_NUM // 3
-        assert _snapshot.downloaded_files_size == self.TOTAL_SIZE // 3
-        # NOTE: downloading_elapsed_time and downloaded_bytes is collected
-        #       by accessing the downloader's properties, so comment out the following
-        #       2 asserts.
-        # assert (
-        #     _snapshot.downloading_elapsed_time.export_pb().ToNanoseconds()
-        #     == self.WORKLOAD_COUNT // 3
-        # )
-        # actual download_bytes is half of the file_size_processed_download to
-        # simulate compression enabled scheme
-        # assert _snapshot.downloaded_bytes == _snapshot.downloaded_files_size // 2
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            collector.delta_calculation_started()
+            for _ in range(PREPARE_LOCAL_COPY_TASKS):
+                pool.submit(_prepare_local_copy_worker)
+        collector.delta_calculation_finished()
+        logger.info("delta calculation finished")
 
-        # NOTE(20240703): we switch to track the delta generating elapsed time with the wall clock
-        #   time instead of CPU consuming time.
-        # prepare local copy operation
-        # assert (
-        #     _snapshot.delta_generating_elapsed_time.export_pb().ToNanoseconds()
-        #     == self.WORKLOAD_COUNT // 3
-        # )
-        # # applying update operation
-        # assert (
-        #     _snapshot.update_applying_elapsed_time.export_pb().ToNanoseconds()
-        #     == self.WORKLOAD_COUNT // 3
-        # )
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            collector.download_started()
+            for _ in range(DOWNLOAD_REMOTE_COPY_TASKS):
+                pool.submit(_download_remote_copy_worker)
+        collector.download_finished()
+        logger.info("download finished")
+
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            collector.apply_update_started()
+            for _ in range(APPLY_DELTA_TASKS):
+                pool.submit(_apply_update_worker)
+        collector.apply_update_finished()
+        logger.info("apply update finished")
+
+        self._collector.shutdown_collector()
+
+        # ------ check the result ------ #
+        assert collector.total_elapsed_time
+        assert collector.delta_calculation_elapsed_time
+        assert collector.download_elapsed_time
+        assert collector.apply_update_elapsed_time
+        assert (
+            collector.total_elapsed_time
+            >= collector.delta_calculation_elapsed_time
+            + collector.download_elapsed_time
+            + collector.apply_update_elapsed_time
+        )
+        assert (
+            collector.processed_files_num
+            == PREPARE_LOCAL_COPY_TASKS + DOWNLOAD_REMOTE_COPY_TASKS + APPLY_DELTA_TASKS
+        )
+        assert (
+            collector.processed_files_size
+            == PREPARE_LOCAL_COPY_TASKS + DOWNLOAD_REMOTE_COPY_TASKS + APPLY_DELTA_TASKS
+        )
+        assert collector.downloaded_files_num == DOWNLOAD_REMOTE_COPY_TASKS
+        assert collector.downloaded_files_size == DOWNLOAD_REMOTE_COPY_TASKS


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce.

For better understanding, adding reason/motivation of this PR are also recommended.
-->

This PR re-implements the OTA progress stats collector implementation as it is out-of-date considering the recent changes to otaclient module. The new implementation is simpler and fits the current otaclient module.

Other changes:
1. otaclient: use DownloaderPool's watchdog func instead of OTAUpdater's one.
2. fix tests cannot exit cleanly on failure due to background OTA image server process doesn't exit.
3. OTAUpdater implements a minimum 1s interval for status query and implements the cache of status response. Query frequent than min interval will be responded with cached status response. 

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file(s) that covers the change(s) is implemented.
- [x] local test is passed.
- [x] VM test is passed, the progress is collected without problem or incorrectness.
