### PR TITLE
feat!: reject any OTA update/rollback request on ecu_info.yaml not properly loaded

### DIFF
--- a/src/otaclient/_status_monitor.py
+++ b/src/otaclient/_status_monitor.py
@@ -323,7 +323,7 @@ class OTAClientStatusCollector:
                     self.load_report(report)
                     and self._status
                     and (
-                        isinstance(report, OTAStatusChangeReport)
+                        isinstance(report.payload, OTAStatusChangeReport)
                         or _now > _next_shm_push
                     )
                 ):

--- a/src/otaclient/_status_monitor.py
+++ b/src/otaclient/_status_monitor.py
@@ -318,7 +318,15 @@ class OTAClientStatusCollector:
                     break
 
                 # ------ push status on load_report ------ #
-                if self.load_report(report) and self._status and _now > _next_shm_push:
+                # NOTE: always push OTAStatus change report
+                if (
+                    self.load_report(report)
+                    and self._status
+                    and (
+                        isinstance(report, OTAStatusChangeReport)
+                        or _now > _next_shm_push
+                    )
+                ):
                     try:
                         self._shm_status.write_msg(self._status)
                         _next_shm_push = _now + self.shm_push_interval

--- a/src/otaclient/grpc/api_v2/servicer.py
+++ b/src/otaclient/grpc/api_v2/servicer.py
@@ -115,15 +115,7 @@ class OTAClientAPIServicer:
         # NOTE(20241220): due to the fact that OTA Service API doesn't have field
         #                 in UpdateResponseEcu msg, the only way to pass the failure_msg
         #                 to upper is by status API.
-        #                 Here we only immediately accept the OTA update request for main ECU,
-        #                 fails other ECUs, and let main ECU's OTA status tells what is going on.
         if not otaclient_cfg.ECU_INFO_LOADED_SUCCESSFULLY:
-            response.add_ecu(
-                api_types.UpdateResponseEcu(
-                    ecu_id=self.my_ecu_id,
-                    result=api_types.FailureType.NO_FAILURE,
-                )
-            )
             for _update_req in request.iter_ecu():
                 response.add_ecu(
                     api_types.UpdateResponseEcu(

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -67,7 +67,12 @@ from otaclient._types import (
 )
 from otaclient._utils import SharedOTAClientStatusWriter, get_traceback, wait_and_log
 from otaclient.boot_control import BootControllerProtocol, get_boot_controller
-from otaclient.configs.cfg import cfg, ecu_info, proxy_info
+from otaclient.configs.cfg import (
+    ECU_INFO_LOADED_SUCCESSFULLY,
+    cfg,
+    ecu_info,
+    proxy_info,
+)
 from otaclient.create_standby import (
     StandbySlotCreatorProtocol,
     get_standby_slot_creator,
@@ -864,9 +869,10 @@ class OTAClient:
                 )
 
             elif not self.started:
-                _err_msg = (
-                    "otaclient is not started, might be due to broken ecu_info.yaml"
-                )
+                _err_msg = "reject OTA request due to otaclient is not (yet) started."
+                if not ECU_INFO_LOADED_SUCCESSFULLY:
+                    _err_msg = f"reject OTA request due to {cfg.ECU_INFO_FPATH} missing or broken"
+
                 logger.error(_err_msg)
                 resp_queue.put_nowait(
                     IPCResponse(

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -848,16 +848,6 @@ class OTAClient:
             except Empty:
                 continue
 
-            if not self.started:
-                resp_queue.put_nowait(
-                    IPCResponse(
-                        res=IPCResEnum.REJECT_OTHER,
-                        msg="otaclient is not started, might be due to broken ecu_info.yaml",
-                        session_id=request.session_id,
-                    )
-                )
-                continue
-
             if _now < _allow_request_after or self.is_busy:
                 _err_msg = (
                     f"otaclient is busy at {self._live_ota_status} or "
@@ -868,6 +858,19 @@ class OTAClient:
                 resp_queue.put_nowait(
                     IPCResponse(
                         res=IPCResEnum.REJECT_BUSY,
+                        msg=_err_msg,
+                        session_id=request.session_id,
+                    )
+                )
+
+            elif not self.started:
+                _err_msg = (
+                    "otaclient is not started, might be due to broken ecu_info.yaml"
+                )
+                logger.error(_err_msg)
+                resp_queue.put_nowait(
+                    IPCResponse(
+                        res=IPCResEnum.REJECT_OTHER,
                         msg=_err_msg,
                         session_id=request.session_id,
                     )

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -704,7 +704,9 @@ class OTAClient:
                 StatusReport(
                     payload=OTAStatusChangeReport(
                         new_ota_status=OTAStatus.FAILURE,
-                        failure_reason="ecu_info.yaml file is broken, reject any OTA request.",
+                        failure_type=FailureType.UNRECOVERABLE,
+                        failure_reason="ecu_info.yaml file is broken, please check /boot/ota/ecu_info.yaml. "
+                        "reject any OTA request.",
                     ),
                 )
             )

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -707,7 +707,7 @@ class OTAClient:
                     payload=OTAStatusChangeReport(
                         new_ota_status=OTAStatus.FAILURE,
                         failure_type=FailureType.UNRECOVERABLE,
-                        failure_reason="ecu_info.yaml file is broken, please check /boot/ota/ecu_info.yaml. "
+                        failure_reason=f"ecu_info.yaml file is broken or missing, please check {cfg.ECU_INFO_FPATH}. "
                         "reject any OTA request.",
                     ),
                 )

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -848,7 +848,7 @@ class OTAClient:
                 resp_queue.put_nowait(
                     IPCResponse(
                         res=IPCResEnum.REJECT_OTHER,
-                        msg="otaclient is not started",
+                        msg="otaclient is not started, might be due to broken ecu_info.yaml",
                         session_id=request.session_id,
                     )
                 )

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -682,6 +682,7 @@ class OTAClient:
                 ),
             )
         )
+        logger.info(f"firmware_version: {self.current_version}")
 
         # ------ load CA store ------ #
         self.ca_chains_store = None
@@ -699,6 +700,7 @@ class OTAClient:
             logger.error(
                 "ecu_info.yaml file is not loaded properly, will reject any OTA request."
             )
+            logger.error(f"set live_ota_status to {OTAStatus.FAILURE!r}")
             self._live_ota_status = OTAStatus.FAILURE
             status_report_queue.put_nowait(
                 StatusReport(
@@ -722,7 +724,6 @@ class OTAClient:
 
             self.started = True
             logger.info("otaclient started")
-            logger.info(f"firmware_version: {self.current_version}")
 
     def _on_failure(
         self,


### PR DESCRIPTION
## Introduction

This PR implements the requirement of rejecting any OTA update/rollback request when ecu_info.yaml file is broken, and reports the failure_reason as due to ecu_info.yaml is broken.

If ecu_info.yaml is broken and cannot be parsed at startup, otaclient will set the live_ota_status to FAILURE, failure_type to UNRECOVERABLE, with failure_message: `ecu_info.yaml file is broken, please check /boot/ota/ecu_info.yaml. reject any OTA request.`

And for every incoming OTA request, otaclient will reject with failure_type.UNRECOVERABLE for every ECUs listed in the request(as otaclient with default ecu_info.yaml doesn't have contact for the sub ECUs).

For multiple ECU environment, due to when falling down to the default ecu_info, we will only have one entry(which is the main ECU) in the available_ecu_ids list, so the situation will be the same as single ECU environment.

Other changes:
1. status_monitor: now status_monitor will always push to shm when the incoming report is OTAStatusChangeReport, regardless the push interval. 

BREAKING CHANGE: now otaclient will set itself in FAILURE OTA status and reject any OTA requests when ecu_info.yaml is not properly loaded at startup.

## The behavior on FMS console

![image](https://github.com/user-attachments/assets/c401d666-2576-4bfe-a57a-c8633de8e580)


## Tests

- [x] (single ECU environment) confirm that when ecu_info.yaml is broken, on FMS console the OTA will fail with error message stating that ecu_info.yaml is broken.
- [x] confirm that when ecu_info.yaml file presented, normal OTA can perform.
- [x] confirm that the behavior of web.auto agent is expected.

https://tier4.atlassian.net/browse/RT4-9345