### PR TITLE
fix(boot_control): jetson_common, grub: support detecting and update rootfs indicating string that use device path 

### DIFF
--- a/src/otaclient/boot_control/_grub.py
+++ b/src/otaclient/boot_control/_grub.py
@@ -113,11 +113,11 @@ class GrubHelper:
     )
     linux_pa: ClassVar[re.Pattern] = re.compile(
         r"(?P<load_linux>^\s+linux\s+(?P<kernel_path>.*vmlinuz-(?P<ver>[\.\w\-]*)))"
-        r"\s+(?P<cmdline>.*(?P<rootfs>root=(?P<rootfs_uuid_str>[\w\-=]*)).*)\s*$",
+        r"\s+(?P<cmdline>.*(?P<rootfs>root=(?P<rootfs_uuid_str>[^\s]*)).*)\s*$",
         re.MULTILINE,
     )
     rootfs_pa: ClassVar[re.Pattern] = re.compile(
-        r"(?P<rootfs>root=(?P<rootfs_uuid_str>[\w\-=]*))"
+        r"(?P<rootfs>root=(?P<rootfs_uuid_str>[^\s]*))"
     )
 
     initrd_pa: ClassVar[re.Pattern] = re.compile(

--- a/src/otaclient/boot_control/_jetson_common.py
+++ b/src/otaclient/boot_control/_jetson_common.py
@@ -380,7 +380,7 @@ def update_extlinux_cfg(_input: str, partuuid: str) -> str:
         append_l: str = ma.group(0)
         if append_l.startswith("#"):
             return append_l
-        res, n = re.compile(r"root=[\w\-=]*").subn(repl, append_l)
+        res, n = re.compile(r"root=[^\s]*").subn(repl, append_l)
         if not n:  # this APPEND line doesn't contain root= placeholder
             res = f"{append_l} {repl}"
 

--- a/tests/data/extlinux.conf-r35.4.1-template1
+++ b/tests/data/extlinux.conf-r35.4.1-template1
@@ -10,6 +10,21 @@ LABEL primary
 FDT /boot/tegra234-orin-agx-cti-AGX201.dtb
       APPEND ${cbootargs} rw rootwait rootfstype=ext4 mminit_loglevel=4 console=ttyTCU0,115200 console=ttyAMA0,115200 console=tty0 firmware_class.path=/etc/firmware fbcon=map:0 net.ifnames=0 nospectre_bhb
 
+LABEL with rootfs specified by dev path
+      MENU LABEL primary kernel
+      LINUX /boot/Image
+      INITRD /boot/initrd
+FDT /boot/tegra234-orin-agx-cti-AGX201.dtb
+      APPEND ${cbootargs} rw root=/dev/mmcblk0p1 rootwait rootfstype=ext4 mminit_loglevel=4 console=ttyTCU0,115200 console=ttyAMA0,115200 console=tty0 firmware_class.path=/etc/firmware fbcon=map:0 net.ifnames=0 nospectre_bhb
+
+LABEL with rootfs specified by PARTUUID
+      MENU LABEL primary kernel
+      LINUX /boot/Image
+      INITRD /boot/initrd
+FDT /boot/tegra234-orin-agx-cti-AGX201.dtb
+      APPEND ${cbootargs} rw rootwait root=PARTUUID=aabbccdd rootfstype=ext4 mminit_loglevel=4 console=ttyTCU0,115200 console=ttyAMA0,115200 console=tty0 firmware_class.path=/etc/firmware fbcon=map:0 net.ifnames=0 nospectre_bhb
+
+
 # When testing a custom kernel, it is recommended that you create a backup of
 # the original kernel and add a new entry to this file so that the device can
 # fallback to the original kernel. To do this:

--- a/tests/data/extlinux.conf-r35.4.1-updated1
+++ b/tests/data/extlinux.conf-r35.4.1-updated1
@@ -10,6 +10,21 @@ LABEL primary
 FDT /boot/tegra234-orin-agx-cti-AGX201.dtb
       APPEND ${cbootargs} rw rootwait rootfstype=ext4 mminit_loglevel=4 console=ttyTCU0,115200 console=ttyAMA0,115200 console=tty0 firmware_class.path=/etc/firmware fbcon=map:0 net.ifnames=0 nospectre_bhb root=PARTUUID=11aa-bbcc-22dd
 
+LABEL with rootfs specified by dev path
+      MENU LABEL primary kernel
+      LINUX /boot/Image
+      INITRD /boot/initrd
+FDT /boot/tegra234-orin-agx-cti-AGX201.dtb
+      APPEND ${cbootargs} rw root=PARTUUID=11aa-bbcc-22dd rootwait rootfstype=ext4 mminit_loglevel=4 console=ttyTCU0,115200 console=ttyAMA0,115200 console=tty0 firmware_class.path=/etc/firmware fbcon=map:0 net.ifnames=0 nospectre_bhb
+
+LABEL with rootfs specified by PARTUUID
+      MENU LABEL primary kernel
+      LINUX /boot/Image
+      INITRD /boot/initrd
+FDT /boot/tegra234-orin-agx-cti-AGX201.dtb
+      APPEND ${cbootargs} rw rootwait root=PARTUUID=11aa-bbcc-22dd rootfstype=ext4 mminit_loglevel=4 console=ttyTCU0,115200 console=ttyAMA0,115200 console=tty0 firmware_class.path=/etc/firmware fbcon=map:0 net.ifnames=0 nospectre_bhb
+
+
 # When testing a custom kernel, it is recommended that you create a backup of
 # the original kernel and add a new entry to this file so that the device can
 # fallback to the original kernel. To do this:


### PR DESCRIPTION
# Introduction

Currently, the boot control implementations for grub and jetson_* assume that the rootfs indicating string(in the form of `root=...`) is either using PARTUUID or UUID to specify rootfs or this string is not presented, but not covering the case of directly using device path. This PR fixes this issue and support updating rootfs indicating string that previously was by device path.

NOTE that although we support parsing device path now, we still not support device path with space!