### PR TITLE
refactor(backport v3.8.x): ota_proxy: refine request handling flow

### DIFF
--- a/src/ota_proxy/ota_cache.py
+++ b/src/ota_proxy/ota_cache.py
@@ -392,7 +392,7 @@ class OTACache:
         resp_headers: CIMultiDictProxy[str] = await (_remote_fd := _do_request()).__anext__()  # type: ignore
         return _remote_fd, resp_headers
 
-    async def _retrieve_file_by_cache(
+    async def _retrieve_file_by_cache_lookup(
         self, *, raw_url: str, cache_policy: OTAFileCacheControl
     ) -> tuple[AsyncIterator[bytes], CIMultiDict[str]] | None:
         """
@@ -595,7 +595,7 @@ class OTACache:
         if _res := await self._retrieve_file_by_external_cache(cache_policy):
             return _res
 
-        if _res := await self._retrieve_file_by_cache(
+        if _res := await self._retrieve_file_by_cache_lookup(
             raw_url=raw_url, cache_policy=cache_policy
         ):
             return _res

--- a/src/ota_proxy/ota_cache.py
+++ b/src/ota_proxy/ota_cache.py
@@ -22,7 +22,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import AsyncIterator, List, Mapping, Optional, Tuple
+from typing import AsyncIterator, Mapping, Optional
 from urllib.parse import SplitResult, quote, urlsplit
 
 import aiohttp
@@ -276,7 +276,7 @@ class OTACache:
                 )
             time.sleep(cfg.DISK_USE_PULL_INTERVAL)
 
-    def _cache_entries_cleanup(self, entry_hashes: List[str]):
+    def _cache_entries_cleanup(self, entry_hashes: list[str]) -> None:
         """Cleanup entries indicated by entry_hashes list."""
         for entry_hash in entry_hashes:
             # remove cache entry
@@ -368,7 +368,7 @@ class OTACache:
         raw_url: str,
         *,
         headers: Mapping[str, str],
-    ) -> Tuple[AsyncIterator[bytes], CIMultiDictProxy[str]]:
+    ) -> tuple[AsyncIterator[bytes], CIMultiDictProxy[str]]:
         async def _do_request() -> AsyncIterator[bytes]:
             async with self._session.get(
                 self._process_raw_url(raw_url),


### PR DESCRIPTION
## Introduction

This PR simplifies the request handling flow, instead of implementing the guard conditions checks in retrieve_file API, now the guard conditions checks are implemented within each _retrieve_file handlers.

## Test

- [ ] test OTA with controlling disk usage transits from below soft limit to reaching hard limit.