### PR TITLE
refactor(otaclient_common): retry_task_map now handles edge condition when input task iterable yields no task

### DIFF
--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -128,7 +128,10 @@ class ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
 
     def _fut_gen(self, interval: int) -> Generator[Future[Any], Any, None]:
         finished_tasks = 0
-        while self._total_task_num != -1 and finished_tasks != self._total_task_num:
+        while finished_tasks == 0 or finished_tasks != self._total_task_num:
+            if self._total_task_num < 0:
+                return
+
             if self._shutdown or self._broken or concurrent_fut_thread._shutdown:
                 logger.warning(
                     f"failed to ensure all tasks, {finished_tasks=}, {self._total_task_num=}"

--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -66,7 +66,7 @@ class ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
         self._start_lock, self._started = threading.Lock(), False
         self._total_task_num = 0
         """
-        NOTE: 
+        NOTE:
             1. when is 0, the tasks dispatch is not yet started.
             2. when becomes -1, it means that the input tasks iterable yields
                 no tasks, the task execution gen should stop immediately.

--- a/tests/test_otaclient_common/test_retry_task_map.py
+++ b/tests/test_otaclient_common/test_retry_task_map.py
@@ -138,3 +138,16 @@ class TestRetryTaskMap:
                     count += 1
         assert all(self._succeeded_tasks)
         assert TASKS_COUNT == count
+
+
+def test_input_yield_no_task():
+    count = 0
+    with retry_task_map.ThreadPoolExecutorWithRetry(
+        max_concurrent=MAX_CONCURRENT,
+    ) as executor:
+        for _ in executor.ensure_tasks(
+            func=lambda _: _,
+            iterable=[],
+        ):
+            count += 1
+    assert count == 0


### PR DESCRIPTION
This PR handles an edge condition when input task iterable yields nothing, which might result in the retry_task_map hang.