### PR TITLE
refactor: re-implement status monitor and the status report framework

### DIFF
--- a/src/otaclient/_types.py
+++ b/src/otaclient/_types.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from typing import ClassVar, Optional
 
 from _otaclient_version import __version__
+
 from otaclient.configs.cfg import ecu_info
 from otaclient_common.typing import StrEnum
 

--- a/src/otaclient/_types.py
+++ b/src/otaclient/_types.py
@@ -20,7 +20,6 @@ from dataclasses import dataclass
 from typing import ClassVar, Optional
 
 from _otaclient_version import __version__
-
 from otaclient.configs.cfg import ecu_info
 from otaclient_common.typing import StrEnum
 

--- a/src/otaclient/status_monitor.py
+++ b/src/otaclient/status_monitor.py
@@ -257,6 +257,7 @@ class OTAClientStatusCollector:
         # ------ during OTA session ------ #
         report_session_id = report.session_id
         if report_session_id != status_storage.session_id:
+            logger.warning(f"drop reports from mismatched session: {report}")
             return  # drop invalid report
         if isinstance(payload, OTAUpdatePhaseChangeReport):
             return _on_update_phase_changed(status_storage, payload)

--- a/src/otaclient/status_monitor.py
+++ b/src/otaclient/status_monitor.py
@@ -1,0 +1,293 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The implementation of tracking otaclient operation stats."""
+
+
+from __future__ import annotations
+
+import atexit
+import logging
+import queue
+import time
+from dataclasses import asdict, dataclass
+from enum import Enum, auto
+from threading import Thread
+from typing import Union, cast
+
+from otaclient._types import (
+    FailureType,
+    OTAClientStatus,
+    OTAStatus,
+    UpdateMeta,
+    UpdatePhase,
+    UpdateProgress,
+    UpdateTiming,
+)
+
+logger = logging.getLogger(__name__)
+
+_otaclient_shutdown = False
+_status_report_queue: queue.Queue | None = None
+
+
+def _global_shutdown():
+    global _otaclient_shutdown
+    _otaclient_shutdown = True
+
+    if _status_report_queue:
+        _status_report_queue.put_nowait(TERMINATE_SENTINEL)
+
+
+atexit.register(_global_shutdown)
+
+
+#
+# ------ report message types for otaclient internal ------ #
+#
+
+
+@dataclass
+class SetOTAClientMetaReport:
+    firmware_version: str = ""
+
+
+@dataclass
+class UpdateProgressReport:
+
+    class Type(Enum):
+        # NOTE: PREPARE_LOCAL, DOWNLOAD_REMOTE and APPLY_DELTA are together
+        #       counted as <processed_files_*>
+        PREPARE_LOCAL_COPY = auto()
+        DOWNLOAD_REMOTE_COPY = auto()
+        APPLY_DELTA = auto()
+        # for in-place update only
+        APPLY_REMOVE_DELTA = auto()
+
+    operation: Type
+    processed_file_num: int = 0
+    processed_file_size: int = 0  # uncompressed processed file size
+
+    # only used by download operation
+    downloaded_bytes: int = 0
+    errors: int = 0
+
+
+@dataclass
+class OTAStatusChangeReport:
+    new_ota_status: OTAStatus
+    # only used when new_ota_status is failure
+    failure_type: FailureType = FailureType.NO_FAILURE
+    failure_reason: str = ""
+
+
+@dataclass
+class OTAUpdatePhaseChangeReport:
+    new_update_phase: UpdatePhase
+    trigger_timestamp: int  # in second
+
+
+@dataclass
+class SetUpdateMetaReport(UpdateMeta):
+    metadata_downloaded_bytes: int = 0
+
+
+@dataclass
+class StatsReport:
+    payload: Union[
+        SetOTAClientMetaReport,
+        UpdateProgressReport,
+        OTAStatusChangeReport,
+        OTAUpdatePhaseChangeReport,
+        SetUpdateMetaReport,
+    ]
+    session_id: str = ""
+
+
+#
+# ------ helper functions ------ #
+#
+def _on_session_finished(
+    status_storage: OTAClientStatus, payload: OTAStatusChangeReport
+):
+    status_storage.session_id = ""
+    status_storage.update_phase = UpdatePhase.INITIALIZING
+    status_storage.update_meta = UpdateMeta()
+    status_storage.update_progress = UpdateProgress()
+    status_storage.update_timing = UpdateTiming()
+    status_storage.ota_status = payload.new_ota_status
+
+    if payload.new_ota_status in [OTAStatus.FAILURE, OTAStatus.ROLLBACK_FAILURE]:
+        status_storage.failure_type = payload.failure_type
+        status_storage.failure_reason = payload.failure_reason
+    else:
+        status_storage.failure_type = FailureType.NO_FAILURE
+        status_storage.failure_reason = ""
+
+
+def _on_new_ota_session(
+    status_storage: OTAClientStatus, payload: OTAStatusChangeReport
+):
+    status_storage.ota_status = payload.new_ota_status
+    status_storage.update_phase = UpdatePhase.INITIALIZING
+    status_storage.update_meta = UpdateMeta()
+    status_storage.update_progress = UpdateProgress()
+    status_storage.update_timing = UpdateTiming(update_start_timestamp=int(time.time()))
+    status_storage.failure_type = FailureType.NO_FAILURE
+    status_storage.failure_reason = ""
+
+
+def _on_update_phase_changed(
+    status_storage: OTAClientStatus, payload: OTAUpdatePhaseChangeReport
+):
+    if (update_timing := status_storage.update_timing) is None:
+        logger.warning(
+            "attempt to update update_timing when no OTA update session on-going"
+        )
+        return
+
+    phase, trigger_timestamp = payload.new_update_phase, payload.trigger_timestamp
+    if phase == UpdatePhase.PROCESSING_POSTUPDATE:
+        update_timing.post_update_start_timestamp = trigger_timestamp
+    elif phase == UpdatePhase.DOWNLOADING_OTA_FILES:
+        update_timing.download_start_timestamp = trigger_timestamp
+    elif phase == UpdatePhase.CALCULATING_DELTA:
+        update_timing.delta_generate_start_timestamp = trigger_timestamp
+    elif phase == UpdatePhase.APPLYING_UPDATE:
+        update_timing.update_apply_start_timestamp = trigger_timestamp
+
+    status_storage.update_phase = phase
+
+
+def _on_update_progress(status_storage: OTAClientStatus, payload: UpdateProgressReport):
+    if (update_progress := status_storage.update_progress) is None:
+        logger.warning(
+            "attempt to update update_progress when no OTA update session on-going"
+        )
+        return
+
+    op = payload.operation
+    if (
+        op == UpdateProgressReport.Type.PREPARE_LOCAL_COPY
+        or op == UpdateProgressReport.Type.APPLY_DELTA
+    ):
+        update_progress.processed_files_num += payload.processed_file_num
+        update_progress.processed_files_size += payload.processed_file_size
+    elif op == UpdateProgressReport.Type.DOWNLOAD_REMOTE_COPY:
+        update_progress.processed_files_num += payload.processed_file_num
+        update_progress.processed_files_size += payload.processed_file_size
+        update_progress.downloaded_bytes += payload.downloaded_bytes
+        update_progress.downloaded_files_num += payload.processed_file_num
+        update_progress.downloaded_files_size += payload.processed_file_size
+        update_progress.downloading_errors += payload.errors
+    elif op == UpdateProgressReport.Type.APPLY_REMOVE_DELTA:
+        update_progress.removed_files_num += payload.processed_file_num
+
+
+def _on_update_meta(status_storage: OTAClientStatus, payload: SetUpdateMetaReport):
+    if (update_meta := status_storage.update_meta) is None or (
+        update_progress := status_storage.update_progress
+    ) is None:
+        logger.warning(
+            "attempt to update update_meta when no OTA update session on-going"
+        )
+        return
+
+    _input = asdict(payload)
+    for k, v in _input.items():
+        if k == "metadata_downloaded_bytes" and v:
+            update_progress.downloaded_bytes += v
+            continue
+        if v:
+            setattr(update_meta, k, v)
+
+
+#
+# ------ stats monitor implementation ------ #
+#
+
+TERMINATE_SENTINEL = cast(StatsReport, object())
+
+
+class OTAClientStatsCollector:
+
+    def __init__(
+        self,
+        msg_queue: queue.Queue[StatsReport],
+        *,
+        min_collect_interval: int = 1,
+        min_push_interval: int = 1,
+    ) -> None:
+        self.min_collect_interval = min_collect_interval
+        self.min_push_interval = min_push_interval
+
+        self._input_queue = msg_queue
+        self._stats = None
+
+    def load_report(self, report: StatsReport):
+        if self._stats is None:
+            self._stats = OTAClientStatus()
+        status_storage = self._stats
+
+        payload = report.payload
+        # ------ update otaclient meta ------ #
+        if isinstance(payload, SetOTAClientMetaReport):
+            status_storage.firmware_version = payload.firmware_version
+
+        # ------ on session start/end ------ #
+        if isinstance(payload, OTAStatusChangeReport):
+            new_ota_status = payload.new_ota_status
+            if new_ota_status in [OTAStatus.UPDATING, OTAStatus.ROLLBACKING]:
+                status_storage.session_id = report.session_id
+                return _on_new_ota_session(status_storage, payload)
+
+            status_storage.session_id = ""  # clear session if we are not in an OTA
+            return _on_session_finished(status_storage, payload)
+
+        # ------ during OTA session ------ #
+        report_session_id = report.session_id
+        if report_session_id != status_storage.session_id:
+            return  # drop invalid report
+        if isinstance(payload, OTAUpdatePhaseChangeReport):
+            return _on_update_phase_changed(status_storage, payload)
+        if isinstance(payload, UpdateProgressReport):
+            return _on_update_progress(status_storage, payload)
+        if isinstance(payload, SetUpdateMetaReport):
+            return _on_update_meta(status_storage, payload)
+
+    def _stats_collector_thread(self) -> None:
+        """Main entry of stats monitor working thread."""
+        while not _otaclient_shutdown:
+            try:
+                report = self._input_queue.get_nowait()
+                if report is TERMINATE_SENTINEL:
+                    break
+                self.load_report(report)
+            except queue.Empty:
+                time.sleep(self.min_collect_interval)
+
+    # API
+
+    def start(self) -> Thread:
+        """Start the stats_monitor thread."""
+        t = Thread(
+            target=self._stats_collector_thread,
+            daemon=True,
+            name="otaclient_stats_monitor",
+        )
+        t.start()
+        return t
+
+    @property
+    def otaclient_status(self) -> OTAClientStatus | None:
+        return self._stats

--- a/tests/test_otaclient/test_status_monitor.py
+++ b/tests/test_otaclient/test_status_monitor.py
@@ -1,0 +1,410 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The implementation of tracking otaclient operation stats."""
+
+
+from __future__ import annotations
+
+import os
+import random
+import time
+from queue import Queue
+from typing import Generator
+
+import pytest
+
+from otaclient._types import FailureType, OTAStatus, UpdatePhase
+from otaclient.status_monitor import (
+    TERMINATE_SENTINEL,
+    OTAClientStatusCollector,
+    OTAStatusChangeReport,
+    OTAUpdatePhaseChangeReport,
+    SetOTAClientMetaReport,
+    SetUpdateMetaReport,
+    StatusReport,
+    UpdateProgressReport,
+)
+
+
+class TestStatusMonitor:
+
+    # update meta
+    TOTAL_FILES_NUM = TOTAL_FILES_SIZE = 1000
+    METADATA_SIZE = 20
+
+    # update session data
+    SESSION_ID_FOR_TEST = os.urandom(8).hex()
+    UPDATE_VERSION_FOR_TEST = f"test_version_123_{os.urandom(8).hex()}"
+    DELTA_NUM = DELTA_SIZE = 300
+    DOWNLOAD_NUM = DWONLOAD_SIZE = TOTAL_DOWNLOAD_SIZE = 600
+    MULTI_PATHS_FILE = MULTI_PATHS_FILE_SIZE = 100
+
+    @pytest.fixture(autouse=True, scope="class")
+    def msg_queue(self) -> Generator[Queue[StatusReport], None, None]:
+        _queue = Queue()
+        yield _queue
+
+    @pytest.fixture(autouse=True, scope="class")
+    def status_collector(self, msg_queue: Queue[StatusReport]):
+        status_collector = OTAClientStatusCollector(msg_queue=msg_queue)
+        _thread = status_collector.start()
+        try:
+            yield status_collector
+        finally:
+            msg_queue.put_nowait(TERMINATE_SENTINEL)
+            _thread.join()
+
+    def test_otaclient_start(
+        self, status_collector: OTAClientStatusCollector, msg_queue: Queue[StatusReport]
+    ):
+        _test_failure_reason = "test_no_failure_reason"
+        _test_current_version = "test_current_version"
+        msg_queue.put_nowait(
+            StatusReport(
+                payload=OTAStatusChangeReport(
+                    new_ota_status=OTAStatus.FAILURE,
+                    failure_type=FailureType.RECOVERABLE,
+                    failure_reason=_test_failure_reason,
+                )
+            )
+        )
+        msg_queue.put_nowait(
+            StatusReport(
+                payload=SetOTAClientMetaReport(
+                    firmware_version=_test_current_version,
+                )
+            )
+        )
+
+        time.sleep(2)  # wait for reports being processed
+
+        otaclient_status = status_collector.otaclient_status
+        assert otaclient_status
+        assert otaclient_status.firmware_version == _test_current_version
+        assert otaclient_status.ota_status == OTAStatus.FAILURE
+        assert otaclient_status.failure_type == FailureType.RECOVERABLE
+        assert otaclient_status.failure_reason == _test_failure_reason
+
+    def test_start_ota_update(
+        self, status_collector: OTAClientStatusCollector, msg_queue: Queue[StatusReport]
+    ):
+        # ------ execution ------ #
+        msg_queue.put_nowait(
+            StatusReport(
+                payload=OTAStatusChangeReport(
+                    new_ota_status=OTAStatus.UPDATING,
+                ),
+                session_id=self.SESSION_ID_FOR_TEST,
+            ),
+        )
+        msg_queue.put_nowait(
+            StatusReport(
+                payload=OTAUpdatePhaseChangeReport(
+                    new_update_phase=UpdatePhase.INITIALIZING,
+                    trigger_timestamp=int(time.time()),
+                ),
+                session_id=self.SESSION_ID_FOR_TEST,
+            )
+        )
+        msg_queue.put_nowait(
+            StatusReport(
+                payload=SetUpdateMetaReport(
+                    update_firmware_version=self.UPDATE_VERSION_FOR_TEST,
+                ),
+                session_id=self.SESSION_ID_FOR_TEST,
+            ),
+        )
+
+        # ------ assertion ------ #
+        time.sleep(2)  # wait for reports being processed
+
+        otaclient_status = status_collector.otaclient_status
+        assert otaclient_status
+        assert otaclient_status.session_id == self.SESSION_ID_FOR_TEST
+        assert otaclient_status.ota_status == OTAStatus.UPDATING
+        assert otaclient_status.update_phase == UpdatePhase.INITIALIZING
+        assert (update_meta := otaclient_status.update_meta)
+        assert update_meta.update_firmware_version == self.UPDATE_VERSION_FOR_TEST
+
+    def test_process_metadata(
+        self, status_collector: OTAClientStatusCollector, msg_queue: Queue[StatusReport]
+    ) -> None:
+        # ------ execution ------ #
+        msg_queue.put_nowait(
+            StatusReport(
+                payload=OTAUpdatePhaseChangeReport(
+                    new_update_phase=UpdatePhase.PROCESSING_METADATA,
+                    trigger_timestamp=int(time.time()),
+                ),
+                session_id=self.SESSION_ID_FOR_TEST,
+            )
+        )
+        msg_queue.put_nowait(
+            StatusReport(
+                payload=SetUpdateMetaReport(
+                    image_file_entries=self.TOTAL_FILES_NUM,
+                    image_size_uncompressed=self.TOTAL_FILES_SIZE,
+                    metadata_downloaded_bytes=self.METADATA_SIZE,
+                ),
+                session_id=self.SESSION_ID_FOR_TEST,
+            )
+        )
+
+        # ------ assertion ------ #
+        time.sleep(2)  # wait for reports being processed
+
+        otaclient_status = status_collector.otaclient_status
+        assert otaclient_status
+        assert otaclient_status.session_id == self.SESSION_ID_FOR_TEST
+        assert otaclient_status.update_phase == UpdatePhase.PROCESSING_METADATA
+        assert (update_meta := otaclient_status.update_meta)
+        assert update_meta.image_file_entries == self.TOTAL_FILES_NUM
+        assert update_meta.image_size_uncompressed == self.TOTAL_FILES_SIZE
+        assert (update_progress := otaclient_status.update_progress)
+        assert update_progress.downloaded_bytes == self.METADATA_SIZE
+
+    def test_filter_invalid_session_id(self, msg_queue: Queue[StatusReport]) -> None:
+        """This test put reports with invalid session_id into the msg_queue.
+
+        If the filter is working, all the later test methods will not fail.
+        """
+        _invalid_session_id = "invalid_session_id"
+
+        # put an update meta change report
+        msg_queue.put_nowait(
+            StatusReport(
+                payload=SetUpdateMetaReport(
+                    image_file_entries=999999999999999,
+                    image_size_uncompressed=0,
+                    metadata_downloaded_bytes=999999999999999,
+                ),
+                session_id=_invalid_session_id,
+            )
+        )
+
+        # put an update phase chagne report
+        msg_queue.put_nowait(
+            StatusReport(
+                payload=OTAUpdatePhaseChangeReport(
+                    new_update_phase=UpdatePhase.INITIALIZING,
+                    trigger_timestamp=32,
+                ),
+                session_id=_invalid_session_id,
+            )
+        )
+
+        # put an update progress change report
+        msg_queue.put_nowait(
+            StatusReport(
+                payload=UpdateProgressReport(
+                    operation=UpdateProgressReport.Type.PREPARE_LOCAL_COPY,
+                    processed_file_num=999999999999,
+                    processed_file_size=9999999999999,
+                ),
+                session_id=_invalid_session_id,
+            )
+        )
+
+    def test_calculate_delta(
+        self, status_collector: OTAClientStatusCollector, msg_queue: Queue[StatusReport]
+    ) -> None:
+        _now = int(time.time())
+
+        # ------ execution ------ #
+        msg_queue.put_nowait(
+            StatusReport(
+                payload=OTAUpdatePhaseChangeReport(
+                    new_update_phase=UpdatePhase.CALCULATING_DELTA,
+                    trigger_timestamp=_now,
+                ),
+                session_id=self.SESSION_ID_FOR_TEST,
+            )
+        )
+
+        for _ in range(self.DELTA_NUM):
+            msg_queue.put_nowait(
+                StatusReport(
+                    payload=UpdateProgressReport(
+                        operation=UpdateProgressReport.Type.PREPARE_LOCAL_COPY,
+                        processed_file_num=1,
+                        processed_file_size=1,
+                    ),
+                    session_id=self.SESSION_ID_FOR_TEST,
+                )
+            )
+
+        # ------ assertion ------ #
+        time.sleep(2)  # wait for reports being processed
+
+        otaclient_status = status_collector.otaclient_status
+        assert otaclient_status
+        assert otaclient_status.session_id == self.SESSION_ID_FOR_TEST
+        assert (
+            update_timing := otaclient_status.update_timing
+        ) and update_timing.delta_generate_start_timestamp == _now
+        assert otaclient_status.update_phase == UpdatePhase.CALCULATING_DELTA
+        assert (update_progress := otaclient_status.update_progress)
+        assert update_progress.processed_files_num == self.DELTA_NUM
+        assert update_progress.processed_files_size == self.DELTA_SIZE
+
+    def test_download_ota_files(
+        self, status_collector: OTAClientStatusCollector, msg_queue: Queue[StatusReport]
+    ) -> None:
+        _now = int(time.time())
+
+        # ------ execution ------ #
+        msg_queue.put_nowait(
+            StatusReport(
+                payload=OTAUpdatePhaseChangeReport(
+                    new_update_phase=UpdatePhase.DOWNLOADING_OTA_FILES,
+                    trigger_timestamp=_now,
+                ),
+                session_id=self.SESSION_ID_FOR_TEST,
+            )
+        )
+
+        _errors_count, _downloaded_bytes_sum = 0, 0
+        for _ in range(self.DOWNLOAD_NUM):
+            _errors = random.randint(0, 5)
+            _downloaded_bytes = random.randint(1, 5)
+            msg_queue.put_nowait(
+                StatusReport(
+                    payload=UpdateProgressReport(
+                        operation=UpdateProgressReport.Type.DOWNLOAD_REMOTE_COPY,
+                        processed_file_num=1,
+                        processed_file_size=1,
+                        downloaded_bytes=_downloaded_bytes,
+                        errors=_errors,
+                    ),
+                    session_id=self.SESSION_ID_FOR_TEST,
+                )
+            )
+            _errors_count += _errors
+            _downloaded_bytes_sum += _downloaded_bytes
+
+        # ------ assertion ------ #
+        time.sleep(2)  # wait for reports being processed
+
+        otaclient_status = status_collector.otaclient_status
+        assert otaclient_status
+        assert otaclient_status.ota_status == OTAStatus.UPDATING
+        assert (
+            update_timing := otaclient_status.update_timing
+        ) and update_timing.download_start_timestamp == _now
+        assert otaclient_status.update_phase == UpdatePhase.DOWNLOADING_OTA_FILES
+        assert (update_progress := otaclient_status.update_progress)
+        assert update_progress.downloading_errors == _errors_count
+        assert update_progress.downloaded_files_num == self.DOWNLOAD_NUM
+        assert update_progress.downloaded_files_size == self.DWONLOAD_SIZE
+        assert (
+            update_progress.downloaded_bytes
+            == _downloaded_bytes_sum + self.METADATA_SIZE
+        )
+
+    def test_apply_update(
+        self, status_collector: OTAClientStatusCollector, msg_queue: Queue[StatusReport]
+    ) -> None:
+        _now = int(time.time())
+
+        # ------ execution ------ #
+        msg_queue.put_nowait(
+            StatusReport(
+                payload=OTAUpdatePhaseChangeReport(
+                    new_update_phase=UpdatePhase.APPLYING_UPDATE,
+                    trigger_timestamp=_now,
+                ),
+                session_id=self.SESSION_ID_FOR_TEST,
+            )
+        )
+
+        for _ in range(self.MULTI_PATHS_FILE):
+            msg_queue.put_nowait(
+                StatusReport(
+                    payload=UpdateProgressReport(
+                        operation=UpdateProgressReport.Type.APPLY_DELTA,
+                        processed_file_num=1,
+                        processed_file_size=1,
+                    ),
+                    session_id=self.SESSION_ID_FOR_TEST,
+                )
+            )
+
+        # ------ assertion ------ #
+        time.sleep(2)  # wait for reports being processed
+        otaclient_status = status_collector.otaclient_status
+        assert otaclient_status
+        assert otaclient_status.ota_status == OTAStatus.UPDATING
+        assert otaclient_status.update_phase == UpdatePhase.APPLYING_UPDATE
+        assert (
+            update_timing := otaclient_status.update_timing
+        ) and update_timing.update_apply_start_timestamp == _now
+
+    def test_post_update(
+        self, status_collector: OTAClientStatusCollector, msg_queue: Queue[StatusReport]
+    ) -> None:
+        _now = int(time.time())
+        msg_queue.put_nowait(
+            StatusReport(
+                payload=OTAUpdatePhaseChangeReport(
+                    new_update_phase=UpdatePhase.PROCESSING_POSTUPDATE,
+                    trigger_timestamp=_now,
+                ),
+                session_id=self.SESSION_ID_FOR_TEST,
+            )
+        )
+
+        time.sleep(2)  # wait for reports being processed
+        otaclient_status = status_collector.otaclient_status
+        assert otaclient_status
+        assert otaclient_status.ota_status == OTAStatus.UPDATING
+        assert otaclient_status.update_phase == UpdatePhase.PROCESSING_POSTUPDATE
+        assert (
+            update_timing := otaclient_status.update_timing
+        ) and update_timing.post_update_start_timestamp == _now
+
+    def test_finalizing_update(
+        self, status_collector: OTAClientStatusCollector, msg_queue: Queue[StatusReport]
+    ) -> None:
+        _now = int(time.time())
+        msg_queue.put_nowait(
+            StatusReport(
+                payload=OTAUpdatePhaseChangeReport(
+                    new_update_phase=UpdatePhase.FINALIZING_UPDATE,
+                    trigger_timestamp=_now,
+                ),
+                session_id=self.SESSION_ID_FOR_TEST,
+            )
+        )
+
+        time.sleep(2)  # wait for reports being processed
+        otaclient_status = status_collector.otaclient_status
+        assert otaclient_status
+        assert otaclient_status.ota_status == OTAStatus.UPDATING
+        assert otaclient_status.update_phase == UpdatePhase.FINALIZING_UPDATE
+
+    def test_confirm_update_progress(
+        self, status_collector: OTAClientStatusCollector
+    ) -> None:
+        time.sleep(2)  # wait for reports being processed
+
+        otaclient_status = status_collector.otaclient_status
+        assert otaclient_status
+        assert otaclient_status.ota_status == OTAStatus.UPDATING
+
+        # confirm the OTA status store is expected
+        # check update_progress
+        assert (update_progress := otaclient_status.update_progress)
+        assert update_progress.downloaded_files_num == self.DOWNLOAD_NUM
+        assert update_progress.processed_files_num == self.TOTAL_FILES_NUM
+        assert update_progress.processed_files_size == self.TOTAL_FILES_SIZE

--- a/tests/test_otaclient/test_status_monitor.py
+++ b/tests/test_otaclient/test_status_monitor.py
@@ -258,7 +258,8 @@ class TestStatusMonitor:
                     total_download_files_num=self.DOWNLOAD_NUM,
                     total_download_files_size=self.DWONLOAD_SIZE,
                     total_remove_files_num=123,
-                )
+                ),
+                session_id=self.SESSION_ID_FOR_TEST,
             )
         )
 

--- a/tests/test_otaclient/test_status_monitor.py
+++ b/tests/test_otaclient/test_status_monitor.py
@@ -251,6 +251,17 @@ class TestStatusMonitor:
                 )
             )
 
+        # NOTE: we know what to download after delta being calculated
+        msg_queue.put_nowait(
+            StatusReport(
+                payload=SetUpdateMetaReport(
+                    total_download_files_num=self.DOWNLOAD_NUM,
+                    total_download_files_size=self.DWONLOAD_SIZE,
+                    total_remove_files_num=123,
+                )
+            )
+        )
+
         # ------ assertion ------ #
         time.sleep(2)  # wait for reports being processed
 
@@ -264,6 +275,10 @@ class TestStatusMonitor:
         assert (update_progress := otaclient_status.update_progress)
         assert update_progress.processed_files_num == self.DELTA_NUM
         assert update_progress.processed_files_size == self.DELTA_SIZE
+        assert (update_meta := otaclient_status.update_meta)
+        assert update_meta.total_download_files_num == self.DOWNLOAD_NUM
+        assert update_meta.total_download_files_size == self.DWONLOAD_SIZE
+        assert update_meta.total_remove_files_num == 123
 
     def test_download_ota_files(
         self, status_collector: OTAClientStatusCollector, msg_queue: Queue[StatusReport]
@@ -410,8 +425,6 @@ class TestStatusMonitor:
         assert otaclient_status.ota_status == OTAStatus.UPDATING
 
         # confirm the OTA status store is expected
-        # check update_progress
         assert (update_progress := otaclient_status.update_progress)
-        assert update_progress.downloaded_files_num == self.DOWNLOAD_NUM
         assert update_progress.processed_files_num == self.TOTAL_FILES_NUM
         assert update_progress.processed_files_size == self.TOTAL_FILES_SIZE

--- a/tests/test_otaclient/test_status_monitor.py
+++ b/tests/test_otaclient/test_status_monitor.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import random
 import time
@@ -174,7 +175,9 @@ class TestStatusMonitor:
         assert (update_progress := otaclient_status.update_progress)
         assert update_progress.downloaded_bytes == self.METADATA_SIZE
 
-    def test_filter_invalid_session_id(self, msg_queue: Queue[StatusReport]) -> None:
+    def test_filter_invalid_session_id(
+        self, msg_queue: Queue[StatusReport], caplog: pytest.LogCaptureFixture
+    ) -> None:
         """This test put reports with invalid session_id into the msg_queue.
 
         If the filter is working, all the later test methods will not fail.
@@ -215,6 +218,10 @@ class TestStatusMonitor:
                 session_id=_invalid_session_id,
             )
         )
+
+        time.sleep(2)
+        assert len(caplog.records) == 3  # three warning logs are issued
+        assert all(_record.levelno == logging.WARNING for _record in caplog.records)
 
     def test_calculate_delta(
         self, status_collector: OTAClientStatusCollector, msg_queue: Queue[StatusReport]


### PR DESCRIPTION
## Introduction

> [!NOTE]
> This PR is split from the #392 and part of the otaclient re-architecture.

> [!NOTE]
> This PR only introduces the new status_monitor, but not yet integrate it.

This PR introduces a new implementation of otaclient internal status monitor based on message queue. 
Note that the introduced new implementation is not yet integrated into the otaclient, will be done in the following PRs.