### PR TITLE
deps: add a reference use requirements.txt file based on pyproject.toml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+# Generated from pyproject.toml, ONLY for reference use!
+aiofiles<25,>=24.1
+aiohttp>=3.9.5,<3.11
+cryptography>=42.0.4,<44
+grpcio>=1.53.2,<1.67
+protobuf<4.22,>=4.21.12
+pydantic<3,>=2.6
+pydantic-settings<3,>=2.3
+pyopenssl<25,>=24.1
+pyyaml<7,>=6.0.1
+requests<2.33,>=2.32
+simple-sqlite3-orm<0.3,>=0.2
+typing-extensions>=4.6.3
+urllib3<2.3,>=2.2.2
+uvicorn[standard]<0.31,>=0.30
+zstandard<0.24,>=0.22


### PR DESCRIPTION
## Introduction

Add a requirements.txt file generated from pyproject.toml. This requirements.txt is only for reference purpose, for tools like snyk that doesn't support parsing pyproject.toml. 