### PR TITLE
refactor(ota_proxy): refine request handling flow, allow external_cache mount without cache_enabled=True, fix disk usage checker

### DIFF
--- a/src/ota_proxy/ota_cache.py
+++ b/src/ota_proxy/ota_cache.py
@@ -139,11 +139,7 @@ class OTACache:
 
         self._external_cache_data_dir = None
         self._external_cache_mp = None
-        if (
-            cache_enabled
-            and external_cache_mnt_point
-            and mount_external_cache(external_cache_mnt_point)
-        ):
+        if external_cache_mnt_point and mount_external_cache(external_cache_mnt_point):
             logger.info(
                 f"external cache source is enabled at: {external_cache_mnt_point}"
             )


### PR DESCRIPTION
## Introduction

This PR simplifies the request handling flow, instead of implementing the guard conditions checks in retrieve_file API, now the guard conditions checks are implemented within each _retrieve_file handlers.

Minor fix:
1. ota_proxy: fixing the background disk space usage checker thread exits unexpectedly.

Behavior changes:
1. ota_proxy external cache feature now is enabled without checking cache_enabled flag.