### PR TITLE
refactor: refine persist_file_handling internal implementation

### DIFF
--- a/src/otaclient/app/ota_client.py
+++ b/src/otaclient/app/ota_client.py
@@ -377,7 +377,11 @@ class _OTAUpdater:
                 )
                 continue
 
-            _handler.preserve_persist_entry(_per_fpath)
+            try:
+                _handler.preserve_persist_entry(_per_fpath)
+            except Exception as e:
+                _err_msg = f"failed to preserve {_per_fpath}: {e!r}, skip"
+                logger.warning(_err_msg)
 
     def _execute_update(self):
         """Implementation of OTA updating."""

--- a/src/otaclient/app/ota_client.py
+++ b/src/otaclient/app/ota_client.py
@@ -377,10 +377,7 @@ class _OTAUpdater:
                 )
                 continue
 
-            if (
-                _per_fpath.is_file() or _per_fpath.is_dir() or _per_fpath.is_symlink()
-            ):  # NOTE: not equivalent to perinf.path.exists()
-                _handler.preserve_persist_entry(_per_fpath)
+            _handler.preserve_persist_entry(_per_fpath)
 
     def _execute_update(self):
         """Implementation of OTA updating."""

--- a/src/otaclient_common/persist_file_handling.py
+++ b/src/otaclient_common/persist_file_handling.py
@@ -191,7 +191,7 @@ class PersistFilesHandler:
         # NOTE: always check if symlink first as is_file/is_dir/exists all follow_symlinks
         if src_path.is_symlink():
             logger.info(
-                f"preserving symlink: {_persist_entry}, points to {os.readlink(_persist_entry)}"
+                f"preserving symlink: {_persist_entry}, points to {os.readlink(src_path)}"
             )
             self._rm_target(dst_path)
             self._prepare_parent(origin_entry)

--- a/src/otaclient_common/persist_file_handling.py
+++ b/src/otaclient_common/persist_file_handling.py
@@ -27,6 +27,7 @@ from otaclient_common.linux import (
     map_gid_by_grpnam,
     map_uid_by_pwnam,
 )
+from otaclient_common.typing import StrOrPath
 
 logger = logging.getLogger(__name__)
 
@@ -43,13 +44,13 @@ class PersistFilesHandler:
 
     def __init__(
         self,
-        src_passwd_file: str | Path,
-        src_group_file: str | Path,
-        dst_passwd_file: str | Path,
-        dst_group_file: str | Path,
+        src_passwd_file: StrOrPath,
+        src_group_file: StrOrPath,
+        dst_passwd_file: StrOrPath,
+        dst_group_file: StrOrPath,
         *,
-        src_root: str | Path,
-        dst_root: str | Path,
+        src_root: StrOrPath,
+        dst_root: StrOrPath,
     ):
         self._uid_mapper = lru_cache()(
             partial(
@@ -87,7 +88,7 @@ class PersistFilesHandler:
         return _mapped_gid
 
     def _chown_with_mapping(
-        self, _src_stat: os.stat_result, _dst_path: str | Path
+        self, _src_stat: os.stat_result, _dst_path: StrOrPath
     ) -> None:
         _src_uid, _src_gid = _src_stat.st_uid, _src_stat.st_gid
         try:
@@ -196,11 +197,11 @@ class PersistFilesHandler:
 
     # API
 
-    def preserve_persist_entry(self, _persist_entry: str | Path):
+    def preserve_persist_entry(self, _persist_entry: StrOrPath):
         """Preserve <_persist_entry> from active slot to standby slot.
 
         Args:
-            _persist_entry (str | Path): The canonical path of the entry to be preserved.
+            _persist_entry (StrOrPath): The canonical path of the entry to be preserved.
 
         Raises:
             ValueError: Raised when src <_persist_entry> is not a regular file, symlink or directory,
@@ -232,7 +233,7 @@ class PersistFilesHandler:
 
         # ------ src is dir ------ #
         if src_path.is_dir():
-            logger.info(f"recursively preserve directory: {src_path}")
+            logger.info(f"recursively preserve directory: {_persist_entry}")
             self._prepare_parent(path_relative_to_root)
             self._recursively_prepare_dir(src_path)
             return
@@ -240,7 +241,7 @@ class PersistFilesHandler:
         # ------ src is not regular file/symlink/dir or missing ------ #
         _err_msg = f"{src_path=} doesn't exist"
         if src_path.exists():
-            _err_msg = f"src must be either a file/symlink/dir, skip {src_path=}"
+            _err_msg = f"src must be either a file/symlink/dir, skip {_persist_entry=}"
 
         logger.warning(_err_msg)
         raise ValueError(_err_msg)

--- a/src/otaclient_common/persist_file_handling.py
+++ b/src/otaclient_common/persist_file_handling.py
@@ -206,19 +206,16 @@ class PersistFilesHandler:
             self._prepare_file(src_path, dst_path)
             return
 
-        # ------ src is not regular file/symlink/dir ------ #
-        # we only process normal file/symlink/dir
-        if src_path.exists() and not src_path.is_dir():
-            _err_msg = f"{src_path=} must be either a file/symlink/dir, skip"
-            logger.warning(_err_msg)
-            return
-
-        # ------ src doesn't exist ------ #
-        if not src_path.exists():
-            _err_msg = f"{src_path=} not found"
-            logger.warning(_err_msg)
-            return
-
         # ------ src is dir ------ #
-        logger.info(f"recursively preserve directory: {src_path}")
-        self._recursively_prepare_dir(src_path, origin_entry=origin_entry)
+        if src_path.is_dir():
+            logger.info(f"recursively preserve directory: {src_path}")
+            self._recursively_prepare_dir(src_path, origin_entry=origin_entry)
+            return
+
+        # ------ src is not regular file/symlink/dir or missing ------ #
+        if src_path.exists():
+            _err_msg = f"src must be either a file/symlink/dir, skip {src_path=}"
+            logger.warning(_err_msg)
+        else:
+            _err_msg = f"{src_path=} doesn't exist"
+            logger.warning(_err_msg)

--- a/src/otaclient_common/persist_file_handling.py
+++ b/src/otaclient_common/persist_file_handling.py
@@ -175,10 +175,12 @@ class PersistFilesHandler:
             for _fname in fnames:
                 _src_fpath, _dst_fpath = src_cur_dpath / _fname, dst_cur_dpath / _fname
                 self._rm_target(_dst_fpath)
+
+                # NOTE that fnames also contain symlink to normal file
                 if _src_fpath.is_symlink():
                     self._prepare_symlink(_src_fpath, _dst_fpath)
-                    continue
-                self._prepare_file(_src_fpath, _dst_fpath)
+                else:
+                    self._prepare_file(_src_fpath, _dst_fpath)
 
             # symlinks to dirs also included in dnames, we must handle it
             for _dname in dnames:
@@ -186,6 +188,9 @@ class PersistFilesHandler:
                 if _src_dpath.is_symlink():
                     self._rm_target(_dst_dpath)
                     self._prepare_symlink(_src_dpath, _dst_dpath)
+                # NOTE that we don't need to create dir here, as os.walk will take us
+                #   to this folder later, we will create the folder in the dest when
+                #   we enter the src folder.
 
     # API
 

--- a/src/otaclient_common/persist_file_handling.py
+++ b/src/otaclient_common/persist_file_handling.py
@@ -106,12 +106,13 @@ class PersistFilesHandler:
     @staticmethod
     def _rm_target(_target: Path) -> None:
         """Remove target with proper methods."""
-        if not _target.exists():
-            return
         if _target.is_symlink() or _target.is_file():
             return _target.unlink(missing_ok=True)
         if _target.is_dir():
             return shutil.rmtree(_target, ignore_errors=True)
+        # NOTE that exists will follow symlink, so we need to check symlink first
+        if not _target.exists():
+            return
 
         raise ValueError(f"{_target} is not normal file/symlink/dir, failed to remove")
 

--- a/src/otaclient_common/persist_file_handling.py
+++ b/src/otaclient_common/persist_file_handling.py
@@ -182,6 +182,15 @@ class PersistFilesHandler:
     # API
 
     def preserve_persist_entry(self, _persist_entry: str | Path):
+        """Preserve <_persist_entry> from active slot to standby slot.
+
+        Args:
+            _persist_entry (str | Path): The canonical path of the entry to be preserved.
+
+        Raises:
+            ValueError: Raised when src <_persist_entry> is not a regular file, symlink or directory,
+                or failed to prepare destination.
+        """
         # persist_entry in persists.txt must be rooted at /
         origin_entry = Path(_persist_entry).relative_to("/")
         src_path = self._src_root / origin_entry
@@ -213,9 +222,9 @@ class PersistFilesHandler:
             return
 
         # ------ src is not regular file/symlink/dir or missing ------ #
+        _err_msg = f"{src_path=} doesn't exist"
         if src_path.exists():
             _err_msg = f"src must be either a file/symlink/dir, skip {src_path=}"
-            logger.warning(_err_msg)
-        else:
-            _err_msg = f"{src_path=} doesn't exist"
-            logger.warning(_err_msg)
+
+        logger.warning(_err_msg)
+        raise ValueError(_err_msg)

--- a/src/otaclient_common/persist_file_handling.py
+++ b/src/otaclient_common/persist_file_handling.py
@@ -106,14 +106,14 @@ class PersistFilesHandler:
     @staticmethod
     def _rm_target(_target: Path) -> None:
         """Remove target with proper methods."""
+        if not _target.exists():
+            return
         if _target.is_symlink() or _target.is_file():
             return _target.unlink(missing_ok=True)
-        elif _target.is_dir():
+        if _target.is_dir():
             return shutil.rmtree(_target, ignore_errors=True)
-        elif _target.exists():
-            raise ValueError(
-                f"{_target} is not normal file/symlink/dir, failed to remove"
-            )
+
+        raise ValueError(f"{_target} is not normal file/symlink/dir, failed to remove")
 
     def _prepare_symlink(self, _src_path: Path, _dst_path: Path) -> None:
         _dst_path.symlink_to(os.readlink(_src_path))


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce.

For better understanding, adding reason/motivation of this PR are also recommended.
-->

This PR refines the persist_file_handling module's internal implementation, reduces the code cognitive complexity, and refines the workflow of entry processing. Also now otaclient won't break out the OTA on failed entry during persist file handling.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file(s) that covers the change(s) is implemented.
- [x] local test is passed.

## Changes

<!-- A list of code change(s) that introduced by this PR. -->

## Behavior changes

Does this PR introduce behavior change(s)?

- [x] Yes, internal behaivor (will not impact user experience).

### Behavior with this PR

<!-- Behavior after the PR is introduced -->

OTA will not break on failed entry during persist file handling processing.
