### PR TITLE
refactor: use StrEnum instead of (str, Enum), and ensure StrEnum's behavior is the same as >= 3.11 across all supported python version

### DIFF
--- a/src/ota_metadata/legacy/parser.py
+++ b/src/ota_metadata/legacy/parser.py
@@ -47,7 +47,6 @@ import re
 import shutil
 import time
 from dataclasses import dataclass, fields
-from enum import Enum
 from functools import partial
 from os import PathLike
 from pathlib import Path
@@ -84,6 +83,7 @@ from otaclient_common.retry_task_map import (
     TasksEnsureFailed,
     ThreadPoolExecutorWithRetry,
 )
+from otaclient_common.typing import StrEnum
 
 from . import SUPORTED_COMPRESSION_TYPES
 from .types import DirectoryInf, PersistentInf, RegularInf, SymbolicLinkInf
@@ -114,7 +114,7 @@ class MetadataJWTVerificationFailed(Exception):
 FV = TypeVar("FV")
 
 
-class MetafilesV1(str, Enum):
+class MetafilesV1(StrEnum):
     """version1 text based ota metafiles fname.
     Check _MetadataJWTClaimsLayout for more details.
     """

--- a/src/otaclient/boot_control/_firmware_package.py
+++ b/src/otaclient/boot_control/_firmware_package.py
@@ -44,7 +44,6 @@ from __future__ import annotations
 
 import logging
 import re
-from enum import Enum
 from pathlib import Path
 from typing import Any, List, Literal, Union
 

--- a/src/otaclient/boot_control/_firmware_package.py
+++ b/src/otaclient/boot_control/_firmware_package.py
@@ -52,12 +52,12 @@ import yaml
 from pydantic import BaseModel, BeforeValidator
 from typing_extensions import Annotated
 
-from otaclient_common.typing import StrOrPath, gen_strenum_validator
+from otaclient_common.typing import StrEnum, StrOrPath, gen_strenum_validator
 
 logger = logging.getLogger(__name__)
 
 
-class PayloadType(str, Enum):
+class PayloadType(StrEnum):
     UEFI_CAPSULE = "UEFI-CAPSULE"
     UEFI_BOOT_APP = "UEFI-BOOT-APP"
     BUP = "BUP"
@@ -148,7 +148,7 @@ class FirmwarePackage(BaseModel):
     digest: Annotated[DigestValue, BeforeValidator(DigestValue.parse)]
 
 
-class HardwareType(str, Enum):
+class HardwareType(StrEnum):
     """
     Currently we only support NVIDIA Jetson device.
     """

--- a/src/otaclient/configs/_cfg_consts.py
+++ b/src/otaclient/configs/_cfg_consts.py
@@ -16,14 +16,13 @@
 
 from __future__ import annotations
 
-from enum import Enum
-
 from otaclient_common import replace_root
+from otaclient_common.typing import StrEnum
 
 CANONICAL_ROOT = "/"
 
 
-class CreateStandbyMechanism(str, Enum):
+class CreateStandbyMechanism(StrEnum):
     LEGACY = "LEGACY"  # deprecated and removed
     REBUILD = "REBUILD"  # default
     IN_PLACE = "IN_PLACE"  # not yet implemented

--- a/src/otaclient/configs/_ecu_info.py
+++ b/src/otaclient/configs/_ecu_info.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import logging
 import warnings
-from enum import Enum
 from pathlib import Path
 from typing import List
 
@@ -27,12 +26,17 @@ from pydantic import AfterValidator, BeforeValidator, Field, IPvAnyAddress
 from typing_extensions import Annotated
 
 from otaclient.configs._common import BaseFixedConfig
-from otaclient_common.typing import NetworkPort, StrOrPath, gen_strenum_validator
+from otaclient_common.typing import (
+    NetworkPort,
+    StrEnum,
+    StrOrPath,
+    gen_strenum_validator,
+)
 
 logger = logging.getLogger(__name__)
 
 
-class BootloaderType(str, Enum):
+class BootloaderType(StrEnum):
     """Bootloaders that supported by otaclient.
 
     auto_detect: (DEPRECATED) at runtime detecting what bootloader is in use in this ECU.

--- a/src/otaclient/create_standby/__init__.py
+++ b/src/otaclient/create_standby/__init__.py
@@ -26,13 +26,13 @@ logger = logging.getLogger(__name__)
 def get_standby_slot_creator(
     mode: CreateStandbyMechanism,
 ) -> Type[StandbySlotCreatorProtocol]:
-    logger.info(f"use slot update {mode=}")
+    logger.info(f"use slot update mechanism: {mode!r}")
     if mode == CreateStandbyMechanism.REBUILD:
         from .rebuild_mode import RebuildMode
 
         return RebuildMode
     else:
-        raise NotImplementedError(f"slot update {mode=} not implemented")
+        raise NotImplementedError(f"slot update mechanism {mode!r} is not implemented")
 
 
 __all__ = ("get_standby_slot_creator",)

--- a/src/otaclient_common/typing.py
+++ b/src/otaclient_common/typing.py
@@ -48,9 +48,13 @@ if sys.version_info >= (3, 11):
     from enum import StrEnum
 
 else:
-    # for pre-3.11, (str, Enum)'s behavior is the same as StrEnum in >= 3.11.
+    # for < 3.11, (str, Enum)'s behavior is the same as StrEnum in >= 3.11.
+    #   besides here, we implement __str__ to use str type's one, to align with
+    #   the behavior of >= 3.11.
     class StrEnum(str, Enum):
-        pass
+
+        def __str__(self) -> str:
+            return str.__str__(self)
 
 
 # pydantic helpers

--- a/src/otaclient_common/typing.py
+++ b/src/otaclient_common/typing.py
@@ -30,12 +30,16 @@ T = TypeVar("T")
 EnumT = TypeVar("EnumT", bound=Enum)
 StrOrPath = Union[str, Path]
 
-# Before 3.11, if type mixin has its own __str__ and __format__,
-#   Enum will implicitly preserve and use the __str__ and __format__.
-#   However, starting from 3.11, we have ReprEnum. ONLY subclass of ReprEnum
-#   will preserves the type mixin's __str__ and __format__.
+# Before 3.11, if type mixin has its own __format__, Enum will implicitly
+#   preserve and use the __format__. This behavior is critical for str Enum
+#   to be used as string directly.
+#   However, starting from 3.11, the above implicit behavior no long exists. Instead
+#   we have ReprEnum. ONLY subclass of ReprEnum will preserves the type mixin's __format__.
 #   The above changes mean that starting from 3.11, <custom_enum>(str, Enum)
 #   cannot be used directly as str in f string or format, we need StrEnum.
+#
+# NOTE that in >= 3.11, str(<StrEnum_member>) will be the enum value, however
+# that is not true in < 3.11,
 #
 # To cover this behavior change, we simply need to use StrEnum for >= 3.11,
 #   and for easy maintain, for < 3.11 we manually define a StrEnum.

--- a/src/otaclient_common/typing.py
+++ b/src/otaclient_common/typing.py
@@ -72,7 +72,7 @@ def gen_strenum_validator(
     """A before validator generator that converts input value into enum
     before passing it to pydantic validator.
 
-    NOTE(20240129): as upto pydantic v2.5.3, (str, Enum) field cannot
+    NOTE(20240129): as upto pydantic v2.5.3, field with StrEnum type cannot
                     pass strict validation if input is str.
     """
 

--- a/src/otaclient_common/typing.py
+++ b/src/otaclient_common/typing.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import sys
 from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, TypeVar, Union
@@ -28,6 +29,25 @@ T = TypeVar("T")
 
 EnumT = TypeVar("EnumT", bound=Enum)
 StrOrPath = Union[str, Path]
+
+# Before 3.11, if type mixin has its own __str__ and __format__,
+#   Enum will implicitly preserve and use the __str__ and __format__.
+#   However, starting from 3.11, we have ReprEnum. ONLY subclass of ReprEnum
+#   will preserves the type mixin's __str__ and __format__.
+#   The above changes mean that starting from 3.11, <custom_enum>(str, Enum)
+#   cannot be used directly as str in f string or format, we need StrEnum.
+#
+# To cover this behavior change, we simply need to use StrEnum for >= 3.11,
+#   and for easy maintain, for < 3.11 we manually define a StrEnum.
+if sys.version_info >= (3, 11):
+    # StrEnum is a subclass of ReprEnum, with type mixin as str.
+    from enum import StrEnum
+
+else:
+    # for pre-3.11, (str, Enum)'s behavior is the same as StrEnum in >= 3.11.
+    class StrEnum(str, Enum):
+        pass
+
 
 # pydantic helpers
 

--- a/tests/test_otaclient_common/test_typing.py
+++ b/tests/test_otaclient_common/test_typing.py
@@ -28,5 +28,5 @@ def test_str_enum():
     # str enum's __format__ should be the str's one, returning the str value.
     assert f"{EnumForTest.A}" == EnumForTest.A.value
     # our version of str enum for < 3.11 fully aligns with >= 3.11, which __str__
-    #   is the str type's one
+    #   is the str type's one.
     assert str(EnumForTest.A) == EnumForTest.A.value

--- a/tests/test_otaclient_common/test_typing.py
+++ b/tests/test_otaclient_common/test_typing.py
@@ -15,6 +15,9 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from subprocess import check_output
+
 from otaclient_common.typing import StrEnum
 
 
@@ -22,7 +25,7 @@ class EnumForTest(StrEnum):
     A = "A"
 
 
-def test_str_enum():
+def test_str_enum(tmp_path: Path):
     # str enum should be able to compare with string instance directly.
     assert EnumForTest.A == EnumForTest.A.value
     # str enum's __format__ should be the str's one, returning the str value.
@@ -30,3 +33,13 @@ def test_str_enum():
     # our version of str enum for < 3.11 fully aligns with >= 3.11, which __str__
     #   is the str type's one.
     assert str(EnumForTest.A) == EnumForTest.A.value
+
+    # When directly use as str, StrEnum should be behaved like a normal string.
+    test_file = tmp_path / "file_written"
+    test_file.write_text(EnumForTest.A)
+
+    assert (
+        check_output(["cat", str(test_file)]).decode()
+        == EnumForTest.A
+        == EnumForTest.A.value
+    )

--- a/tests/test_otaclient_common/test_typing.py
+++ b/tests/test_otaclient_common/test_typing.py
@@ -1,0 +1,32 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+
+from otaclient_common.typing import StrEnum
+
+
+class EnumForTest(StrEnum):
+    A = "A"
+
+
+def test_str_enum():
+    # str enum should be able to compare with string instance directly.
+    assert EnumForTest.A == EnumForTest.A.value
+    # str enum's __format__ should be the str's one, returning the str value.
+    assert f"{EnumForTest.A}" == EnumForTest.A.value
+    # our version of str enum for < 3.11 fully aligns with >= 3.11, which __str__
+    #   is the str type's one
+    assert str(EnumForTest.A) == EnumForTest.A.value


### PR DESCRIPTION
## Introduction

Enum with str type mixin is widely used in the otaclient code base, and otaclient needs to be compatible from py3.8 to py3.12, 
However, the behavior of python's enum with type mixin has a breaking change starting from py3.11. 
Roughly speaking, starting from py3.11, a new StrEnum is introduced, and it behaves like the (str, Enum) in pre-3.11, and (str, Enum) in >= py3.11 no longer behaves like the one in pre-3.11. 

Also see https://docs.python.org/3.11/library/enum.html#enum.ReprEnum for more details about the new behavior.

This PR introduces the `otaclient_common.typing.StrEnum` for unified StrEnum behavior across different python version.
For >= py3.11, we directly use the `StrEnum` from python stdlib. For < py3.11, we implement a py3.11 compatible `StrEnum`, its behavior is exactly the same with the one in >= py3.11.

## Tests

- [x] test covered the changes implemented.
- [x] test covered the changes passed.
- [x] local VM OTA test passed.