### PR TITLE
feat: add otaclient_common.shm_status for sharing status between processes

### DIFF
--- a/src/otaclient_common/shm_status.py
+++ b/src/otaclient_common/shm_status.py
@@ -1,0 +1,157 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A lib for sharing status between processes.
+
+shared memory layout:
+
+rwlock(1byte) | hmac-sha3_512(64bytes) | msg_len(4bytes,big) | msg(<msg_len>bytes)
+In which, msg is pickled python object.
+"""
+
+
+from __future__ import annotations
+
+import hmac
+import logging
+import multiprocessing.shared_memory as mp_shm
+import pickle
+import time
+from typing import Generic
+
+from otaclient_common.typing import T
+
+logger = logging.getLogger(__name__)
+
+HASH_ALG = "sha3_512"
+DEFAULT_KEY_LEN = 64  # bytes
+
+RWLOCK_LEN = 1  # byte
+HMAC_SHA3_512_LEN = 64  # bytes
+PAYLOAD_LEN_BYTES = 4  # bytes
+MIN_ENCAP_MSG_LEN = RWLOCK_LEN + HMAC_SHA3_512_LEN + PAYLOAD_LEN_BYTES
+
+RWLOCK_LOCKED = b"\xab"
+RWLOCK_OPEN = b"\x54"
+
+
+class MPSharedStatusReader(Generic[T]):
+
+    def __init__(
+        self, *, name: str, key: bytes, max_retry: int = 6, retry_interval: int = 1
+    ) -> None:
+        for _idx in range(max_retry):
+            try:
+                self._shm = shm = mp_shm.SharedMemory(name=name, create=False)
+                break
+            except Exception as e:
+                logger.warning(
+                    f"retry #{_idx}: failed to connect to {name=}: {e!r}, keep retrying ..."
+                )
+                time.sleep(retry_interval)
+        else:
+            raise ValueError(f"failed to connect share memory with {name=}")
+
+        self.mem_size = size = shm.size
+        self.msg_max_size = size - MIN_ENCAP_MSG_LEN
+        self._key = key
+
+    def atexit(self) -> None:
+        self._shm.close()
+
+    def sync_msg(self) -> T:
+        buffer = self._shm.buf
+
+        # check if we can read
+        _cursor = 0
+        rwlock = bytes(buffer[_cursor:RWLOCK_LEN])
+        if rwlock != RWLOCK_OPEN:
+            if rwlock == RWLOCK_LOCKED:
+                raise ValueError("write in progress, abort")
+            raise ValueError(f"invalid input_msg: wrong rwlock bytes: {rwlock=}")
+        _cursor += RWLOCK_LEN
+
+        # parsing the msg
+        input_hmac = bytes(buffer[_cursor : _cursor + HMAC_SHA3_512_LEN])
+        _cursor += HMAC_SHA3_512_LEN
+
+        _payload_len_bytes = bytes(buffer[_cursor : _cursor + PAYLOAD_LEN_BYTES])
+        payload_len = int.from_bytes(_payload_len_bytes, "big", signed=False)
+        _cursor += PAYLOAD_LEN_BYTES
+
+        if payload_len > self.msg_max_size:
+            raise ValueError(f"invalid msg: {payload_len=} > {self.msg_max_size}")
+
+        payload = bytes(buffer[_cursor : _cursor + payload_len])
+        payload_hmac = hmac.digest(key=self._key, msg=payload, digest=HASH_ALG)
+
+        if hmac.compare_digest(payload_hmac, input_hmac):
+            return pickle.loads(payload)
+        raise ValueError("failed to validate input msg")
+
+
+class MPSharedStatusWriter(Generic[T]):
+
+    def __init__(
+        self,
+        *,
+        name: str | None = None,
+        size: int = 0,
+        create: bool = False,
+        msg_max_size: int | None = None,
+        key: bytes,
+    ) -> None:
+        if create:
+            _msg_max_size = size - MIN_ENCAP_MSG_LEN
+            if _msg_max_size < 0:
+                raise ValueError(f"{size=} < {MIN_ENCAP_MSG_LEN=}")
+            self._shm = shm = mp_shm.SharedMemory(name=name, size=size, create=True)
+            self.mem_size = shm.size
+        else:
+            self._shm = shm = mp_shm.SharedMemory(name=name, create=False)
+            self.mem_size = size = shm.size
+            _msg_max_size = size - MIN_ENCAP_MSG_LEN
+            if _msg_max_size < 0:
+                shm.close()
+                raise ValueError(f"{size=} < {MIN_ENCAP_MSG_LEN=}")
+
+        self.name = shm.name
+        self._key = key
+        self.msg_max_size = min(_msg_max_size, msg_max_size or float("infinity"))
+
+    def atexit(self) -> None:
+        self._shm.close()
+
+    def write_msg(self, obj: T) -> None:
+        buffer = self._shm.buf
+        _pickled = pickle.dumps(obj)
+        _pickled_len = len(_pickled)
+
+        if _pickled_len > self.msg_max_size:
+            raise ValueError(f"exceed {self.msg_max_size=}: {_pickled_len=}")
+
+        _hmac = hmac.digest(key=self._key, msg=_pickled, digest=HASH_ALG)
+        msg = b"".join(
+            [
+                RWLOCK_LOCKED,
+                _hmac,
+                _pickled_len.to_bytes(PAYLOAD_LEN_BYTES, "big", signed=False),
+                _pickled,
+            ]
+        )
+        msg_len = len(msg)
+        if msg_len > self.mem_size:
+            raise ValueError(f"{msg_len=} > {self.mem_size=}")
+
+        buffer[:msg_len] = msg
+        buffer[:1] = RWLOCK_OPEN

--- a/src/otaclient_common/shm_status.py
+++ b/src/otaclient_common/shm_status.py
@@ -33,13 +33,13 @@ from otaclient_common.typing import T
 
 logger = logging.getLogger(__name__)
 
-HASH_ALG = "sha3_512"
+HASH_ALG = "sha512"
 DEFAULT_KEY_LEN = 64  # bytes
 
 RWLOCK_LEN = 1  # byte
-HMAC_SHA3_512_LEN = 64  # bytes
+HMAC_SHA_512_LEN = 64  # bytes
 PAYLOAD_LEN_BYTES = 4  # bytes
-MIN_ENCAP_MSG_LEN = RWLOCK_LEN + HMAC_SHA3_512_LEN + PAYLOAD_LEN_BYTES
+MIN_ENCAP_MSG_LEN = RWLOCK_LEN + HMAC_SHA_512_LEN + PAYLOAD_LEN_BYTES
 
 RWLOCK_LOCKED = b"\xab"
 RWLOCK_OPEN = b"\x54"
@@ -82,8 +82,8 @@ class MPSharedStatusReader(Generic[T]):
         _cursor += RWLOCK_LEN
 
         # parsing the msg
-        input_hmac = bytes(buffer[_cursor : _cursor + HMAC_SHA3_512_LEN])
-        _cursor += HMAC_SHA3_512_LEN
+        input_hmac = bytes(buffer[_cursor : _cursor + HMAC_SHA_512_LEN])
+        _cursor += HMAC_SHA_512_LEN
 
         _payload_len_bytes = bytes(buffer[_cursor : _cursor + PAYLOAD_LEN_BYTES])
         payload_len = int.from_bytes(_payload_len_bytes, "big", signed=False)

--- a/tests/test_otaclient_common/test_shm_status.py
+++ b/tests/test_otaclient_common/test_shm_status.py
@@ -1,0 +1,185 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import multiprocessing.shared_memory as mp_shm
+import multiprocessing.synchronize as mp_sync
+import secrets
+import time
+from dataclasses import dataclass
+from functools import partial
+
+import pytest
+
+from otaclient_common.shm_status import (
+    DEFAULT_KEY_LEN,
+    MPSharedStatusReader,
+    MPSharedStatusWriter,
+    RWBusy,
+)
+
+
+@dataclass
+class OuterMsg:
+    _inner_msg: InnerMsg
+
+
+@dataclass
+class InnerMsg:
+    i_int: int
+    i_str: str
+
+
+class MsgReader(MPSharedStatusReader[OuterMsg]): ...
+
+
+class MsgWriter(MPSharedStatusWriter[OuterMsg]): ...
+
+
+DATA_ENTRIES_NUM = 10
+_TEST_DATA = {
+    _idx: OuterMsg(
+        InnerMsg(
+            i_int=_idx,
+            i_str=str(_idx),
+        )
+    )
+    for _idx in range(DATA_ENTRIES_NUM)
+}
+
+
+def writer_process(
+    shm_name: str,
+    key: bytes,
+    *,
+    interval: float,
+    write_all_flag: mp_sync.Event,
+):
+    _shm_writer = MsgWriter(name=shm_name, key=key)
+
+    for _, _entry in _TEST_DATA.items():
+        _shm_writer.write_msg(_entry)
+        time.sleep(interval)
+    write_all_flag.set()
+
+
+def read_slow_process(
+    shm_name: str,
+    key: bytes,
+    *,
+    interval: float,
+    success_flag: mp_sync.Event,
+):
+    """Reader is slower than writer, we only need to ensure reader can read the latest written msg."""
+    _shm_reader = MsgReader(name=shm_name, key=key)
+
+    while True:
+        _msg = _shm_reader.sync_msg()
+
+        if _msg._inner_msg.i_int == DATA_ENTRIES_NUM - 1:
+            return success_flag.set()
+        time.sleep(interval)
+
+
+def read_fast_process(
+    shm_name: str,
+    key: bytes,
+    *,
+    interval: float,
+    success_flag: mp_sync.Event,
+):
+    """Reader is faster than writer, we need to ensure all the msgs are read."""
+    _shm_reader = MsgReader(name=shm_name, key=key)
+    _read = [False for _ in range(DATA_ENTRIES_NUM)]
+
+    while True:
+        time.sleep(interval)
+        try:
+            _msg = _shm_reader.sync_msg()
+        except RWBusy:
+            continue
+
+        _read[_msg._inner_msg.i_int] = True
+        if all(_read):
+            return success_flag.set()
+
+
+WRITE_INTERVAL = 0.1
+READ_SLOW_INTERVAL = 0.5
+READ_FAST_INTERVAL = 0.01
+
+
+@pytest.mark.parametrize(
+    "reader_func, read_interval, timeout",
+    (
+        (
+            read_fast_process,
+            READ_FAST_INTERVAL,
+            WRITE_INTERVAL * DATA_ENTRIES_NUM + 1,
+        ),
+        (
+            read_slow_process,
+            READ_SLOW_INTERVAL,
+            WRITE_INTERVAL * DATA_ENTRIES_NUM + 1,
+        ),
+    ),
+)
+def test_shm_status_read_fast(reader_func, read_interval, timeout):
+    _shm = mp_shm.SharedMemory(size=1024, create=True)
+    _mp_ctx = mp.get_context("spawn")
+    _key = secrets.token_bytes(DEFAULT_KEY_LEN)
+
+    _write_all_flag = _mp_ctx.Event()
+    _success_flag = _mp_ctx.Event()
+
+    _writer_p = _mp_ctx.Process(
+        target=partial(
+            writer_process,
+            shm_name=_shm.name,
+            key=_key,
+            interval=WRITE_INTERVAL,
+            write_all_flag=_write_all_flag,
+        )
+    )
+    _reader_p = _mp_ctx.Process(
+        target=partial(
+            reader_func,
+            shm_name=_shm.name,
+            key=_key,
+            interval=read_interval,
+            success_flag=_success_flag,
+        )
+    )
+    _writer_p.start()
+    _reader_p.start()
+
+    def _cleanup():
+        _writer_p.terminate()
+        _writer_p.join()
+
+        _reader_p.terminate()
+        _reader_p.join()
+
+        _shm.close()
+        _shm.unlink()
+
+    time.sleep(timeout)
+    try:
+        assert _write_all_flag.is_set(), "writer timeout finish up writing"
+        assert _success_flag.is_set(), "reader failed to read all msg"
+    finally:
+        _cleanup()

--- a/tests/test_otaclient_common/test_shm_status.py
+++ b/tests/test_otaclient_common/test_shm_status.py
@@ -89,11 +89,14 @@ def read_slow_process(
     _shm_reader = MsgReader(name=shm_name, key=key)
 
     while True:
-        _msg = _shm_reader.sync_msg()
+        time.sleep(interval)
+        try:
+            _msg = _shm_reader.sync_msg()
+        except RWBusy:
+            continue
 
         if _msg._inner_msg.i_int == DATA_ENTRIES_NUM - 1:
             return success_flag.set()
-        time.sleep(interval)
 
 
 def read_fast_process(

--- a/tests/test_otaclient_common/test_shm_status.py
+++ b/tests/test_otaclient_common/test_shm_status.py
@@ -50,7 +50,7 @@ class MsgReader(MPSharedStatusReader[OuterMsg]): ...
 class MsgWriter(MPSharedStatusWriter[OuterMsg]): ...
 
 
-DATA_ENTRIES_NUM = 10
+DATA_ENTRIES_NUM = 20
 _TEST_DATA = {
     _idx: OuterMsg(
         InnerMsg(


### PR DESCRIPTION
## Introduction

This PR backports `otaclient_common.shm_status` module from the dev branch. This module achieves sharing status byu pickled python object securely and efficiently with shared memory and hmac-sha512. 