### PR TITLE
chore: prepare release for v3.8.0

### DIFF
--- a/src/otaclient/boot_control/_jetson_cboot.py
+++ b/src/otaclient/boot_control/_jetson_cboot.py
@@ -520,6 +520,9 @@ class JetsonCBootControl(BootControllerProtocol):
         # NOTE(20240417): rootfs slot is manually switched by set-active-boot-slot,
         #   so we need to manually set the slot as success after first reboot.
         if not self._cboot_control.unified_ab_enabled:
+            logger.info(
+                f"unified A/B is not enabled, set {current_rootfs_slot} boot succeeded."
+            )
             NVBootctrlJetsonCBOOT.mark_boot_successful(
                 current_rootfs_slot, target="rootfs"
             )


### PR DESCRIPTION
## What's Changed

### New Features
* feature: introduce firmware package control for NVIDIA Jetson device by @Bodong-Yang in https://github.com/tier4/ota-client/pull/376
* feat: add jetson-uefi boot control support, refine jetson-cboot boot control implementation by @Bodong-Yang in https://github.com/tier4/ota-client/pull/300
### Bug Fixes
* fix: proxy_info: allow to set string value to local_ota_proxy_listen_port field by @Bodong-Yang in https://github.com/tier4/ota-client/pull/326
* build(deps): bump to simple-sqlite3-orm v0.2.1 by @Bodong-Yang in https://github.com/tier4/ota-client/pull/369
### Improvements & Refinements
* refactor: improve the performance of active slot scanning by @Bodong-Yang in https://github.com/tier4/ota-client/pull/308
* refactor: project re-struct phase1, use hatch as build tool by @Bodong-Yang in https://github.com/tier4/ota-client/pull/310
* refactor: project restruct phase2 by @Bodong-Yang in https://github.com/tier4/ota-client/pull/311
* refactor: implement new ThreadPoolExecutorWithRetry to replace RetryTaskMap by @Bodong-Yang in https://github.com/tier4/ota-client/pull/314
* refactor: refine log_setting to support new src layout  by @Bodong-Yang in https://github.com/tier4/ota-client/pull/317
* refactor: rpi_boot: detects slot by partition layout, not by checking slot fslabel by @Bodong-Yang in https://github.com/tier4/ota-client/pull/321
* refactor: rpi_boot: use chroot to run flash-kernel, ditch double reboot strategy by @Bodong-Yang in https://github.com/tier4/ota-client/pull/318
* refactor: retry_task_map now takes initializer and initargs params by @Bodong-Yang in https://github.com/tier4/ota-client/pull/324
* refactor: create_standby: add semaphore during delta generating to limit pending tasks in memory by @Bodong-Yang in https://github.com/tier4/ota-client/pull/320
* refactor: implement downloader as a library module, provide Downloader and DownloaderPool by @Bodong-Yang in https://github.com/tier4/ota-client/pull/323
* refactor: DownloaderPool: implement watchdog func for breaking on max idling timeout by @Bodong-Yang in https://github.com/tier4/ota-client/pull/351
* refactor: re-implement the OTA progress stats collector by @Bodong-Yang in https://github.com/tier4/ota-client/pull/352
* refactor: otaclient module: restructure OTAUpdater, flatten nested internal methods by @Bodong-Yang in https://github.com/tier4/ota-client/pull/353
* refactor: refine persist_file_handling internal implementation by @Bodong-Yang in https://github.com/tier4/ota-client/pull/354
* refactor: ota_proxy: use simple-sqlite3-orm instead of vendoring an orm inside otaproxy package by @Bodong-Yang in https://github.com/tier4/ota-client/pull/363
* refactor(otaproxy): refine the implementation of cache streaming  by @Bodong-Yang in https://github.com/tier4/ota-client/pull/370
* refactor: project restruct phase3 by @Bodong-Yang in https://github.com/tier4/ota-client/pull/375
* refactor: include new protobuf generated code generated with new build system and grpcio-tools==1.57.0 by @Bodong-Yang in https://github.com/tier4/ota-client/pull/379
### Build, CI & Dependencies
* ci: fix sonarcloud setting by @Bodong-Yang in https://github.com/tier4/ota-client/pull/315
* ci: minor fix to test CI by @Bodong-Yang in https://github.com/tier4/ota-client/pull/316
* deps: bump requests to 2.32  by @Bodong-Yang in https://github.com/tier4/ota-client/pull/319
* ci(pre-commit): add pre-commit-hooks check-yaml and check-toml by @Bodong-Yang in https://github.com/tier4/ota-client/pull/328
* ci(deps): enable dependabot version updates by @Bodong-Yang in https://github.com/tier4/ota-client/pull/327
* build(deps): Bump softprops/action-gh-release from 1 to 2 by @dependabot in https://github.com/tier4/ota-client/pull/329
* build(deps): Bump zstandard from 0.18 to 0.22.0 by @dependabot in https://github.com/tier4/ota-client/pull/333
* ci: deprecate the old proto version tracking github action by @Bodong-Yang in https://github.com/tier4/ota-client/pull/338
* build(deps): Bump pytest-mock from 3.8.2 to 3.14.0 by @dependabot in https://github.com/tier4/ota-client/pull/337
* build(deps): Bump MishaKav/pytest-coverage-comment from 1.1.51 to 1.1.52 by @dependabot in https://github.com/tier4/ota-client/pull/341
* build(deps): Bump pydantic-settings from 2.2.1 to 2.3.4 by @dependabot in https://github.com/tier4/ota-client/pull/349
* build(deps): Bump pydantic from 2.7 to 2.8.0 by @dependabot in https://github.com/tier4/ota-client/pull/347
* build(deps): bump to use pyyaml 6.0.1 by @Bodong-Yang in https://github.com/tier4/ota-client/pull/350
* build(deps): Bump uvicorn[standard] from 0.20 to 0.30.1 by @dependabot in https://github.com/tier4/ota-client/pull/348
* build(deps): Bump aiofiles from 22.1 to 24.1.0 by @dependabot in https://github.com/tier4/ota-client/pull/343
* build(deps): Update cryptography requirement from <43,>=42.0.4 to >=42.0.4,<44 by @dependabot in https://github.com/tier4/ota-client/pull/357
* deps: loosen the deps version specifying by @Bodong-Yang in https://github.com/tier4/ota-client/pull/366
* ci: introduce test for multiple OS version(ubuntu-18.04 and ubuntu-22.04) by @Bodong-Yang in https://github.com/tier4/ota-client/pull/368
* build(deps): Update aiohttp requirement from <3.10,>=3.9.5 to >=3.9.5,<3.11 by @dependabot in https://github.com/tier4/ota-client/pull/373
* build(deps): Bump zstandard from >=0.22,<0.23 to >=0.22,<0.24 by @dependabot in https://github.com/tier4/ota-client/pull/356
* ci(proto): introduce modern build mechanism for generating otaclient service API proto package by @Bodong-Yang in https://github.com/tier4/ota-client/pull/377
* ci: minor fix to release ci by @Bodong-Yang in https://github.com/tier4/ota-client/pull/380
* ci: introduce ruff as linter by @Bodong-Yang in https://github.com/tier4/ota-client/pull/381
### Docs Updates
* docs: cleanup the old out-of-date docs by @Bodong-Yang in https://github.com/tier4/ota-client/pull/307
### Chore & Misc.
* chore(tools): remove out-of-date unmaintained tools  by @Bodong-Yang in https://github.com/tier4/ota-client/pull/313
* chore(tools): add a simple tool for triggering OTA update locally by @Bodong-Yang in https://github.com/tier4/ota-client/pull/325
* chore: sonarcloud: exclude protobuf generated files; release_ci: only publish artifacts on release event by @Bodong-Yang in https://github.com/tier4/ota-client/pull/378
### Other Changes
* ci: depbot: enlarge open-pull-requests-limit to 10 by @Bodong-Yang in https://github.com/tier4/ota-client/pull/345
* ci: configure github action release notes generation by @Bodong-Yang in https://github.com/tier4/ota-client/pull/387

**Full Changelog**: https://github.com/tier4/ota-client/compare/v3.7.1...v3.8.0-rc2

## Release test
https://tier4.atlassian.net/wiki/x/aoOyww
https://tier4.atlassian.net/wiki/x/LYbEww
https://tier4.atlassian.net/wiki/x/A4GZx
https://tier4.atlassian.net/wiki/x/LwHAx

## Related links
https://tier4.atlassian.net/browse/RT4-11854