### PR TITLE
feat: otaclient.configs.cfg: exposes ECU_INFO_LOADED_SUCCESSFULLY and PROXY_INFO_LOADED_SUCCESSFULLY to indicate whether default ecu_info/proxy_info are used

### DIFF
--- a/src/otaclient/configs/_ecu_info.py
+++ b/src/otaclient/configs/_ecu_info.py
@@ -115,25 +115,35 @@ class ECUInfo(BaseFixedConfig):
 
 # NOTE: this is backward compatibility for old x1 that doesn't have
 #       ecu_info.yaml installed.
+# NOTE(20241220): this is also the minimum workable ecu_info.yaml that
+#       exposes otaclient OTA API at local. This default settings should
+#       allow a single ECU setup works without problem.
 DEFAULT_ECU_INFO = ECUInfo(
     format_version=1,  # current version is 1
     ecu_id="autoware",  # should be unique for each ECU in vehicle
 )
 
 
-def parse_ecu_info(ecu_info_file: StrOrPath) -> ECUInfo:
+def parse_ecu_info(ecu_info_file: StrOrPath) -> tuple[bool, ECUInfo]:
+    """Parse the ecu_info.yaml file located at <ecu_info_file>.
+
+    Returns:
+        tuple[bool, ECUInfo]: bool indicates whether the provided ecu_info.yaml file
+            is loaded properly, if False, it loading ecu_info.yaml file failed and
+            the default ecu_info is used.
+    """
     try:
         _raw_yaml_str = Path(ecu_info_file).read_text()
     except FileNotFoundError as e:
         logger.warning(f"{ecu_info_file=} not found: {e!r}")
         logger.warning(f"use default ecu_info: {DEFAULT_ECU_INFO}")
-        return DEFAULT_ECU_INFO
+        return False, DEFAULT_ECU_INFO
 
     try:
         loaded_ecu_info = yaml.safe_load(_raw_yaml_str)
         assert isinstance(loaded_ecu_info, dict), "not a valid yaml file"
-        return ECUInfo.model_validate(loaded_ecu_info, strict=True)
+        return True, ECUInfo.model_validate(loaded_ecu_info, strict=True)
     except Exception as e:
         logger.warning(f"{ecu_info_file=} is invalid: {e!r}\n{_raw_yaml_str=}")
         logger.warning(f"use default ecu_info: {DEFAULT_ECU_INFO}")
-        return DEFAULT_ECU_INFO
+        return False, DEFAULT_ECU_INFO

--- a/src/otaclient/configs/_ecu_info.py
+++ b/src/otaclient/configs/_ecu_info.py
@@ -129,7 +129,7 @@ def parse_ecu_info(ecu_info_file: StrOrPath) -> tuple[bool, ECUInfo]:
 
     Returns:
         tuple[bool, ECUInfo]: bool indicates whether the provided ecu_info.yaml file
-            is loaded properly, if False, it loading ecu_info.yaml file failed and
+            is loaded properly, if False, it means loading ecu_info.yaml file failed and
             the default ecu_info is used.
     """
     try:

--- a/src/otaclient/configs/cfg.py
+++ b/src/otaclient/configs/cfg.py
@@ -75,4 +75,6 @@ cfg = _OTAClientConfigs()
 ECU_INFO_LOADED_SUCCESSFULLY, ecu_info = parse_ecu_info(
     ecu_info_file=cfg.ECU_INFO_FPATH
 )
-proxy_info = parse_proxy_info(proxy_info_file=cfg.PROXY_INFO_FPATH)
+PROXY_INFO_LOADED_SUCCESSFULLY, proxy_info = parse_proxy_info(
+    proxy_info_file=cfg.PROXY_INFO_FPATH
+)

--- a/src/otaclient/configs/cfg.py
+++ b/src/otaclient/configs/cfg.py
@@ -38,6 +38,19 @@ __all__ = [
 cfg_configurable = set_configs()
 cfg_consts = Consts()
 
+ECU_INFO_LOADED_SUCCESSFULLY: bool
+"""A const set at startup time ecu_info.yaml parsing.
+
+If it is False, it means that the ecu_info.yaml file is invalid,
+    and the default ecu_info(defined in _ecu_info module) is used.
+"""
+PROXY_INFO_LOADED_SUCCESSFULLY: bool
+"""A const set at startup time proxy_info.yaml parsing.
+
+If it is False, it means that the proxy_info.yaml file is invalid,
+    and the default proxy_info(defined in _proxy_info module) is used.
+"""
+
 if TYPE_CHECKING:
 
     class _OTAClientConfigs(ConfigurableSettings, Consts):
@@ -59,5 +72,7 @@ else:
 
 
 cfg = _OTAClientConfigs()
-ecu_info = parse_ecu_info(ecu_info_file=cfg.ECU_INFO_FPATH)
+ECU_INFO_LOADED_SUCCESSFULLY, ecu_info = parse_ecu_info(
+    ecu_info_file=cfg.ECU_INFO_FPATH
+)
 proxy_info = parse_proxy_info(proxy_info_file=cfg.PROXY_INFO_FPATH)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -252,14 +252,16 @@ local_ota_proxy_listen_port: 8082
 def ecu_info_fixture(tmp_path: Path) -> ECUInfo:
     _yaml_f = tmp_path / "ecu_info.yaml"
     _yaml_f.write_text(ECU_INFO_YAML)
-    return parse_ecu_info(_yaml_f)
+    _, res = parse_ecu_info(_yaml_f)
+    return res
 
 
 @pytest.fixture
 def proxy_info_fixture(tmp_path: Path) -> ProxyInfo:
     _yaml_f = tmp_path / "proxy_info.yaml"
     _yaml_f.write_text(PROXY_INFO_YAML)
-    return parse_proxy_info(_yaml_f)
+    _, res = parse_proxy_info(_yaml_f)
+    return res
 
 
 MAX_TRACEBACK_SIZE = 2048

--- a/tests/test_otaclient/test_configs/test_ecu_info.py
+++ b/tests/test_otaclient/test_configs/test_ecu_info.py
@@ -143,7 +143,7 @@ def test_ecu_info(tmp_path: Path, ecu_info_yaml: str, expected_ecu_info: ECUInfo
     (ecu_info_file := ota_dir / "ecu_info.yaml").write_text(ecu_info_yaml)
 
     # --- execution --- #
-    loaded_ecu_info = parse_ecu_info(ecu_info_file)
+    _, loaded_ecu_info = parse_ecu_info(ecu_info_file)
 
     # --- assertion --- #
     assert loaded_ecu_info == expected_ecu_info

--- a/tests/test_otaclient/test_configs/test_proxy_info.py
+++ b/tests/test_otaclient/test_configs/test_proxy_info.py
@@ -106,6 +106,6 @@ logger = logging.getLogger(__name__)
 def test_proxy_info(tmp_path: Path, _input_yaml: str, _expected: ProxyInfo):
     proxy_info_file = tmp_path / "proxy_info.yml"
     proxy_info_file.write_text(_input_yaml)
-    _proxy_info = parse_proxy_info(str(proxy_info_file))
+    _, _proxy_info = parse_proxy_info(str(proxy_info_file))
 
     assert _proxy_info == _expected


### PR DESCRIPTION
## Introduction

This PR introduces the changes to indicate whether default ecu_info/proxy_info is used due to ecu_info.yaml file/proxy_info.yaml file is broken. 
This is for later implementing the feature of rejecting any OTA update request when ecu_info.yaml is broken.