### PR TITLE
fix: retry_task_map: fix mem leak when network is totally cut off

### DIFF
--- a/src/otaclient/app/configs.py
+++ b/src/otaclient/app/configs.py
@@ -122,7 +122,7 @@ class BaseConfig(_InternalSettings):
     # if retry keeps failing without any success in
     # DOWNLOAD_GROUP_NO_SUCCESS_RETRY_TIMEOUT time, failed the whole
     # download task group and raise NETWORK OTA error.
-    MAX_CONCURRENT_DOWNLOAD_TASKS = 64
+    MAX_CONCURRENT_DOWNLOAD_TASKS = 128
     DOWNLOAD_GROUP_INACTIVE_TIMEOUT = 5 * 60  # seconds
     DOWNLOAD_GROUP_BACKOFF_MAX = 12  # seconds
     DOWNLOAD_GROUP_BACKOFF_FACTOR = 1  # seconds

--- a/src/otaclient/app/configs.py
+++ b/src/otaclient/app/configs.py
@@ -122,7 +122,7 @@ class BaseConfig(_InternalSettings):
     # if retry keeps failing without any success in
     # DOWNLOAD_GROUP_NO_SUCCESS_RETRY_TIMEOUT time, failed the whole
     # download task group and raise NETWORK OTA error.
-    MAX_CONCURRENT_DOWNLOAD_TASKS = 128
+    MAX_CONCURRENT_DOWNLOAD_TASKS = 64
     DOWNLOAD_GROUP_INACTIVE_TIMEOUT = 5 * 60  # seconds
     DOWNLOAD_GROUP_BACKOFF_MAX = 12  # seconds
     DOWNLOAD_GROUP_BACKOFF_FACTOR = 1  # seconds

--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -114,8 +114,7 @@ class ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
                     logger.warning("draining the workitem queue ...")
                     # drain the worker queues to cancel all the futs
                     with contextlib.suppress(Empty):
-                        _workitem = self._work_queue.get_nowait()
-                        _workitem.future.cancel()
+                        self._work_queue.get_nowait()
                     return self.shutdown(wait=True)
             time.sleep(interval)
 

--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -112,10 +112,12 @@ class ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
                         f"custom watchdog func failed: {e!r}, shutdown the pool"
                     )
                     logger.warning("draining the workitem queue ...")
+                    self.shutdown(wait=False)
                     # drain the worker queues to cancel all the futs
                     with contextlib.suppress(Empty):
-                        self._work_queue.get_nowait()
-                    return self.shutdown(wait=True)
+                        while True:
+                            self._work_queue.get_nowait()
+                    return
             time.sleep(interval)
 
     def _task_done_cb(

--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -217,10 +217,6 @@ class ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
                 return
 
             self._total_task_num = _tasks_count
-            if _tasks_count > 0:
-                logger.info(f"finish dispatch {_tasks_count} tasks")
-            else:
-                logger.warning("no task is scheduled!")
 
         threading.Thread(target=_dispatcher, daemon=True).start()
 

--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -198,17 +198,19 @@ class ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
             _tasks_count = -1  # means no task is scheduled
             try:
                 for _tasks_count, item in enumerate(iterable, start=1):
-                    while not self._concurrent_semaphore.acquire(
-                        timeout=SE_ACQUIRE_TIMEOUT
-                    ):
+                    while True:
                         if self._shutdown:
                             logger.warning("threadpool is closing, exit")
                             return  # directly exit on shutdown
 
-                        fut = self.submit(func, item)
-                        fut.add_done_callback(
-                            partial(self._task_done_cb, item=item, func=func)
-                        )
+                        if self._concurrent_semaphore.acquire(
+                            timeout=SE_ACQUIRE_TIMEOUT
+                        ):
+                            fut = self.submit(func, item)
+                            fut.add_done_callback(
+                                partial(self._task_done_cb, item=item, func=func)
+                            )
+                            break
             except Exception as e:
                 logger.error(f"tasks dispatcher failed: {e!r}, abort")
                 self.shutdown(wait=True)

--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -100,7 +100,11 @@ class ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
     ) -> None:
         """Watchdog will shutdown the threadpool on certain conditions being met."""
         while not self._shutdown and not concurrent_fut_thread._shutdown:
-            if max_retry and self._retry_count > max_retry:
+            if (
+                max_retry is not None
+                and max_retry > 0
+                and self._retry_count > max_retry
+            ):
                 logger.warning(f"exceed {max_retry=}, abort")
                 return self.shutdown(wait=True)
 

--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -101,7 +101,7 @@ class ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
         """Watchdog will shutdown the threadpool on certain conditions being met."""
         while not self._shutdown and not concurrent_fut_thread._shutdown:
             if (
-                max_retry is not None
+                isinstance(max_retry, int)
                 and max_retry > 0
                 and self._retry_count > max_retry
             ):

--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -139,6 +139,10 @@ class ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
                 logger.warning(
                     f"failed to ensure all tasks, {finished_tasks=}, {self._total_task_num=}"
                 )
+                # drain the _fut_queue
+                with contextlib.suppress(Empty):
+                    while True:
+                        self._fut_queue.get_nowait()
                 raise TasksEnsureFailed  # raise exc to upper caller
 
             try:

--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -213,6 +213,10 @@ class ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
                 return
 
             self._total_task_num = _tasks_count
+            if _tasks_count > 0:
+                logger.info(f"finish dispatch {_tasks_count} tasks")
+            else:
+                logger.warning("no task is scheduled!")
 
         threading.Thread(target=_dispatcher, daemon=True).start()
 


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->

Previously, when handling failed task, the retry_task_map first releases the semaphore, and then reschedules the failed task directly without acquire the semaphore again. This results in the concurrent tasks semaphore being escaped when there are a lot of failed tasks. 
This is especially critical when the network is totally cut off, the failed tasks are pilling up and new tasks are still being scheduled, resulting in memory leaks.

This PR fixes the above problem by fixing the task_done_cb, now when handling and re-scheduling the failed tasks, the semaphore will be kept. semaphore will only be released when the task is done successfully, or the thread-pool shutdowns.

Other refinements to the retry_task_map includes:
1. watchdog: when watchdog func failed, watchdog thread will try to drain the pending workitem queue.
2. fut_gen: when thread-pool shutdowns, drain the finished futures queue.
3. dispatcher: directly exits when thread-pool shutdowns.
4. watchdog: refine the watchdog thread implementation.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file that covers the bug case(s) is implemented.
- [x] local test is passed.
- [x] e2e normal OTA test with virtual machine passed.
- [x] e2e OTA test with cutoff network with virtual machine passed, no memory leak is observed.

## Before & after fix

Before fix, the mem will leak depends on how many tasks are waited for scheduled. After fix, the number of failed tasks and already scheduled tasks are limited by the concurrency semaphore, the mem leak is resolved.

## Ticket

<!-- List of tickets or links related to this PR -->

https://tier4.atlassian.net/browse/RT4-12271