### PR TITLE
refactor: split slot mount helper as a standalone module, refactor to make the mount/umount more robust

### DIFF
--- a/src/otaclient/boot_control/_grub.py
+++ b/src/otaclient/boot_control/_grub.py
@@ -43,6 +43,7 @@ from subprocess import CalledProcessError
 from typing import ClassVar, Dict, Generator, List, Optional, Tuple
 
 from otaclient import errors as ota_errors
+from otaclient.boot_control._slot_mnt_helper import SlotMountHelper
 from otaclient.configs.cfg import cfg
 from otaclient_api.v2 import types as api_types
 from otaclient_common._io import (
@@ -55,7 +56,6 @@ from otaclient_common.common import subprocess_call, subprocess_check_output
 from ._common import (
     CMDHelperFuncs,
     OTAStatusFilesControl,
-    SlotMountHelper,
     cat_proc_cmdline,
 )
 from .configs import grub_cfg as boot_cfg
@@ -751,7 +751,7 @@ class GrubController(BootControllerProtocol):
             self._mp_control = SlotMountHelper(
                 standby_slot_dev=self._boot_control.standby_root_dev,
                 standby_slot_mount_point=cfg.STANDBY_SLOT_MNT,
-                active_slot_dev=self._boot_control.active_root_dev,
+                active_rootfs=cfg.ACTIVE_ROOT,
                 active_slot_mount_point=cfg.ACTIVE_SLOT_MNT,
             )
             self._ota_status_control = OTAStatusFilesControl(

--- a/src/otaclient/boot_control/_jetson_cboot.py
+++ b/src/otaclient/boot_control/_jetson_cboot.py
@@ -31,6 +31,7 @@ from otaclient.boot_control._firmware_package import (
     PayloadType,
     load_firmware_package,
 )
+from otaclient.boot_control._slot_mnt_helper import SlotMountHelper
 from otaclient.configs.cfg import cfg
 from otaclient_api.v2 import types as api_types
 from otaclient_common import replace_root
@@ -38,7 +39,7 @@ from otaclient_common._io import cal_file_digest
 from otaclient_common.common import subprocess_run_wrapper
 from otaclient_common.typing import StrOrPath
 
-from ._common import CMDHelperFuncs, OTAStatusFilesControl, SlotMountHelper
+from ._common import CMDHelperFuncs, OTAStatusFilesControl
 from ._jetson_common import (
     SLOT_PAR_MAP,
     BSPVersion,
@@ -453,7 +454,7 @@ class JetsonCBootControl(BootControllerProtocol):
             self._mp_control = SlotMountHelper(
                 standby_slot_dev=self._cboot_control.standby_rootfs_devpath,
                 standby_slot_mount_point=cfg.STANDBY_SLOT_MNT,
-                active_slot_dev=self._cboot_control.curent_rootfs_devpath,
+                active_rootfs=cfg.ACTIVE_ROOT,
                 active_slot_mount_point=cfg.ACTIVE_SLOT_MNT,
             )
 

--- a/src/otaclient/boot_control/_jetson_uefi.py
+++ b/src/otaclient/boot_control/_jetson_uefi.py
@@ -177,7 +177,7 @@ EFIVARS_SYS_MOUNT_POINT = "/sys/firmware/efi/efivars/"
 @contextlib.contextmanager
 def _ensure_efivarfs_mounted() -> Generator[None, Any, None]:  # pragma: no cover
     """Ensure the efivarfs is mounted as rw, and then umount it."""
-    if CMDHelperFuncs.is_target_mounted(EFIVARS_SYS_MOUNT_POINT):
+    if CMDHelperFuncs.is_target_mounted(EFIVARS_SYS_MOUNT_POINT, raise_exception=False):
         options = "remount,rw,nosuid,nodev,noexec,relatime"
     else:
         logger.warning(

--- a/src/otaclient/boot_control/_jetson_uefi.py
+++ b/src/otaclient/boot_control/_jetson_uefi.py
@@ -39,6 +39,7 @@ from otaclient.boot_control._firmware_package import (
     PayloadType,
     load_firmware_package,
 )
+from otaclient.boot_control._slot_mnt_helper import SlotMountHelper
 from otaclient.configs.cfg import cfg
 from otaclient_api.v2 import types as api_types
 from otaclient_common import replace_root
@@ -46,7 +47,7 @@ from otaclient_common._io import cal_file_digest, file_sha256, write_str_to_file
 from otaclient_common.common import subprocess_call
 from otaclient_common.typing import StrOrPath
 
-from ._common import CMDHelperFuncs, OTAStatusFilesControl, SlotMountHelper
+from ._common import CMDHelperFuncs, OTAStatusFilesControl
 from ._jetson_common import (
     SLOT_PAR_MAP,
     BSPVersion,
@@ -861,7 +862,7 @@ class JetsonUEFIBootControl(BootControllerProtocol):
             self._mp_control = SlotMountHelper(
                 standby_slot_dev=uefi_control.standby_rootfs_devpath,
                 standby_slot_mount_point=cfg.STANDBY_SLOT_MNT,
-                active_slot_dev=self._uefi_control.curent_rootfs_devpath,
+                active_rootfs=cfg.ACTIVE_ROOT,
                 active_slot_mount_point=cfg.ACTIVE_SLOT_MNT,
             )
 

--- a/src/otaclient/boot_control/_rpi_boot.py
+++ b/src/otaclient/boot_control/_rpi_boot.py
@@ -27,6 +27,7 @@ from typing import Any, Generator, Literal
 from typing_extensions import Self
 
 import otaclient.errors as ota_errors
+from otaclient.boot_control._slot_mnt_helper import SlotMountHelper
 from otaclient.configs.cfg import cfg
 from otaclient_api.v2 import types as api_types
 from otaclient_common._io import copyfile_atomic, write_str_to_file_atomic
@@ -36,7 +37,6 @@ from otaclient_common.typing import StrOrPath
 from ._common import (
     CMDHelperFuncs,
     OTAStatusFilesControl,
-    SlotMountHelper,
 )
 from .configs import rpi_boot_cfg as boot_cfg
 from .protocol import BootControllerProtocol
@@ -436,7 +436,7 @@ class RPIBootController(BootControllerProtocol):
             self._mp_control = SlotMountHelper(
                 standby_slot_dev=self._rpiboot_control.standby_slot_dev,
                 standby_slot_mount_point=cfg.STANDBY_SLOT_MNT,
-                active_slot_dev=self._rpiboot_control.active_slot_dev,
+                active_rootfs=cfg.ACTIVE_ROOT,
                 active_slot_mount_point=cfg.ACTIVE_SLOT_MNT,
             )
             # init ota-status files

--- a/src/otaclient/boot_control/_slot_mnt_helper.py
+++ b/src/otaclient/boot_control/_slot_mnt_helper.py
@@ -44,7 +44,7 @@ def ensure_mount(
     for _retry in range(MAX_RETRY_COUNT + 1):
         try:
             mount_func(target=target, mount_point=mnt_point)
-            CMDHelperFuncs.is_target_mounted(target, raise_exception=True)
+            CMDHelperFuncs.is_target_mounted(mnt_point, raise_exception=True)
             return
         except CalledProcessError as e:
             logger.error(
@@ -72,14 +72,11 @@ def ensure_umount(
     Raises:
         If <ignore_error> is False, raises the last failed attemp's CalledProcessError.
     """
-    if not CMDHelperFuncs.is_target_mounted(mnt_point, raise_exception=False):
-        return
-
     for _retry in range(MAX_RETRY_COUNT + 1):
         try:
-            CMDHelperFuncs.umount(mnt_point, raise_exception=True)
             if not CMDHelperFuncs.is_target_mounted(mnt_point, raise_exception=False):
                 break
+            CMDHelperFuncs.umount(mnt_point, raise_exception=True)
         except CalledProcessError as e:
             logger.warning(f"retry#{_retry} failed to umount {mnt_point}: {e!r}")
             logger.warning(f"{e.stderr}\n{e.stdout}")
@@ -151,6 +148,8 @@ class SlotMountHelper:  # pragma: no cover
         """
         logger.debug("mount standby slot rootfs dev...")
         ensure_mointpoint(self.standby_slot_mount_point)
+        ensure_umount(self.standby_slot_dev, ignore_error=False)
+
         ensure_mount(
             target=self.standby_slot_dev,
             mnt_point=self.standby_slot_mount_point,

--- a/src/otaclient/boot_control/_slot_mnt_helper.py
+++ b/src/otaclient/boot_control/_slot_mnt_helper.py
@@ -78,7 +78,8 @@ def ensure_umount(
     for _retry in range(MAX_RETRY_COUNT + 1):
         try:
             CMDHelperFuncs.umount(mnt_point, raise_exception=True)
-            break
+            if not CMDHelperFuncs.is_target_mounted(mnt_point, raise_exception=False):
+                break
         except CalledProcessError as e:
             logger.warning(f"retry#{_retry} failed to umount {mnt_point}: {e!r}")
             logger.warning(f"{e.stderr}\n{e.stdout}")

--- a/src/otaclient/boot_control/_slot_mnt_helper.py
+++ b/src/otaclient/boot_control/_slot_mnt_helper.py
@@ -1,0 +1,188 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helper for mounting/umount slots during OTA."""
+
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+from subprocess import CalledProcessError
+from time import sleep
+from typing import Optional
+
+from otaclient.boot_control._common import CMDHelperFuncs
+from otaclient.configs.cfg import cfg
+from otaclient_common import replace_root
+from otaclient_common.typing import StrOrPath
+
+logger = logging.getLogger(__name__)
+
+MAX_RETRY_COUNT = 6
+RETRY_INTERVAL = 2
+
+
+class SlotMountHelper:
+    """Helper class that provides methods for mounting slots."""
+
+    def __init__(
+        self,
+        *,
+        standby_slot_dev: StrOrPath,
+        standby_slot_mount_point: StrOrPath,
+        active_rootfs: StrOrPath,
+        active_slot_mount_point: StrOrPath,
+    ) -> None:
+        self.standby_slot_dev = str(standby_slot_dev)
+        self.active_rootfs = str(active_rootfs)
+
+        self.standby_slot_mount_point = Path(standby_slot_mount_point)
+        self.active_slot_mount_point = Path(active_slot_mount_point)
+
+        # standby slot /boot dir
+        # NOTE(20230907): this will always be <standby_slot_mp>/boot,
+        #                 in the future this attribute will not be used by
+        #                 standby slot creater.
+        self.standby_boot_dir = Path(
+            replace_root(
+                cfg.BOOT_DPATH, cfg.CANONICAL_ROOT, self.standby_slot_mount_point
+            )
+        )
+
+    @staticmethod
+    def _umount(mnt_point: StrOrPath, *, ignore_error: bool) -> None:
+        """Try to umount the <mnt_point> at our best.
+
+        Raises:
+            If <ignore_error> is False, raises the last failed attemp's CalledProcessError.
+        """
+        if not CMDHelperFuncs.is_target_mounted(mnt_point):
+            return
+
+        for _retry in range(MAX_RETRY_COUNT + 1):
+            try:
+                CMDHelperFuncs.umount(mnt_point, raise_exception=True)
+                break
+            except CalledProcessError as e:
+                logger.warning(f"retry#{_retry} failed to umount standby slot: {e!r}")
+                logger.warning(f"{e.stderr}\n{e.stdout}")
+
+                if _retry >= MAX_RETRY_COUNT:
+                    logger.error(f"reached max retry on umounting {mnt_point}, abort")
+                    if not ignore_error:
+                        raise
+
+                sleep(RETRY_INTERVAL)
+                continue
+
+    def _ensure_mointpoint(self, mnt_point: Path) -> None:
+        """Ensure the <mnt_point> exists, has no mount on it and ready for mount.
+
+        If the <mnt_point> is valid, but we failed to umount any previous mounts on it,
+            we still keep use the mountpoint as later mount will override the previous one.
+        """
+        if not mnt_point.is_dir():
+            mnt_point.unlink(missing_ok=True)
+
+        if not mnt_point.exists():
+            mnt_point.mkdir(exist_ok=True, parents=True)
+            return
+
+        try:
+            self._umount(mnt_point, ignore_error=False)
+        except Exception:
+            logger.warning(f"still use {mnt_point} and override the previous mount")
+
+    @staticmethod
+    def _ensure_mount(target: StrOrPath, mnt_point: StrOrPath, *, mount_func) -> None:
+        for _retry in range(MAX_RETRY_COUNT + 1):
+            try:
+                mount_func(target=target, mount_point=mnt_point)
+                CMDHelperFuncs.is_target_mounted(target, raise_exception=True)
+                return
+            except CalledProcessError as e:
+                logger.error(f"retry#{_retry} failed to mout standby slot: {e!r}")
+                logger.error(f"{e.stderr=}\n{e.stdout=}")
+
+                if _retry == MAX_RETRY_COUNT:
+                    logger.error("exceed max retry count on mounting, abort")
+                    raise
+
+                sleep(RETRY_INTERVAL)
+                continue
+
+    def mount_standby(self) -> None:
+        """Mount standby slot dev to <standby_slot_mount_point>.
+
+        Raises:
+            CalledProcessedError on the last failed attemp.
+        """
+        logger.debug("mount standby slot rootfs dev...")
+        self._ensure_mointpoint(self.standby_slot_mount_point)
+        self._ensure_mount(
+            target=self.standby_slot_dev,
+            mnt_point=self.standby_slot_mount_point,
+            mount_func=CMDHelperFuncs.mount_rw,
+        )
+
+    def mount_active(self) -> None:
+        """Mount current active rootfs ready-only.
+
+        Raises:
+            CalledProcessedError on the last failed attemp.
+        """
+        logger.debug("mount active slot rootfs dev...")
+        self._ensure_mointpoint(self.active_slot_mount_point)
+        self._ensure_mount(
+            target=self.active_rootfs,
+            mnt_point=self.active_slot_mount_point,
+            mount_func=CMDHelperFuncs.bind_mount_ro,
+        )
+
+    def preserve_ota_folder_to_standby(self):
+        """Copy the /boot/ota folder to standby slot to preserve it.
+
+        /boot/ota folder contains the ota setting for this device,
+        so we should preserve it for each slot, accross each update.
+        """
+        logger.debug("copy /boot/ota from active to standby.")
+        try:
+            _src = self.active_slot_mount_point / Path(cfg.OTA_DPATH).relative_to("/")
+            _dst = self.standby_slot_mount_point / Path(cfg.OTA_DPATH).relative_to("/")
+            shutil.copytree(_src, _dst, dirs_exist_ok=True)
+        except Exception as e:
+            raise ValueError(
+                f"failed to copy /boot/ota from active to standby: {e!r}"
+            ) from e
+
+    def prepare_standby_dev(
+        self,
+        *,
+        erase_standby: bool = False,
+        fslabel: Optional[str] = None,
+    ) -> None:
+        CMDHelperFuncs.umount(self.standby_slot_dev, raise_exception=False)
+        if erase_standby:
+            return CMDHelperFuncs.mkfs_ext4(self.standby_slot_dev, fslabel=fslabel)
+
+        # TODO: in the future if in-place update mode is implemented, do a
+        #   fschck over the standby slot file system.
+        if fslabel:
+            CMDHelperFuncs.set_ext4_fslabel(self.standby_slot_dev, fslabel=fslabel)
+
+    def umount_all(self, *, ignore_error: bool = True):
+        logger.debug("unmount standby slot and active slot mount point...")
+        self._umount(self.active_slot_mount_point, ignore_error=ignore_error)
+        self._umount(self.standby_slot_mount_point, ignore_error=ignore_error)

--- a/src/otaclient/boot_control/_slot_mnt_helper.py
+++ b/src/otaclient/boot_control/_slot_mnt_helper.py
@@ -97,7 +97,7 @@ def ensure_mointpoint(mnt_point: Path) -> None:  # pragma: no cover
     If the <mnt_point> is valid, but we failed to umount any previous mounts on it,
         we still keep use the mountpoint as later mount will override the previous one.
     """
-    if not mnt_point.is_dir():
+    if mnt_point.is_symlink() or not mnt_point.is_dir():
         mnt_point.unlink(missing_ok=True)
 
     if not mnt_point.exists():

--- a/src/otaclient/boot_control/_slot_mnt_helper.py
+++ b/src/otaclient/boot_control/_slot_mnt_helper.py
@@ -34,7 +34,7 @@ RETRY_INTERVAL = 2
 
 
 def ensure_mount(
-    target: StrOrPath, mnt_point: StrOrPath, *, mount_func, raise_exception: bool = True
+    target: StrOrPath, mnt_point: StrOrPath, *, mount_func, raise_exception: bool
 ) -> None:  # pragma: no cover
     """Ensure the <target> mounted on <mnt_point> by our best.
 
@@ -91,7 +91,9 @@ def ensure_umount(
             continue
 
 
-def ensure_mointpoint(mnt_point: Path) -> None:  # pragma: no cover
+def ensure_mointpoint(
+    mnt_point: Path, *, ignore_error: bool
+) -> None:  # pragma: no cover
     """Ensure the <mnt_point> exists, has no mount on it and ready for mount.
 
     If the <mnt_point> is valid, but we failed to umount any previous mounts on it,
@@ -105,7 +107,7 @@ def ensure_mointpoint(mnt_point: Path) -> None:  # pragma: no cover
         return
 
     try:
-        ensure_umount(mnt_point, ignore_error=False)
+        ensure_umount(mnt_point, ignore_error=ignore_error)
     except Exception:
         logger.warning(
             f"{mnt_point} still has other mounts on it, "
@@ -147,13 +149,14 @@ class SlotMountHelper:  # pragma: no cover
             CalledProcessedError on the last failed attemp.
         """
         logger.debug("mount standby slot rootfs dev...")
-        ensure_mointpoint(self.standby_slot_mount_point)
+        ensure_mointpoint(self.standby_slot_mount_point, ignore_error=True)
         ensure_umount(self.standby_slot_dev, ignore_error=False)
 
         ensure_mount(
             target=self.standby_slot_dev,
             mnt_point=self.standby_slot_mount_point,
             mount_func=CMDHelperFuncs.mount_rw,
+            raise_exception=True,
         )
 
     def mount_active(self) -> None:
@@ -163,11 +166,12 @@ class SlotMountHelper:  # pragma: no cover
             CalledProcessedError on the last failed attemp.
         """
         logger.debug("mount active slot rootfs dev...")
-        ensure_mointpoint(self.active_slot_mount_point)
+        ensure_mointpoint(self.active_slot_mount_point, ignore_error=True)
         ensure_mount(
             target=self.active_rootfs,
             mnt_point=self.active_slot_mount_point,
             mount_func=CMDHelperFuncs.bind_mount_ro,
+            raise_exception=True,
         )
 
     def preserve_ota_folder_to_standby(self):

--- a/src/otaclient_common/linux.py
+++ b/src/otaclient_common/linux.py
@@ -200,7 +200,7 @@ def subprocess_run_wrapper(
     return subprocess.run(
         cmd,
         check=check,
-        stderr=subprocess.PIPE,
+        stderr=subprocess.PIPE if check_output else None,
         stdout=subprocess.PIPE if check_output else None,
         timeout=timeout,
         preexec_fn=preexec_fn,

--- a/src/otaclient_common/linux.py
+++ b/src/otaclient_common/linux.py
@@ -200,7 +200,7 @@ def subprocess_run_wrapper(
     return subprocess.run(
         cmd,
         check=check,
-        stderr=subprocess.PIPE if check_output else None,
+        stderr=subprocess.PIPE,
         stdout=subprocess.PIPE if check_output else None,
         timeout=timeout,
         preexec_fn=preexec_fn,

--- a/tests/test_otaclient/test_boot_control/test_grub.py
+++ b/tests/test_otaclient/test_boot_control/test_grub.py
@@ -237,8 +237,9 @@ class TestGrubControl:
         grub_ab_slot: tuple[Path, Path, Path],
         _grub_mkconfig_fsm: GrubMkConfigFSM,
     ):
-        from otaclient.boot_control._common import CMDHelperFuncs, SlotMountHelper
+        from otaclient.boot_control._common import CMDHelperFuncs
         from otaclient.boot_control._grub import GrubABPartitionDetector
+        from otaclient.boot_control._slot_mnt_helper import SlotMountHelper
 
         slot_a, slot_b, _ = grub_ab_slot
 

--- a/tests/test_otaclient/test_boot_control/test_rpi_boot.py
+++ b/tests/test_otaclient/test_boot_control/test_rpi_boot.py
@@ -24,8 +24,9 @@ import pytest
 import pytest_mock
 
 from otaclient.boot_control import _rpi_boot
-from otaclient.boot_control._common import CMDHelperFuncs, SlotMountHelper
+from otaclient.boot_control._common import CMDHelperFuncs
 from otaclient.boot_control._rpi_boot import RPIBootController
+from otaclient.boot_control._slot_mnt_helper import SlotMountHelper
 from otaclient.boot_control.configs import RPIBootControlConfig, rpi_boot_cfg
 from otaclient.configs import DefaultOTAClientConfigs
 from otaclient.configs.cfg import cfg as otaclient_cfg


### PR DESCRIPTION
## Introduction

This PR implements the robust mount/umount for SlotMountHelper. Now otaclient will try its best to ensure the mount point is clear(no other mounts on it) before mount, and for standby slot mount, also ensure the standby slot dev is not mounted before mounting. The failure reason for the mount failure will also be logged.


## Tests

- [x] OTA works when the active_slot and/or standby slot mount points are both already mounted.
- [x] OTA works when the standby slot dev is already mounted(at multiple places).
- [x] OTA works when the `/run/otaclient/mnt` is removed.
- [x] normal OTA works.