### PR TITLE
refactor: drop pyopenssl dependency, use cryptography to re-implement OTA image verification logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,11 @@ dynamic = [
 dependencies = [
   "aiofiles<25,>=24.1",
   "aiohttp>=3.10.11,<3.12",
-  "cryptography>=42.0.8,<43",
+  "cryptography>=42.0.8,<45",
   "grpcio>=1.53.2,<1.69",
   "protobuf>=4.21.12,<5.29",
   "pydantic<3,>=2.6",
   "pydantic-settings<3,>=2.3",
-  "pyopenssl==24.1.0",
   "pyyaml<7,>=6.0.1",
   "requests<2.33,>=2.32",
   "simple-sqlite3-orm<0.3,>=0.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,11 @@
 # DO NOT EDIT! Only for reference use.
 aiofiles<25,>=24.1
 aiohttp>=3.10.11,<3.12
-cryptography>=42.0.8,<43
+cryptography>=42.0.8,<45
 grpcio>=1.53.2,<1.69
 protobuf>=4.21.12,<5.29
 pydantic<3,>=2.6
 pydantic-settings<3,>=2.3
-pyopenssl==24.1.0
 pyyaml<7,>=6.0.1
 requests<2.33,>=2.32
 simple-sqlite3-orm<0.3,>=0.2

--- a/src/ota_metadata/legacy/parser.py
+++ b/src/ota_metadata/legacy/parser.py
@@ -288,7 +288,6 @@ class _MetadataJWTParser:
 
         hit_cachain = self.ca_chains_store.verify(cert_to_verify)
         if hit_cachain:
-            logger.info(f"verfication succeeded against: {hit_cachain.chain_prefix}")
             return
 
         _err_msg = f"metadata sign certificate {metadata_cert} could not be verified"

--- a/src/ota_metadata/utils/cert_store.py
+++ b/src/ota_metadata/utils/cert_store.py
@@ -99,6 +99,19 @@ class CAChainStore(Dict[str, CAChain]):
     def add_chain(self, chain: CAChain) -> None:
         self[chain.chain_prefix] = chain
 
+    def verify(self, cert: Certificate) -> CAChain | None:
+        """Verify the input <cert> against this CAChainStore.
+
+        Returns:
+            Return the cachain that issues the <cert>, None if no cachain matches.
+        """
+        for _, chain in self.items():
+            try:
+                chain.verify(cert)
+                return chain
+            except Exception:
+                pass
+
 
 def load_ca_cert_chains(cert_dir: StrOrPath) -> CAChainStore:
     """Load CA cert chains from <cert_dir>.

--- a/src/ota_metadata/utils/cert_store.py
+++ b/src/ota_metadata/utils/cert_store.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Iterable
 
 from cryptography.x509 import Certificate, Name, load_pem_x509_certificate
 
@@ -52,6 +52,10 @@ class CACertChains(Dict[Name, Certificate]):
 
     def add_cert(self, cert: Certificate) -> None:
         self[cert.subject] = cert
+
+    def add_certs(self, certs: Iterable[Certificate]) -> None:
+        for cert in certs:
+            self[cert.subject] = cert
 
     def verify(self, cert: Certificate) -> None:
         """Verify the input <cert> against this chain.

--- a/src/ota_metadata/utils/cert_store.py
+++ b/src/ota_metadata/utils/cert_store.py
@@ -84,11 +84,11 @@ class CAChain(Dict[Name, Certificate]):
         """
         _now = datetime.now(tz=timezone.utc)
         if not (cert.not_valid_after_utc >= _now >= cert.not_valid_before_utc):
-            logger.error(
+            _err_msg = (
                 "cert is not within valid period: "
                 f"{cert.not_valid_after_utc=}, {_now=}, {cert.not_valid_before_utc=}"
             )
-            return
+            raise ValueError(_err_msg)
 
         _start = cert
         for _ in range(len(self) + 1):

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -36,8 +36,8 @@ import requests.exceptions as requests_exc
 from ota_metadata.legacy import parser as ota_metadata_parser
 from ota_metadata.legacy import types as ota_metadata_types
 from ota_metadata.utils.cert_store import (
-    CACertChainStore,
     CACertStoreInvalid,
+    CAChainStore,
     load_ca_cert_chains,
 )
 from otaclient import errors as ota_errors
@@ -161,7 +161,7 @@ class _OTAUpdater:
         version: str,
         raw_url_base: str,
         cookies_json: str,
-        ca_chains_store: CACertChainStore,
+        ca_chains_store: CAChainStore,
         upper_otaproxy: str | None = None,
         boot_controller: BootControllerProtocol,
         create_standby_cls: Type[StandbySlotCreatorProtocol],
@@ -682,7 +682,7 @@ class OTAClient:
             _err_msg = f"failed to import ca_chains_store: {e!r}, OTA will NOT occur on no CA chains installed!!!"
             logger.error(_err_msg)
 
-            self.ca_chains_store = CACertChainStore()
+            self.ca_chains_store = CAChainStore()
 
         self.started = True
         logger.info("otaclient started")

--- a/tools/offline_ota_image_builder/builder.py
+++ b/tools/offline_ota_image_builder/builder.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Mapping, Optional, Sequence
 
 from ota_metadata.legacy import parser as ota_metadata_parser
-from ota_metadata.utils.cert_store import CACertChainStore
+from ota_metadata.utils.cert_store import CAChainStore
 from otaclient_common.common import subprocess_call
 
 from .configs import cfg
@@ -75,7 +75,7 @@ def _process_ota_image(ota_image_dir: StrPath, *, data_dir: StrPath, meta_dir: S
     # NOTE: we don't need to do certificate verification here, sso we use an empty cert store.
     metadata_jwt = ota_metadata_parser._MetadataJWTParser(
         metadata_jwt_fpath.read_text(),
-        ca_chains_store=CACertChainStore(),
+        ca_chains_store=CAChainStore(),
     ).get_otametadata()
 
     rootfs_dir = ota_image_dir / metadata_jwt.rootfs_directory


### PR DESCRIPTION
## Introduction

This PR drops the pyopenssl dependency, refactors the OTA image verification logic with cryptography instead. 
Note that we don't use the cryptography's high-level x509 verification APIs as that APIs are dedicated for TLS. Instead we directly use low-level APIs to perform certificate signature & valid period check.

This PR pins the cryptography version to >=42.0.8, <45.

Major changes:
1. ota_metadata.utils.cert_store: re-implement with cryptography.
2. ota_metadata.legacy.parser: integrate the new cert_store.

https://tier4.atlassian.net/browse/RT4-13274