### PR TITLE
refactor: implement wait_and_log helper method to log periodically during waiting for all sub ECUs before reboot

### DIFF
--- a/src/otaclient/boot_control/_common.py
+++ b/src/otaclient/boot_control/_common.py
@@ -446,6 +446,7 @@ class CMDHelperFuncs:
             cmd.extend(args)
 
         try:
+            logger.warning("system will reboot now!")
             subprocess_call(cmd, raise_exception=True)
             sys.exit(0)
         except CalledProcessError:

--- a/src/otaclient/utils.py
+++ b/src/otaclient/utils.py
@@ -20,7 +20,7 @@ import itertools
 import logging
 import time
 from abc import abstractmethod
-from typing import Protocol
+from typing import Callable, Protocol
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +37,7 @@ def wait_and_log(
     *,
     check_interval: int = 2,
     log_interval: int = 30,
+    log_func: Callable[[str], None] = logger.info,
 ) -> None:
     """Wait for <flag> until it is set while print a log every <log_interval>."""
     log_round = 0
@@ -46,6 +47,6 @@ def wait_and_log(
 
         _new_log_round = seconds // log_interval
         if _new_log_round > log_round:
-            logger.info(f"wait for {message}: {seconds}s passed ...")
+            log_func(f"wait for {message}: {seconds}s passed ...")
             log_round = _new_log_round
         time.sleep(check_interval)

--- a/src/otaclient/utils.py
+++ b/src/otaclient/utils.py
@@ -1,0 +1,51 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Common shared utils, only used by otaclient package."""
+
+
+from __future__ import annotations
+
+import itertools
+import logging
+import time
+from abc import abstractmethod
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class CheckableFlag(Protocol):
+
+    @abstractmethod
+    def is_set(self) -> bool: ...
+
+
+def wait_and_log(
+    flag: CheckableFlag,
+    message: str = "",
+    *,
+    check_interval: int = 2,
+    log_interval: int = 30,
+) -> None:
+    """Wait for <flag> until it is set while print a log every <log_interval>."""
+    log_round = 0
+    for seconds in itertools.count(step=check_interval):
+        if flag.is_set():
+            return
+
+        _new_log_round = seconds // log_interval
+        if _new_log_round > log_round:
+            logger.info(f"wait for {message}: {seconds}s passed ...")
+            log_round = _new_log_round
+        time.sleep(check_interval)

--- a/tests/test_otaclient/test_create_standby.py
+++ b/tests/test_otaclient/test_create_standby.py
@@ -118,7 +118,7 @@ class TestOTAupdateWithCreateStandbyRebuildMode:
         persist_handler.assert_called_once()
         # --- assert update finished
         _updater.shutdown.assert_called_once()
-        otaclient_control_flags.wait_can_reboot_flag.assert_called_once()  # type: ignore
+        otaclient_control_flags._can_reboot.is_set.assert_called_once()  # type: ignore
         # --- ensure the update stats are collected
         collector = _updater._update_stats_collector
         assert collector.processed_files_num

--- a/tests/test_otaclient/test_create_standby.py
+++ b/tests/test_otaclient/test_create_standby.py
@@ -90,6 +90,8 @@ class TestOTAupdateWithCreateStandbyRebuildMode:
         otaclient_control_flags = typing.cast(
             OTAClientControlFlags, mocker.MagicMock(spec=OTAClientControlFlags)
         )
+        otaclient_control_flags._can_reboot = _can_reboot = mocker.MagicMock()
+        _can_reboot.is_set = mocker.MagicMock(return_value=True)
 
         ca_store = load_ca_cert_chains(cfg.CERTS_DIR)
 

--- a/tests/test_otaclient/test_ota_client.py
+++ b/tests/test_otaclient/test_ota_client.py
@@ -176,6 +176,9 @@ class TestOTAUpdater:
         otaclient_control_flags = typing.cast(
             OTAClientControlFlags, mocker.MagicMock(spec=OTAClientControlFlags)
         )
+        otaclient_control_flags._can_reboot = _can_reboot = mocker.MagicMock()
+        _can_reboot.is_set = mocker.MagicMock(return_value=True)
+
         ca_store = load_ca_cert_chains(cfg.CERTS_DIR)
 
         _updater = _OTAUpdater(
@@ -199,7 +202,7 @@ class TestOTAUpdater:
             _downloaded_files_size += _f.stat().st_size
         assert _downloaded_files_size == self._delta_bundle.total_download_files_size
         # assert the control_flags has been waited
-        otaclient_control_flags.wait_can_reboot_flag.assert_called_once()
+        otaclient_control_flags._can_reboot.is_set.assert_called_once()
         assert _updater.updating_version == str(cfg.UPDATE_VERSION)
         # assert boot controller is used
         self._boot_control.pre_update.assert_called_once()

--- a/tests/test_otaclient/test_utils.py
+++ b/tests/test_otaclient/test_utils.py
@@ -1,0 +1,55 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+
+import logging
+import time
+
+import pytest
+
+from otaclient.utils import wait_and_log
+
+logger = logging.getLogger(__name__)
+
+
+class _TickingFlag:
+
+    def __init__(self, trigger_in: int) -> None:
+        self._trigger_time = time.time() + trigger_in
+
+    def is_set(self) -> bool:
+        _now = time.time()
+        return _now > self._trigger_time
+
+
+def test_wait_and_log(caplog: pytest.LogCaptureFixture):
+    # NOTE: allow 2 more seconds for expected_trigger_time
+    trigger_in, expected_trigger_time = 11, time.time() + 11 + 2
+    _flag = _TickingFlag(trigger_in=trigger_in)
+    _msg = "ticking flag"
+
+    wait_and_log(
+        _flag,
+        _msg,
+        check_interval=1,
+        log_interval=2,
+        log_func=logger.warning,
+    )
+
+    assert len(caplog.records) == 5
+    assert caplog.records[0].levelno == logging.WARNING
+    assert caplog.records[0].msg == f"wait for {_msg}: 2s passed ..."
+    assert time.time() < expected_trigger_time


### PR DESCRIPTION
This PR introduces `wait_and_log` helper method, which issues logs during waiting for flag set. otaclient now uses this method when waiting for all sub ECUs before reboot. 

Other changes:
1. otaclient will issue a warning log before actually calling reboot command.
2. otaclient will sleep 6 seconds before actually reboot the system.