### PR TITLE
fix(backport v3.8.x): ota_proxy: fix disk space usage checker not working & backport #418

### DIFF
--- a/src/ota_proxy/cache_streaming.py
+++ b/src/ota_proxy/cache_streaming.py
@@ -335,6 +335,7 @@ async def cache_streaming(
     Raises:
         CacheStreamingFailed if any exception happens during retrieving.
     """
+    _cache_write_gen = None
     try:
         _cache_write_gen = await tracker.start_provider(cache_meta)
         _cache_writer_failed = False
@@ -370,8 +371,9 @@ async def cache_streaming(
     finally:
         # force terminate the generator in all condition at exit, this
         #   can ensure the generator being gced after cache_streaming exits.
-        with contextlib.suppress(StopAsyncIteration):
-            await _cache_write_gen.athrow(StopAsyncIteration)
+        if _cache_write_gen:
+            with contextlib.suppress(StopAsyncIteration):
+                await _cache_write_gen.athrow(StopAsyncIteration)
 
         # remove the refs
         fd, tracker = None, None  # type: ignore

--- a/src/ota_proxy/config.py
+++ b/src/ota_proxy/config.py
@@ -16,8 +16,8 @@
 class Config:
     BASE_DIR = "/ota-cache"
     CHUNK_SIZE = 1 * 1024 * 1024  # 4MB
-    DISK_USE_LIMIT_SOFT_P = 70  # in p%
-    DISK_USE_LIMIT_HARD_P = 80  # in p%
+    DISK_USE_LIMIT_SOFT_P = 90  # in p%
+    DISK_USE_LIMIT_HARD_P = 92  # in p%
     DISK_USE_PULL_INTERVAL = 2  # in seconds
     # value is the largest numbers of files that
     # might need to be deleted for the bucket to hold a new entry

--- a/src/ota_proxy/ota_cache.py
+++ b/src/ota_proxy/ota_cache.py
@@ -248,7 +248,7 @@ class OTACache:
                 self._storage_below_hard_limit_event.clear()
                 break
 
-            current_used_p = disk_usage.used / disk_usage.total * 100
+            current_used_p = int(disk_usage.used / disk_usage.total * 100)
 
             _previous_below_hard = self._storage_below_hard_limit_event.is_set()
             _current_below_hard = True
@@ -266,13 +266,13 @@ class OTACache:
             # logging space monitoring result
             if _previous_below_hard and not _current_below_hard:
                 logger.warning(
-                    f"disk usage reached hard limit({current_used_p=:.1}%,"
-                    f"{cfg.DISK_USE_LIMIT_HARD_P:.1}%), cache disabled"
+                    f"disk usage reached hard limit({current_used_p=}%,"
+                    f"{cfg.DISK_USE_LIMIT_HARD_P=}%), cache disabled"
                 )
             elif not _previous_below_hard and _current_below_hard:
                 logger.info(
-                    f"disk usage is below hard limit({current_used_p=:.1}%),"
-                    f"{cfg.DISK_USE_LIMIT_SOFT_P:.1}%), cache enabled again"
+                    f"disk usage is below hard limit({current_used_p=}%),"
+                    f"{cfg.DISK_USE_LIMIT_SOFT_P=}%), cache enabled again"
                 )
             time.sleep(cfg.DISK_USE_PULL_INTERVAL)
 


### PR DESCRIPTION
## Introduction

This PR fixes otaproxy's background disk space usage checker not working as expected due to checker thread exits early caused by raised exception, resulting in otaproxy LRU cache rotation not being triggered on soft disk space usage reached and otaproxy cache disabled on hard space usage reached.

This PR also backports a minor fix PR #418 .

Other changes include:
1. ota_proxy: increase soft limit to 90% disk usage, hard limit to 92% disk usage.

## Tests

- [x] confirm otaproxy's LRU cache triggered on soft disk space usage limitation reached.
- [x] normal OTA on VM e2e test works.