### PR TITLE
feat(retry_task_map): introduce worker-thread-scope backoff wait on failed tasks rescheduling.

### DIFF
--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -255,6 +255,8 @@ if TYPE_CHECKING:
             watchdog_check_interval: int = 3,  # seconds
             initializer: Callable[..., Any] | None = None,
             initargs: tuple = (),
+            backoff_factor: float = 0.01,
+            backoff_max: float = 1,
         ) -> None:
             """Initialize a ThreadPoolExecutorWithRetry instance.
 
@@ -270,6 +272,10 @@ if TYPE_CHECKING:
                     Defaults to None.
                 initargs (tuple): The same <initargs> param passed through to ThreadPoolExecutor.
                     Defaults to ().
+                backoff_factor (float): The backoff factor on thread-scope backoff wait for failed tasks rescheduling.
+                    Defaults to 0.01.
+                backoff_max (float): The backoff max on thread-scope backoff wait for failed tasks rescheduling.
+                    Defaults to 1.
             """
             raise NotImplementedError
 

--- a/tests/test_otaclient_common/test_retry_task_map.py
+++ b/tests/test_otaclient_common/test_retry_task_map.py
@@ -32,6 +32,8 @@ TASKS_COUNT = 2000
 MAX_CONCURRENT = 128
 MAX_WAIT_BEFORE_SUCCESS = 10
 THREAD_INIT_MSG = "thread init message"
+BACKOFF_FACTOR = 0.001  # for faster test
+BACKOFF_MAX = 0.1
 
 
 class _RetryTaskMapTestErr(Exception):
@@ -47,7 +49,7 @@ def _thread_initializer(msg: str) -> None:
 class TestRetryTaskMap:
 
     @pytest.fixture(autouse=True)
-    def setup(self):
+    def setup(self) -> None:
         self._start_time = time.time()
         self._success_wait_dict = {
             idx: random.randint(0, MAX_WAIT_BEFORE_SUCCESS)
@@ -83,6 +85,8 @@ class TestRetryTaskMap:
             watchdog_func=_exit_on_exceed_max_count,
             initializer=_thread_initializer,
             initargs=(THREAD_INIT_MSG,),
+            backoff_factor=BACKOFF_FACTOR,
+            backoff_max=BACKOFF_MAX,
         ) as executor:
             with pytest.raises(retry_task_map.TasksEnsureFailed):
                 for _fut in executor.ensure_tasks(
@@ -99,6 +103,8 @@ class TestRetryTaskMap:
             max_total_retry=MAX_TOTAL_RETRY,
             initializer=_thread_initializer,
             initargs=(THREAD_INIT_MSG,),
+            backoff_factor=BACKOFF_FACTOR,
+            backoff_max=BACKOFF_MAX,
         ) as executor:
             with pytest.raises(retry_task_map.TasksEnsureFailed):
                 for _fut in executor.ensure_tasks(
@@ -115,6 +121,8 @@ class TestRetryTaskMap:
             max_concurrent=MAX_CONCURRENT,
             initializer=_thread_initializer,
             initargs=(THREAD_INIT_MSG,),
+            backoff_factor=BACKOFF_FACTOR,
+            backoff_max=BACKOFF_MAX,
         ) as executor:
             for _fut in executor.ensure_tasks(
                 self.workload_failed_and_then_succeed, range(TASKS_COUNT)
@@ -130,6 +138,8 @@ class TestRetryTaskMap:
             max_concurrent=MAX_CONCURRENT,
             initializer=_thread_initializer,
             initargs=(THREAD_INIT_MSG,),
+            backoff_factor=BACKOFF_FACTOR,
+            backoff_max=BACKOFF_MAX,
         ) as executor:
             for _fut in executor.ensure_tasks(
                 self.workload_succeed, range(TASKS_COUNT)


### PR DESCRIPTION
## Introduction

This PR introduces worker-thread-scope backoff wait on failed tasks rescheduling for otaclient_common.retry_task_map. 
For each worker thread, a `coutinues_failed_count` is maintained, when rescheduling failed tasks, now we will wait with backoff before put the failed task back into task queue.
This will help lower the CPU usage a lot when the network is fully disconnected.

## Tests

- [x] confirm CPU usage lower on network fully disconnected.
- [x] confirm that otaclient can resume very soon after network online.
- [x] local pytest passed.
- [x] OTA e2e test on VM passed.