### PR TITLE
ci: test CI: also triggered on PR assigned

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,7 @@ on:
       # NOTE(20241016): this is a workaround for PR with head
       #   updated by gen_requirements_txt workflow
       - review_requested
+      - assigned
   push:
     branches:
       - main


### PR DESCRIPTION
Also see #401 , another workaround for PR with head updated by github action bot.