### PR TITLE
deps: bump aiohttp to >=3.10.11,<3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dynamic = [
 ]
 dependencies = [
   "aiofiles<25,>=24.1",
-  "aiohttp>=3.10.2,<3.12",
+  "aiohttp>=3.10.11,<3.12",
   "cryptography>=43.0.1,<44",
   "grpcio>=1.53.2,<1.69",
   "protobuf>=4.21.12,<5.29",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Automatically generated from pyproject.toml by gen_requirements_txt.py script.
 # DO NOT EDIT! Only for reference use.
 aiofiles<25,>=24.1
-aiohttp>=3.10.2,<3.12
+aiohttp>=3.10.11,<3.12
 cryptography>=43.0.1,<44
 grpcio>=1.53.2,<1.69
 protobuf>=4.21.12,<5.29


### PR DESCRIPTION
## Introduction

Bump aiohttp to >=3.10.11,<3.12, see https://www.cve.org/CVERecord?id=CVE-2024-52304 for more details.