### PR TITLE
refactor(ota_metadata.legacy): remove unused dynamic import

### DIFF
--- a/src/ota_metadata/legacy/__init__.py
+++ b/src/ota_metadata/legacy/__init__.py
@@ -13,22 +13,4 @@
 # limitations under the License.
 """OTA image metadata, legacy version."""
 
-
-from __future__ import annotations
-
-import sys
-from pathlib import Path
-
-from otaclient_common import import_from_file
-
 SUPORTED_COMPRESSION_TYPES = ("zst", "zstd")
-
-# ------ dynamically import pb2 generated code ------ #
-
-_PROTO_DIR = Path(__file__).parent
-_PB2_FPATH = _PROTO_DIR / "ota_metafiles_pb2.py"
-_PACKAGE_PREFIX = ".".join(__name__.split(".")[:-1])
-
-_module_name, _module = import_from_file(_PB2_FPATH)
-sys.modules[_module_name] = _module
-sys.modules[f"{_PACKAGE_PREFIX}.{_module_name}"] = _module

--- a/src/otaclient/app/main.py
+++ b/src/otaclient/app/main.py
@@ -23,9 +23,6 @@ from pathlib import Path
 
 import grpc.aio
 
-# NOTE: as ota_metadata are using dynamic module import,
-#   we need to import them before any other otaclient modules.
-import ota_metadata.legacy  # noqa: F401
 from otaclient import __version__
 from otaclient.app.configs import config as cfg
 from otaclient.app.configs import ecu_info, server_cfg


### PR DESCRIPTION
## Introduction

This PR cleans up the ota_metadata.legacy package, remove the unused dynamic package proto generated package import as it is not used.