### PR TITLE
fix: backport(v3.8.x): pin pyopenssl verison to 24.1.0, cryptography version to 42.0.8.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dynamic = [
 dependencies = [
   "aiofiles<25,>=24.1",
   "aiohttp>=3.9.5,<3.11",
-  "cryptography>=42.0.4,<44",
+  "cryptography==42.0.8",
   "grpcio<1.54,>=1.53.2",
   "protobuf<4.22,>=4.21.12",
   "pydantic<3,>=2.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "protobuf<4.22,>=4.21.12",
   "pydantic<3,>=2.6",
   "pydantic-settings<3,>=2.3",
-  "pyopenssl<25,>=24.1",
+  "pyopenssl==24.1.0",
   "pyyaml<7,>=6.0.1",
   "requests<2.33,>=2.32",
   "simple-sqlite3-orm<0.3,>=0.2",


### PR DESCRIPTION
## Introduction

This is a emergency fix due to a breaking change from pyopenssl since 24.3.0. In pyopenssl 24.3.0, some of the deprecated methods are removed, including the methods used by ota_metadata package. To workaround this issue quickly before we migrate to cryptography package, pin the pyopenssl package to 24.1.0.