### PR TITLE
refactor: create otaclient_common._io module for holding io related helper funcs

### DIFF
--- a/.github/tools/gen_requirements_txt.py
+++ b/.github/tools/gen_requirements_txt.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import sys
 from typing import Any
 
-import tomllib
+import tomllib  # type: ignore[import]
 
 
 def gen_requirements_txt(pyproject_cfg: dict[str, Any]) -> str:

--- a/src/otaclient/app/main.py
+++ b/src/otaclient/app/main.py
@@ -33,7 +33,7 @@ from otaclient.app.ota_client_stub import OTAClientServiceStub
 from otaclient.log_setting import configure_logging
 from otaclient_api.v2 import otaclient_v2_pb2_grpc as v2_grpc
 from otaclient_api.v2.api_stub import OtaClientServiceV2
-from otaclient_common.common import read_str_from_file, write_str_to_file_sync
+from otaclient_common._io import read_str_from_file, write_str_to_file_atomic
 
 # configure logging before any code being executed
 configure_logging()
@@ -56,7 +56,7 @@ def _check_other_otaclient():
     _run_dir.mkdir(parents=True, exist_ok=True)
     os.chmod(_run_dir, 0o550)
     # write our pid to the lock file
-    write_str_to_file_sync(cfg.OTACLIENT_PID_FILE, f"{os.getpid()}")
+    write_str_to_file_atomic(cfg.OTACLIENT_PID_FILE, f"{os.getpid()}")
 
 
 def create_otaclient_grpc_server():

--- a/src/otaclient/app/main.py
+++ b/src/otaclient/app/main.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 def _check_other_otaclient():
     """Check if there is another otaclient instance running."""
     # create a lock file to prevent multiple ota-client instances start
-    if pid := read_str_from_file(cfg.OTACLIENT_PID_FILE):
+    if pid := read_str_from_file(cfg.OTACLIENT_PID_FILE, _default=""):
         # running process will have a folder under /proc
         if Path(f"/proc/{pid}").is_dir():
             logger.error(f"another instance of ota-client({pid=}) is running, abort")

--- a/src/otaclient/boot_control/_common.py
+++ b/src/otaclient/boot_control/_common.py
@@ -26,12 +26,8 @@ from typing import Callable, Literal, NoReturn, Optional, Union
 
 from otaclient.app.configs import config as cfg
 from otaclient_api.v2 import types as api_types
-from otaclient_common.common import (
-    read_str_from_file,
-    subprocess_call,
-    subprocess_check_output,
-    write_str_to_file_sync,
-)
+from otaclient_common._io import read_str_from_file, write_str_to_file_atomic
+from otaclient_common.common import subprocess_call, subprocess_check_output
 from otaclient_common.typing import StrOrPath
 
 logger = logging.getLogger(__name__)
@@ -583,30 +579,30 @@ class OTAStatusFilesControl:
     # slot_in_use control
 
     def _store_current_slot_in_use(self, _slot: str):
-        write_str_to_file_sync(
+        write_str_to_file_atomic(
             self.current_ota_status_dir / cfg.SLOT_IN_USE_FNAME, _slot
         )
 
     def _store_standby_slot_in_use(self, _slot: str):
-        write_str_to_file_sync(
+        write_str_to_file_atomic(
             self.standby_ota_status_dir / cfg.SLOT_IN_USE_FNAME, _slot
         )
 
     def _load_current_slot_in_use(self) -> Optional[str]:
         if res := read_str_from_file(
-            self.current_ota_status_dir / cfg.SLOT_IN_USE_FNAME, default=""
+            self.current_ota_status_dir / cfg.SLOT_IN_USE_FNAME, _default=""
         ):
             return res
 
     # status control
 
     def _store_current_status(self, _status: api_types.StatusOta):
-        write_str_to_file_sync(
+        write_str_to_file_atomic(
             self.current_ota_status_dir / cfg.OTA_STATUS_FNAME, _status.name
         )
 
     def _store_standby_status(self, _status: api_types.StatusOta):
-        write_str_to_file_sync(
+        write_str_to_file_atomic(
             self.standby_ota_status_dir / cfg.OTA_STATUS_FNAME, _status.name
         )
 
@@ -621,7 +617,7 @@ class OTAStatusFilesControl:
     # version control
 
     def _store_standby_version(self, _version: str):
-        write_str_to_file_sync(
+        write_str_to_file_atomic(
             self.standby_ota_status_dir / cfg.OTA_VERSION_FNAME,
             _version,
         )
@@ -680,8 +676,7 @@ class OTAStatusFilesControl:
     def load_active_slot_version(self) -> str:
         return read_str_from_file(
             self.current_ota_status_dir / cfg.OTA_VERSION_FNAME,
-            missing_ok=True,
-            default=cfg.DEFAULT_VERSION_STR,
+            _default=cfg.DEFAULT_VERSION_STR,
         )
 
     def on_failure(self):
@@ -794,4 +789,4 @@ class SlotMountHelper:
 
 
 def cat_proc_cmdline(target: str = "/proc/cmdline") -> str:
-    return read_str_from_file(target, missing_ok=False)
+    return read_str_from_file(target)

--- a/src/otaclient/boot_control/_common.py
+++ b/src/otaclient/boot_control/_common.py
@@ -608,7 +608,7 @@ class OTAStatusFilesControl:
 
     def _load_current_status(self) -> Optional[api_types.StatusOta]:
         if _status_str := read_str_from_file(
-            self.current_ota_status_dir / cfg.OTA_STATUS_FNAME
+            self.current_ota_status_dir / cfg.OTA_STATUS_FNAME, _default=""
         ).upper():
             with contextlib.suppress(KeyError):
                 # invalid status string
@@ -789,4 +789,4 @@ class SlotMountHelper:
 
 
 def cat_proc_cmdline(target: str = "/proc/cmdline") -> str:
-    return read_str_from_file(target)
+    return read_str_from_file(target, _default="")

--- a/src/otaclient/boot_control/_grub.py
+++ b/src/otaclient/boot_control/_grub.py
@@ -794,7 +794,7 @@ class GrubController(BootControllerProtocol):
         )
 
         # standby partition fstab (to be merged)
-        fstab_standby = read_str_from_file(standby_slot_fstab)
+        fstab_standby = read_str_from_file(standby_slot_fstab, _default="")
         fstab_standby_dict: Dict[str, re.Match] = {}
 
         for line in fstab_standby.splitlines():
@@ -804,7 +804,7 @@ class GrubController(BootControllerProtocol):
 
         # merge entries
         merged: List[str] = []
-        fstab_active = read_str_from_file(active_slot_fstab)
+        fstab_active = read_str_from_file(active_slot_fstab, _default="")
         for line in fstab_active.splitlines():
             if ma := fstab_entry_pa.match(line):
                 mp = ma.group("mount_point")

--- a/src/otaclient/boot_control/_grub.py
+++ b/src/otaclient/boot_control/_grub.py
@@ -794,7 +794,7 @@ class GrubController(BootControllerProtocol):
         )
 
         # standby partition fstab (to be merged)
-        fstab_standby = read_str_from_file(standby_slot_fstab, _default="")
+        fstab_standby = read_str_from_file(standby_slot_fstab)
         fstab_standby_dict: Dict[str, re.Match] = {}
 
         for line in fstab_standby.splitlines():
@@ -804,7 +804,7 @@ class GrubController(BootControllerProtocol):
 
         # merge entries
         merged: List[str] = []
-        fstab_active = read_str_from_file(active_slot_fstab, _default="")
+        fstab_active = read_str_from_file(active_slot_fstab)
         for line in fstab_active.splitlines():
             if ma := fstab_entry_pa.match(line):
                 mp = ma.group("mount_point")

--- a/src/otaclient/boot_control/_jetson_cboot.py
+++ b/src/otaclient/boot_control/_jetson_cboot.py
@@ -34,7 +34,8 @@ from otaclient.boot_control._firmware_package import (
 )
 from otaclient_api.v2 import types as api_types
 from otaclient_common import replace_root
-from otaclient_common.common import file_digest, subprocess_run_wrapper
+from otaclient_common._io import cal_file_digest
+from otaclient_common.common import subprocess_run_wrapper
 from otaclient_common.typing import StrOrPath
 
 from ._common import CMDHelperFuncs, OTAStatusFilesControl, SlotMountHelper
@@ -249,7 +250,7 @@ class NVUpdateEngine:
                 logger.warning(f"{bup_fpath=} doesn't exist! skip...")
                 continue
 
-            _digest = file_digest(bup_fpath, algorithm=payload_digest_alg)
+            _digest = cal_file_digest(bup_fpath, algorithm=payload_digest_alg)
             if _digest != payload_digest_value:
                 logger.warning(
                     f"{payload_digest_alg} validation failed, "

--- a/src/otaclient/boot_control/_jetson_common.py
+++ b/src/otaclient/boot_control/_jetson_common.py
@@ -30,7 +30,8 @@ from pydantic import BaseModel, BeforeValidator, PlainSerializer
 from typing_extensions import Annotated, Literal, Self
 
 from otaclient_common import replace_root
-from otaclient_common.common import copytree_identical, write_str_to_file_sync
+from otaclient_common._io import write_str_to_file_atomic
+from otaclient_common.common import copytree_identical
 from otaclient_common.typing import StrOrPath
 
 from ._common import CMDHelperFuncs
@@ -299,7 +300,7 @@ class FirmwareBSPVersionControl:
 
     def write_to_file(self, fw_bsp_fpath: StrOrPath) -> None:
         """Write firmware_bsp_version from memory to firmware_bsp_version file."""
-        write_str_to_file_sync(fw_bsp_fpath, self._version.model_dump_json())
+        write_str_to_file_atomic(fw_bsp_fpath, self._version.model_dump_json())
 
     @property
     def current_slot_bsp_ver(self) -> BSPVersion:
@@ -459,7 +460,7 @@ def update_standby_slot_extlinux_cfg(
         )
         src = active_slot_extlinux_fpath
 
-    write_str_to_file_sync(
+    write_str_to_file_atomic(
         standby_slot_extlinux_fpath,
         update_extlinux_cfg(
             src.read_text(),

--- a/src/otaclient/boot_control/_jetson_uefi.py
+++ b/src/otaclient/boot_control/_jetson_uefi.py
@@ -42,12 +42,8 @@ from otaclient.boot_control._firmware_package import (
 )
 from otaclient_api.v2 import types as api_types
 from otaclient_common import replace_root
-from otaclient_common.common import (
-    file_digest,
-    file_sha256,
-    subprocess_call,
-    write_str_to_file_sync,
-)
+from otaclient_common._io import cal_file_digest, file_sha256, write_str_to_file_atomic
+from otaclient_common.common import subprocess_call
 from otaclient_common.typing import StrOrPath
 
 from ._common import CMDHelperFuncs, OTAStatusFilesControl, SlotMountHelper
@@ -403,7 +399,7 @@ def _l4tlauncher_version_control(
         _ver_control = L4TLauncherBSPVersionControl(
             bsp_ver=l4tlauncher_bsp_ver, sha256_digest=l4tlauncher_sha256_digest
         )
-        write_str_to_file_sync(l4tlauncher_ver_fpath, _ver_control.dump())
+        write_str_to_file_atomic(l4tlauncher_ver_fpath, _ver_control.dump())
         return l4tlauncher_bsp_ver
 
     # NOTE(20240624): if we failed to detect the l4tlauncher's version,
@@ -418,7 +414,7 @@ def _l4tlauncher_version_control(
     _ver_control = L4TLauncherBSPVersionControl(
         bsp_ver=current_slot_bsp_ver, sha256_digest=l4tlauncher_sha256_digest
     )
-    write_str_to_file_sync(l4tlauncher_ver_fpath, _ver_control.dump())
+    write_str_to_file_atomic(l4tlauncher_ver_fpath, _ver_control.dump())
     return current_slot_bsp_ver
 
 
@@ -509,7 +505,7 @@ class UEFIFirmwareUpdater:
             )
 
             try:
-                _digest = file_digest(capsule_fpath, algorithm=capsule_digest_alg)
+                _digest = cal_file_digest(capsule_fpath, algorithm=capsule_digest_alg)
                 assert (
                     _digest == capsule_digest_value
                 ), f"{capsule_digest_alg} validation failed, expect {capsule_digest_value}, get {_digest}"
@@ -561,7 +557,9 @@ class UEFIFirmwareUpdater:
                 sha256_digest=_payload.digest.digest,
             )
             try:
-                _digest = file_digest(ota_image_bootaa64, algorithm=payload_digest_alg)
+                _digest = cal_file_digest(
+                    ota_image_bootaa64, algorithm=payload_digest_alg
+                )
                 assert (
                     _digest == payload_digest_value
                 ), f"{payload_digest_alg} validation failed, expect {payload_digest_value}, get {_digest}"
@@ -570,7 +568,7 @@ class UEFIFirmwareUpdater:
                 shutil.copy(ota_image_bootaa64, self.bootaa64_at_esp)
                 os.sync()  # ensure the boot application is written to the disk
 
-                write_str_to_file_sync(
+                write_str_to_file_atomic(
                     self.l4tlauncher_ver_fpath,
                     new_l4tlauncher_ver_ctrl.dump(),
                 )

--- a/src/otaclient/boot_control/selecter.py
+++ b/src/otaclient/boot_control/selecter.py
@@ -58,7 +58,7 @@ def detect_bootloader() -> BootloaderType:
         # evidence: rpi device has a special file which reveals the rpi model
         rpi_model_file = Path(rpi_boot_cfg.RPI_MODEL_FILE)
         if rpi_model_file.is_file():
-            if (_model_str := read_str_from_file(rpi_model_file)).find(
+            if (_model_str := read_str_from_file(rpi_model_file, _default="")).find(
                 rpi_boot_cfg.RPI_MODEL_HINT
             ) != -1:
                 return BootloaderType.RPI_BOOT

--- a/src/otaclient/boot_control/selecter.py
+++ b/src/otaclient/boot_control/selecter.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 from typing_extensions import deprecated
 
-from otaclient_common.common import read_str_from_file
+from otaclient_common._io import read_str_from_file
 
 from .configs import BootloaderType
 from .protocol import BootControllerProtocol

--- a/src/otaclient_common/_io.py
+++ b/src/otaclient_common/_io.py
@@ -59,8 +59,8 @@ else:
         return digestobj
 
 
-def file_digest(
-    fpath: StrOrPath, *, algorithm: str, chunk_size: int = DEFAULT_FILE_CHUNK_SIZE
+def gen_file_digest(
+    fpath: StrOrPath, algorithm: str, chunk_size: int = DEFAULT_FILE_CHUNK_SIZE
 ) -> str:
     """Generate file digest with <algorithm>.
 
@@ -70,7 +70,7 @@ def file_digest(
         return _file_digest(f, algorithm, _bufsize=chunk_size).hexdigest()
 
 
-file_sha256 = partial(file_digest, algorithm="sha256")
+file_sha256 = partial(gen_file_digest, algorithm="sha256")
 file_sha256.__doc__ = "Generate file digest with sha256."
 
 

--- a/src/otaclient_common/_io.py
+++ b/src/otaclient_common/_io.py
@@ -30,6 +30,12 @@ from otaclient_common.typing import StrOrPath
 logger = logging.getLogger(__name__)
 
 DEFAULT_FILE_CHUNK_SIZE = 1024**2  # 1MiB
+TMP_FILE_PREFIX = ".ota_io_tmp_"
+
+
+def _gen_tmp_fname() -> str:
+    return f"{TMP_FILE_PREFIX}{os.urandom(6).hex()}"
+
 
 if sys.version_info >= (3, 11):
     from hashlib import file_digest as _file_digest
@@ -92,7 +98,7 @@ def write_str_to_file_atomic(
         fpath = Path(os.path.realpath(fpath))
 
     fpath_parent = Path(fpath).parent
-    tmp_f = fpath_parent / f".tmp_f_{os.urandom(6).hex()}"
+    tmp_f = fpath_parent / _gen_tmp_fname()
     try:
         # ensure the new file is written
         with open(tmp_f, "w") as f:
@@ -146,7 +152,7 @@ def symlink_atomic(src: StrOrPath, target: StrOrPath) -> None:
     if src.is_symlink() and str(os.readlink(src)) != str(target):
         return  # the symlink is already correct
 
-    tmp_link = Path(src).parent / f"tmp_link_{os.urandom(6).hex()}"
+    tmp_link = Path(src).parent / _gen_tmp_fname()
     try:
         tmp_link.symlink_to(target)
         os.rename(tmp_link, src)  # unconditionally replaced
@@ -178,7 +184,7 @@ def copyfile_atomic(
     # get the file size of the <src>
     src_stat = src.stat()
 
-    _tmp_file = dst.parent / f".tmp_{os.urandom(6).hex()}"
+    _tmp_file = dst.parent / _gen_tmp_fname()
     try:
         # prepare a copy of src file under dst's parent folder
         shutil.copy(src, _tmp_file, follow_symlinks=follow_symlink)

--- a/src/otaclient_common/_io.py
+++ b/src/otaclient_common/_io.py
@@ -147,10 +147,11 @@ def symlink_atomic(src: StrOrPath, target: StrOrPath) -> None:
         Any exceptions raised by Pathlib.symlink_to or os.rename.
     """
     src = Path(src)
-    if not src.exists():
+    if src.is_symlink():
+        if str(os.readlink(src)) == str(target):
+            return  # the symlink is already correct
+    elif not src.exists():  # NOTE: exists follow the symlink!
         return src.symlink_to(target)
-    if src.is_symlink() and str(os.readlink(src)) == str(target):
-        return  # the symlink is already correct
 
     tmp_link = Path(src).parent / _gen_tmp_fname()
     try:

--- a/src/otaclient_common/_io.py
+++ b/src/otaclient_common/_io.py
@@ -184,6 +184,7 @@ def copyfile_atomic(
         shutil.copy(src, _tmp_file, follow_symlinks=follow_symlink)
 
         # perform a basic check with file size
+        # NOTE(20241009): if the copy failed, at least not to override the dst file.
         tmp_stat = _tmp_file.stat()
         if tmp_stat.st_size != src_stat.st_size:
             _err_msg = f"{tmp_stat.st_size=} != {src_stat.st_size=}, shutil.copy failed"

--- a/src/otaclient_common/_io.py
+++ b/src/otaclient_common/_io.py
@@ -127,7 +127,7 @@ def read_str_from_file(
     try:
         return Path(path).read_text().strip()
     except FileNotFoundError:
-        if _default:
+        if _default is not None:
             return _default
         raise
 

--- a/src/otaclient_common/_io.py
+++ b/src/otaclient_common/_io.py
@@ -159,7 +159,6 @@ def copyfile_atomic(
     src: StrOrPath,
     dst: StrOrPath,
     *,
-    backup_suffix: str | None = None,
     follow_symlink: bool = True,
 ) -> None:
     """Atomically copy the <src> file to <dst> file.
@@ -167,8 +166,7 @@ def copyfile_atomic(
     This method will perform a basic check before replace by checking the file size.
 
     <src> must be presented and point to a file.
-    <dst> should be absent or not a directory. If <backup_suffix> is set, the original <dst>
-        will be copied and a backup file with <backup_suffix> will be generated.
+    <dst> should be absent or not a directory.
 
     Raises:
         ValueError if the shutil.copy failed to correctly copy the file(failed the size check).
@@ -177,9 +175,6 @@ def copyfile_atomic(
     NOTE: atomic is ensured by os.rename/os.replace under the same filesystem.
     """
     src, dst = Path(src), Path(dst)
-    if backup_suffix and dst.exists():
-        shutil.copy(str(dst), f"{dst}{backup_suffix}", follow_symlinks=follow_symlink)
-
     # get the file size of the <src>
     src_stat = src.stat()
 
@@ -197,6 +192,5 @@ def copyfile_atomic(
 
         # atomically rename/replace the dst file with the copy
         os.replace(_tmp_file, dst)
-    except Exception:
+    finally:
         _tmp_file.unlink(missing_ok=True)
-        raise

--- a/src/otaclient_common/_io.py
+++ b/src/otaclient_common/_io.py
@@ -105,7 +105,7 @@ def write_str_to_file_atomic(
             f.write(_input)
             f.flush()
             os.fsync(f.fileno())
-        os.rename(tmp_f, fpath)  # atomically override
+        os.replace(tmp_f, fpath)  # atomically override
     finally:
         tmp_f.unlink(missing_ok=True)
 

--- a/src/otaclient_common/_io.py
+++ b/src/otaclient_common/_io.py
@@ -147,8 +147,6 @@ def symlink_atomic(src: StrOrPath, target: StrOrPath) -> None:
     src = Path(src)
     if not src.exists():
         return src.symlink_to(target)
-    if src.is_dir():
-        raise IsADirectoryError(f"{src} exists and it is a directory")
     if src.is_symlink() and str(os.readlink(src)) != str(target):
         return  # the symlink is already correct
 

--- a/src/otaclient_common/_io.py
+++ b/src/otaclient_common/_io.py
@@ -149,7 +149,7 @@ def symlink_atomic(src: StrOrPath, target: StrOrPath) -> None:
     src = Path(src)
     if not src.exists():
         return src.symlink_to(target)
-    if src.is_symlink() and str(os.readlink(src)) != str(target):
+    if src.is_symlink() and str(os.readlink(src)) == str(target):
         return  # the symlink is already correct
 
     tmp_link = Path(src).parent / _gen_tmp_fname()

--- a/tests/test_otaclient/test_boot_control/test_ota_status_control.py
+++ b/tests/test_otaclient/test_boot_control/test_ota_status_control.py
@@ -24,7 +24,7 @@ import pytest
 from otaclient.boot_control._common import OTAStatusFilesControl
 from otaclient.boot_control.configs import BaseConfig as cfg
 from otaclient_api.v2 import types as api_types
-from otaclient_common.common import read_str_from_file, write_str_to_file
+from otaclient_common._io import read_str_from_file, write_str_to_file_atomic
 
 logger = logging.getLogger(__name__)
 
@@ -110,11 +110,11 @@ class TestOTAStatusFilesControl:
     ):
         logger.info(f"{test_case=}")
         # ------ setup ------ #
-        write_str_to_file(
+        write_str_to_file_atomic(
             self.slot_a_status_file,
             input_slot_a_status.name if input_slot_a_status else "",
         )
-        write_str_to_file(self.slot_a_slot_in_use_file, input_slot_a_slot_in_use)
+        write_str_to_file_atomic(self.slot_a_slot_in_use_file, input_slot_a_slot_in_use)
 
         # ------ execution ------ #
         status_control = OTAStatusFilesControl(
@@ -193,10 +193,14 @@ class TestOTAStatusFilesControl:
         """First reboot after OTA from slot_a to slot_b."""
         logger.info(f"{test_case=}")
         # ------ setup ------ #
-        write_str_to_file(self.slot_a_status_file, api_types.StatusOta.FAILURE.name)
-        write_str_to_file(self.slot_a_slot_in_use_file, self.slot_b)
-        write_str_to_file(self.slot_b_status_file, api_types.StatusOta.UPDATING.name)
-        write_str_to_file(self.slot_b_slot_in_use_file, self.slot_b)
+        write_str_to_file_atomic(
+            self.slot_a_status_file, api_types.StatusOta.FAILURE.name
+        )
+        write_str_to_file_atomic(self.slot_a_slot_in_use_file, self.slot_b)
+        write_str_to_file_atomic(
+            self.slot_b_status_file, api_types.StatusOta.UPDATING.name
+        )
+        write_str_to_file_atomic(self.slot_b_slot_in_use_file, self.slot_b)
 
         # ------ execution ------ #
         # otaclient boots on slot_b
@@ -249,10 +253,14 @@ class TestOTAStatusFilesControl:
     def test_accidentally_boots_back_to_standby(self):
         """slot_a should be active slot but boots back to slot_b."""
         # ------ setup ------ #
-        write_str_to_file(self.slot_a_status_file, api_types.StatusOta.SUCCESS.name)
-        write_str_to_file(self.slot_a_slot_in_use_file, self.slot_a)
-        write_str_to_file(self.slot_b_status_file, api_types.StatusOta.FAILURE.name)
-        write_str_to_file(self.slot_b_slot_in_use_file, self.slot_a)
+        write_str_to_file_atomic(
+            self.slot_a_status_file, api_types.StatusOta.SUCCESS.name
+        )
+        write_str_to_file_atomic(self.slot_a_slot_in_use_file, self.slot_a)
+        write_str_to_file_atomic(
+            self.slot_b_status_file, api_types.StatusOta.FAILURE.name
+        )
+        write_str_to_file_atomic(self.slot_b_slot_in_use_file, self.slot_a)
 
         # ------ execution ------ #
         # otaclient accidentally boots on slot_b

--- a/tests/test_otaclient_common/test_io.py
+++ b/tests/test_otaclient_common/test_io.py
@@ -162,3 +162,4 @@ def test_copyfile_atomic(tmp_path: Path):
 
     copyfile_atomic(_src, _dst)
     assert file_sha256(_dst) == file_sha256(_src) == _data_hash
+    assert subprocess.check_output(["cat", str(_dst)]) == _data

--- a/tests/test_otaclient_common/test_io.py
+++ b/tests/test_otaclient_common/test_io.py
@@ -1,0 +1,156 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+
+import os
+import random
+import string
+import subprocess
+from hashlib import sha256
+from pathlib import Path
+
+import pytest
+
+from otaclient_common._io import (
+    TMP_FILE_PREFIX,
+    _gen_tmp_fname,
+    cal_file_digest,
+    copyfile_atomic,
+    file_sha256,
+    symlink_atomic,
+    write_str_to_file_atomic,
+)
+
+# 3MiB each
+CAL_FILE_DIGEST_TEST_DATA = [
+    (
+        b"abcdefgh" * 393216,
+        "bbeddf312779f8bb34907df04d2c5cc70bd68f62a06bc09864c50adff87354b2",
+    ),
+    (
+        0x1234567811223344.to_bytes(8, "big") * 393216,
+        "8bb4daf6b0dd9aeb69da9f2b634951cb988413a81b72e14919329fa5951d3b0f",
+    ),
+]
+
+
+def test_gen_file_digest(tmp_path: Path):
+    for _test_tup in CAL_FILE_DIGEST_TEST_DATA:
+        _tmp_file = tmp_path / f"_test_file_digest_tmp_{os.urandom(6).hex()}"
+
+        contents, sha256_hash = _test_tup
+        try:
+            _tmp_file.write_bytes(contents)
+            assert cal_file_digest(_tmp_file, algorithm="sha256") == sha256_hash
+        finally:
+            _tmp_file.unlink(missing_ok=True)
+
+
+class TestWriteStrToFileAtomic:
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_test(self):
+        self.data_lens = [100, 500, 1000, 9000]  # bytes
+        self.data = [
+            "".join([random.choice(string.printable) for _ in range(_len)])
+            for _len in self.data_lens
+        ]
+
+    def test_write_str_to_file_atomic(self, tmp_path: Path):
+        for data in self.data:
+            _tmp_dst = tmp_path / _gen_tmp_fname("_test_file")
+            write_str_to_file_atomic(_tmp_dst, data, follow_symlink=False)
+
+            # intensionally use external subprocess call to ensure the changes
+            #   are written to the disk properly.
+            assert subprocess.check_output(["cat", str(_tmp_dst)]) == data
+
+    def test_write_str_to_file_atomic_follow_symlink(self, tmp_path: Path):
+        for data in self.data:
+            _tmp_real_dst = tmp_path / _gen_tmp_fname("_test_file")
+            _tmp_dst_symlink = tmp_path / _gen_tmp_fname("_test_file_symlink")
+            _tmp_dst_symlink.symlink_to(_tmp_real_dst)
+
+            write_str_to_file_atomic(_tmp_real_dst, data, follow_symlink=True)
+            assert subprocess.check_output(["cat", str(_tmp_dst_symlink)]) == data
+
+    def test_write_str_to_file_atomic_not_follow_symlink(self, tmp_path: Path):
+        for data in self.data:
+            _tmp_real_dst = tmp_path / _gen_tmp_fname("_test_file")
+            _tmp_dst_symlink = tmp_path / _gen_tmp_fname("_test_file_symlink")
+            _tmp_dst_symlink.symlink_to(_tmp_real_dst)
+
+            write_str_to_file_atomic(_tmp_real_dst, data, follow_symlink=False)
+            assert subprocess.check_output(["cat", str(_tmp_dst_symlink)]) == data
+            assert (
+                _tmp_dst_symlink.is_symlink()
+                and _tmp_dst_symlink.resolve() == _tmp_real_dst
+            )
+
+
+@pytest.mark.parametrize(
+    "target, symlink_contents, exc",
+    (
+        # symlink already existed
+        ("/a/target", "symlink=/not/our/target", None),
+        # create new symlink
+        ("/a/target", "notexisted=", None),
+        # src is a normal file
+        ("/a/target", "file=somecontentssomecontents", None),
+        # src is already the correct symlink
+        ("/a/target", "symlink=/a/target", None),
+        # src is a directory
+        ("/a/target", "dir=", IsADirectoryError),
+    ),
+)
+def test_symlink_atomic(target: str, symlink_contents: str, exc, tmp_path: Path):
+    _workdir = tmp_path / "workdir"
+    _workdir.mkdir()
+
+    _symlink = _workdir / _gen_tmp_fname("_test_symlink")
+    _type, _contents = symlink_contents.split("=")
+    if _type == "symlink":
+        _symlink.symlink_to(_contents)
+    elif _type == "file":
+        _symlink.write_text(_contents)
+    elif _type == "dir":
+        _symlink.mkdir()
+
+    if exc:
+        with pytest.raises(exc):
+            symlink_atomic(_symlink, target)
+
+    else:
+        symlink_atomic(_symlink, target)
+        assert _symlink.resolve() == target  # ensure symlink is updated
+
+    assert not list(_workdir.glob(f"{TMP_FILE_PREFIX}*"))  # ensure no tmp file leftover
+
+
+def test_copyfile_atomic(tmp_path: Path):
+    _src = tmp_path / "_src"
+    _dst = tmp_path / "_dst"
+
+    _data = os.urandom(32) * 1024**2
+    _data_hash = sha256(_data).hexdigest()
+
+    with open(_src, "wb") as f:
+        f.write(_data)
+        f.flush()
+        os.fsync(f.fileno())
+
+    copyfile_atomic(_src, _dst)
+    assert file_sha256(_dst) == file_sha256(_src) == _data_hash

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -31,7 +31,7 @@ from google.protobuf.message import Message as _Message
 
 from otaclient_api.v2 import otaclient_v2_pb2_grpc as v2_grpc
 from otaclient_api.v2 import types as api_types
-from otaclient_common.common import file_sha256
+from otaclient_common._io import file_sha256
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Introduction

This PR introduces a new module `otaclient_common._io` for holding io related helper functions with refinement.

Especially, this modules provides the following new features/changes:
1. implement new `cal_file_digest` helper function, based on python stdlib file_digest.
2. a new `write_str_to_file_atomic` method, replacing the old `write_str_to_file`, which uses the rename syscall to atomically update target file. This function is intended for writing critical config files like boot cfg files, and it is much robust to unexpected interruption, ensured by kernel rename syscall.
3. refined `symlink_atomic` func.
4. new `copyfile_atomic` func.

## Tests

- [x] test file(s) that covers the change(s) is implemented.
- [x] local test is passed.
- [x] OTA test with VM passed.