### PR TITLE
fix: ecu_status: should use any_child_ecu_in_update flag instead of any_in_update to avoid self-lockedown, still wait on any_child_ecu_in_update before reboot

### DIFF
--- a/src/otaclient/_types.py
+++ b/src/otaclient/_types.py
@@ -126,7 +126,7 @@ class OTAClientStatus:
 
 @dataclass
 class MultipleECUStatusFlags:
-    any_in_update: mp_sync.Event
+    any_child_ecu_in_update: mp_sync.Event
     any_requires_network: mp_sync.Event
     all_success: mp_sync.Event
 

--- a/src/otaclient/grpc/api_v2/ecu_status.py
+++ b/src/otaclient/grpc/api_v2/ecu_status.py
@@ -44,7 +44,6 @@ import logging
 import math
 import time
 from itertools import chain
-from typing import Dict, Iterable, Optional
 
 from otaclient._types import MultipleECUStatusFlags, OTAClientStatus
 from otaclient.configs.cfg import cfg, ecu_info
@@ -62,23 +61,6 @@ DISCONNECTED_ECU_TIMEOUT_FACTOR = 3
 
 IDLE_POLLING_INTERVAL = 10  # second
 ACTIVE_POLLING_INTERVAL = 1  # seconds
-
-
-class _OrderedSet(Dict[T, None]):
-    def __init__(self, _input: Optional[Iterable[T]]):
-        if _input:
-            for elem in _input:
-                self[elem] = None
-        super().__init__()
-
-    def add(self, value: T):
-        self[value] = None
-
-    def remove(self, value: T):
-        super().pop(value)
-
-    def discard(self, value: T):
-        super().pop(value, None)
 
 
 class ECUStatusStorage:
@@ -101,7 +83,7 @@ class ECUStatusStorage:
         # NOTE(20241219): we will only look at status of ECUs listed in available_ecu_ids.
         #                 ECUs that in the secondaries field but no in available_ecu_ids field
         #                 are considered to be the ECUs not ready for OTA. See ecu_info.yaml doc.
-        self._available_ecu_ids: _OrderedSet[str] = _OrderedSet(
+        self._available_ecu_ids: dict[str, None] = dict.fromkeys(
             ecu_info.get_available_ecu_ids()
         )
 

--- a/src/otaclient/grpc/api_v2/ecu_status.py
+++ b/src/otaclient/grpc/api_v2/ecu_status.py
@@ -49,7 +49,6 @@ from otaclient._types import MultipleECUStatusFlags, OTAClientStatus
 from otaclient.configs.cfg import cfg, ecu_info
 from otaclient.grpc.api_v2.types import convert_to_apiv2_status
 from otaclient_api.v2 import types as api_types
-from otaclient_common.typing import T
 
 logger = logging.getLogger(__name__)
 

--- a/src/otaclient/grpc/api_v2/ecu_status.py
+++ b/src/otaclient/grpc/api_v2/ecu_status.py
@@ -340,10 +340,10 @@ class ECUStatusStorage:
             self.last_update_request_received_timestamp = int(time.time())
             self.lost_ecus_id -= ecus_accept_update
             self.failed_ecus_id -= ecus_accept_update
+            self.success_ecus_id -= ecus_accept_update
 
             self.in_update_ecus_id.update(ecus_accept_update)
             self.in_update_child_ecus_id = self.in_update_ecus_id - {self.my_ecu_id}
-            self.success_ecus_id -= ecus_accept_update
 
             ecu_status_flags.all_success.clear()
             ecu_status_flags.any_requires_network.set()

--- a/src/otaclient/grpc/api_v2/ecu_status.py
+++ b/src/otaclient/grpc/api_v2/ecu_status.py
@@ -213,7 +213,7 @@ class ECUStatusStorage:
             and status.ecu_id not in lost_ecus
         }
         # NOTE: all_success doesn't count the lost ECUs
-        if len(self.success_ecus_id) == len(self._available_ecu_ids):
+        if self.success_ecus_id == set(self._available_ecu_ids):
             ecu_status_flags.all_success.set()
         else:
             ecu_status_flags.all_success.clear()

--- a/src/otaclient/main.py
+++ b/src/otaclient/main.py
@@ -116,7 +116,7 @@ def main() -> None:  # pragma: no cover
     local_otaclient_op_queue = mp_ctx.Queue()
     local_otaclient_resp_queue = mp_ctx.Queue()
     ecu_status_flags = MultipleECUStatusFlags(
-        any_in_update=mp_ctx.Event(),
+        any_child_ecu_in_update=mp_ctx.Event(),
         any_requires_network=mp_ctx.Event(),
         all_success=mp_ctx.Event(),
     )

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -579,11 +579,9 @@ class _OTAUpdater:
             )
         )
 
-        # NOTE: we don't need to wait for sub ECUs if sub ECUs don't
-        #       depend on otaproxy on this ECU.
         if proxy_info.enable_local_ota_proxy:
             wait_and_log(
-                check_flag=self.ecu_status_flags.any_requires_network.is_set,
+                check_flag=self.ecu_status_flags.any_child_ecu_in_update.is_set,
                 check_for=False,
                 message="permit reboot flag",
                 log_func=logger.info,

--- a/tests/test_otaclient/test_create_standby.py
+++ b/tests/test_otaclient/test_create_standby.py
@@ -145,7 +145,7 @@ class TestOTAupdateWithCreateStandbyRebuildMode:
         # ------ assertions ------ #
         persist_handler.assert_called_once()
 
-        ecu_status_flags.any_requires_network.is_set.assert_called_once()
+        ecu_status_flags.any_child_ecu_in_update.is_set.assert_called_once()
         # --- ensure the update stats are collected
         collected_status = status_collector.otaclient_status
         assert collected_status

--- a/tests/test_otaclient/test_create_standby.py
+++ b/tests/test_otaclient/test_create_standby.py
@@ -106,7 +106,7 @@ class TestOTAupdateWithCreateStandbyRebuildMode:
     ):
         status_collector, status_report_queue = ota_status_collector
         ecu_status_flags = mocker.MagicMock()
-        ecu_status_flags.any_requires_network.is_set = mocker.MagicMock(
+        ecu_status_flags.any_child_ecu_in_update.is_set = mocker.MagicMock(
             return_value=False
         )
 

--- a/tests/test_otaclient/test_grpc/test_api_v2/test_ecu_status.py
+++ b/tests/test_otaclient/test_grpc/test_api_v2/test_ecu_status.py
@@ -471,7 +471,7 @@ class TestECUStatusStorage:
                 {
                     "lost_ecus_id": set(),
                     "in_update_ecus_id": {"autoware"},
-                    "in_update_child_ecus_id": {},
+                    "in_update_child_ecus_id": set(),
                     "failed_ecus_id": set(),
                     "success_ecus_id": {"p1", "p2"},
                 },

--- a/tests/test_otaclient/test_grpc/test_api_v2/test_ecu_status.py
+++ b/tests/test_otaclient/test_grpc/test_api_v2/test_ecu_status.py
@@ -434,6 +434,54 @@ class TestECUStatusStorage:
                     "all_success": False,
                 },
             ),
+            # case 3:
+            # only main ECU doing OTA update.
+            (
+                # local ECU status: UPDATING
+                _internal_types.OTAClientStatus(
+                    ota_status=_internal_types.OTAStatus.UPDATING,
+                    update_phase=_internal_types.UpdatePhase.DOWNLOADING_OTA_FILES,
+                ),
+                # sub ECUs status
+                [
+                    # p1: SUCCESS
+                    api_types.StatusResponse(
+                        available_ecu_ids=["p1"],
+                        ecu_v2=[
+                            api_types.StatusResponseEcuV2(
+                                ecu_id="p1",
+                                ota_status=api_types.StatusOta.SUCCESS,
+                            ),
+                        ],
+                    ),
+                    # p2: SUCCESS
+                    api_types.StatusResponse(
+                        available_ecu_ids=["p2"],
+                        ecu=[
+                            api_types.StatusResponseEcu(
+                                ecu_id="p2",
+                                status=api_types.Status(
+                                    status=api_types.StatusOta.SUCCESS,
+                                ),
+                            )
+                        ],
+                    ),
+                ],
+                # expected overal ECUs status report set by on_ecus_accept_update_request,
+                {
+                    "lost_ecus_id": set(),
+                    "in_update_ecus_id": {"autoware"},
+                    "in_update_child_ecus_id": {},
+                    "failed_ecus_id": set(),
+                    "success_ecus_id": {"p1", "p2"},
+                },
+                # ecu_status_flags
+                {
+                    "any_child_ecu_in_update": False,
+                    "any_requires_network": True,
+                    "all_success": False,
+                },
+            ),
         ),
     )
     async def test_overall_ecu_status_report_generation(
@@ -563,55 +611,6 @@ class TestECUStatusStorage:
                 # ecu_status_flags
                 {
                     "any_child_ecu_in_update": True,
-                    "any_requires_network": True,
-                    "all_success": False,
-                },
-            ),
-            # case 3:
-            # only main ECU doing OTA update.
-            (
-                # local ECU status: UPDATING
-                _internal_types.OTAClientStatus(
-                    ota_status=_internal_types.OTAStatus.UPDATING,
-                    update_phase=_internal_types.UpdatePhase.DOWNLOADING_OTA_FILES,
-                ),
-                # sub ECUs status
-                [
-                    # p1: SUCCESS
-                    api_types.StatusResponse(
-                        available_ecu_ids=["p1"],
-                        ecu_v2=[
-                            api_types.StatusResponseEcuV2(
-                                ecu_id="p1",
-                                ota_status=api_types.StatusOta.SUCCESS,
-                            ),
-                        ],
-                    ),
-                    # p2: SUCCESS
-                    api_types.StatusResponse(
-                        available_ecu_ids=["p2"],
-                        ecu=[
-                            api_types.StatusResponseEcu(
-                                ecu_id="p2",
-                                status=api_types.Status(
-                                    status=api_types.StatusOta.SUCCESS,
-                                ),
-                            )
-                        ],
-                    ),
-                ],
-                ["p1"],
-                # expected overal ECUs status report set by on_ecus_accept_update_request,
-                {
-                    "lost_ecus_id": set(),
-                    "in_update_ecus_id": {"autoware"},
-                    "in_update_child_ecus_id": {},
-                    "failed_ecus_id": set(),
-                    "success_ecus_id": {"p1", "p2"},
-                },
-                # ecu_status_flags
-                {
-                    "any_child_ecu_in_update": False,
                     "any_requires_network": True,
                     "all_success": False,
                 },

--- a/tests/test_otaclient/test_ota_core.py
+++ b/tests/test_otaclient/test_ota_core.py
@@ -161,7 +161,7 @@ class TestOTAUpdater:
     ) -> None:
         _, report_queue = ota_status_collector
         ecu_status_flags = mocker.MagicMock()
-        ecu_status_flags.any_requires_network.is_set = mocker.MagicMock(
+        ecu_status_flags.any_child_ecu_in_update.is_set = mocker.MagicMock(
             return_value=False
         )
 
@@ -202,7 +202,7 @@ class TestOTAUpdater:
         assert _downloaded_files_size == self._delta_bundle.total_download_files_size
 
         # assert the control_flags has been waited
-        ecu_status_flags.any_requires_network.is_set.assert_called_once()
+        ecu_status_flags.any_child_ecu_in_update.is_set.assert_called_once()
 
         assert _updater.update_version == str(cfg.UPDATE_VERSION)
 
@@ -235,7 +235,7 @@ class TestOTAClient:
     ):
         _, status_report_queue = ota_status_collector
         ecu_status_flags = mocker.MagicMock()
-        ecu_status_flags.any_requires_network.is_set = mocker.MagicMock(
+        ecu_status_flags.any_child_ecu_in_update.is_set = mocker.MagicMock(
             return_value=False
         )
 


### PR DESCRIPTION
## Introduction

This PR reverts the change that otaclient waits for any_requires_network instead of any_in_update. This change was introduced after otaclient v3.8.x. 
Also, a logic fix is introduced to use `any_child_ecu_in_update` instead of `any_in_update`.

`any_in_update` will be set when any ECU(including self-ECU) is in UPDATE. If otaclient waits for this flag before OTA reboot(at this point the self-ECU's OTA status is still UPDATING), it will be dead-locked by itself. 
Fix by using `any_child_ecu_in_update` instead, which aligns with the previous implementation at otaclient v3.8.x.