### PR TITLE
deps: loosen the deps version specifying

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,20 +24,20 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "aiofiles==24.1",
+  "aiofiles<25,>=24.1",
   "aiohttp<3.10,>=3.9.5",
   "cryptography>=42.0.4,<44",
   "grpcio<1.54,>=1.53.2",
   "protobuf<4.22,>=4.21.12",
-  "pydantic==2.8",
-  "pydantic-settings==2.3.4",
-  "pyopenssl==24.1",
-  "pyyaml==6.0.1",
+  "pydantic<3,>=2.6",
+  "pydantic-settings<3,>=2.3",
+  "pyopenssl<25,>=24.1",
+  "pyyaml<7,>=6.0.1",
   "requests<2.33,>=2.32",
   "typing-extensions>=4.6.3",
-  "urllib3>=2.2.2,<2.3",
-  "uvicorn[standard]==0.30.1",
-  "zstandard==0.22",
+  "urllib3<2.3,>=2.2.2",
+  "uvicorn[standard]<0.31,>=0.30",
+  "zstandard<0.23,>=0.22",
 ]
 optional-dependencies.dev = [
   "black",


### PR DESCRIPTION
# Introduction

Currently otaclient requires many deps packages to exactly pin to a specific version, this is not very flexible and unnecessary. 
This PR loosens the package version specifying, all the packages now pin with a range with the following strategy:
1. for most packages, set the upper bound lower than the next API version, and set the lower bound to a recent usable version(**or a recent safe version if security fix is available**), for example, `cryptography>=42.0.4,<44`, in which the recent security fixed version if `42.0.4`.
2. for some packages, set the upper bound to the next revision level, for example, `requests<2.33,>=2.32`.
3. for packages without a fixed API level(with versioning schame like 0.x.y), set the upper bound to the next revision level.
4. don't set restriction on patch level, i.e., we allow any patch versions between two revision level.