### PR TITLE
build(deps): bump to simple-sqlite3-orm v0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "pyopenssl<25,>=24.1",
   "pyyaml<7,>=6.0.1",
   "requests<2.33,>=2.32",
-  "simple-sqlite3-orm @ https://github.com/pga2rn/simple-sqlite3-orm/releases/download/v0.2.0/simple_sqlite3_orm-0.2.0-py3-none-any.whl",
+  "simple-sqlite3-orm @ https://github.com/pga2rn/simple-sqlite3-orm/releases/download/v0.2.1/simple_sqlite3_orm-0.2.1-py3-none-any.whl",
   "typing-extensions>=4.6.3",
   "urllib3<2.3,>=2.2.2",
   "uvicorn[standard]<0.31,>=0.30",


### PR DESCRIPTION
Bumps simple-sqlite3-orm to v0.2.1.

Upstream fixes a problem related to using both RETURNING and LIMIT in DELETE stmt, see https://github.com/pga2rn/simple-sqlite3-orm/pull/19 for more details.

Bumps the version fixes otaproxy not working on ubuntu 22.04 and newer.