### PR TITLE
feat: ota_proxy: migrate to anyio, drop deps of aiofiles

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "pydantic-settings<3,>=2.3",
   "pyyaml<7,>=6.0.1",
   "requests<2.33,>=2.32",
-  "simple-sqlite3-orm==0.7.0rc0",
+  "simple-sqlite3-orm<0.8,>=0.7",
   "typing-extensions>=4.6.3",
   "urllib3<2.3,>=2.2.2",
   "uvicorn[standard]>=0.30,<0.35",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "aiofiles<25,>=24.1",
+  "anyio>=4.5.1,<5",
   "aiohttp>=3.10.11,<3.12",
   "cryptography>=43.0.1,<45",
   "grpcio>=1.53.2,<1.69",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "pydantic-settings<3,>=2.3",
   "pyyaml<7,>=6.0.1",
   "requests<2.33,>=2.32",
-  "simple-sqlite3-orm<0.7,>=0.6",
+  "simple-sqlite3-orm==0.7.0rc0",
   "typing-extensions>=4.6.3",
   "urllib3<2.3,>=2.2.2",
   "uvicorn[standard]>=0.30,<0.35",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pydantic<3,>=2.10
 pydantic-settings<3,>=2.3
 pyyaml<7,>=6.0.1
 requests<2.33,>=2.32
-simple-sqlite3-orm==0.7.0rc0
+simple-sqlite3-orm<0.8,>=0.7
 typing-extensions>=4.6.3
 urllib3<2.3,>=2.2.2
 uvicorn[standard]>=0.30,<0.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Automatically generated from pyproject.toml by gen_requirements_txt.py script.
 # DO NOT EDIT! Only for reference use.
-aiofiles<25,>=24.1
+anyio>=4.5.1,<5
 aiohttp>=3.10.11,<3.12
 cryptography>=43.0.1,<45
 grpcio>=1.53.2,<1.69
@@ -11,7 +11,7 @@ pydantic<3,>=2.10
 pydantic-settings<3,>=2.3
 pyyaml<7,>=6.0.1
 requests<2.33,>=2.32
-simple-sqlite3-orm<0.7,>=0.6
+simple-sqlite3-orm==0.7.0rc0
 typing-extensions>=4.6.3
 urllib3<2.3,>=2.2.2
 uvicorn[standard]>=0.30,<0.35

--- a/src/ota_proxy/__init__.py
+++ b/src/ota_proxy/__init__.py
@@ -33,7 +33,7 @@ __all__ = (
 )
 
 
-async def run_otaproxy(
+def run_otaproxy(
     host: str,
     port: int,
     *,
@@ -45,6 +45,7 @@ async def run_otaproxy(
     enable_https: bool,
     external_cache_mnt_point: str | None = None,
 ):
+    import anyio
     import uvicorn
 
     from . import App, OTACache
@@ -69,4 +70,4 @@ async def run_otaproxy(
         http="h11",
     )
     _server = uvicorn.Server(_config)
-    await _server.serve()
+    anyio.run(_server.serve, backend="asyncio", backend_options={"use_uvloop": True})

--- a/src/ota_proxy/__main__.py
+++ b/src/ota_proxy/__main__.py
@@ -16,10 +16,7 @@
 from __future__ import annotations
 
 import argparse
-import asyncio
 import logging
-
-import uvloop
 
 from . import run_otaproxy
 from .config import config as cfg
@@ -78,17 +75,14 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     logger.info(f"launch ota_proxy at {args.host}:{args.port}")
-    uvloop.install()
-    asyncio.run(
-        run_otaproxy(
-            host=args.host,
-            port=args.port,
-            cache_dir=args.cache_dir,
-            cache_db_f=args.cache_db_file,
-            enable_cache=args.enable_cache,
-            upper_proxy=args.upper_proxy,
-            enable_https=args.enable_https,
-            init_cache=args.init_cache,
-            external_cache_mnt_point=args.external_cache_mnt_point,
-        )
+    run_otaproxy(
+        host=args.host,
+        port=args.port,
+        cache_dir=args.cache_dir,
+        cache_db_f=args.cache_db_file,
+        enable_cache=args.enable_cache,
+        upper_proxy=args.upper_proxy,
+        enable_https=args.enable_https,
+        init_cache=args.init_cache,
+        external_cache_mnt_point=args.external_cache_mnt_point,
     )

--- a/src/ota_proxy/cache_streaming.py
+++ b/src/ota_proxy/cache_streaming.py
@@ -26,7 +26,7 @@ from concurrent.futures import Executor
 from pathlib import Path
 from typing import AsyncGenerator, AsyncIterator, Callable, Coroutine
 
-import aiofiles
+from anyio import open_file
 
 from otaclient_common.common import get_backoff
 from otaclient_common.typing import StrOrPath
@@ -147,7 +147,7 @@ class CacheTracker:
         """
         logger.debug(f"start to cache for {cache_meta=}...")
         try:
-            async with aiofiles.open(self.fpath, "wb", executor=self._executor) as f:
+            async with await open_file(self.fpath, "wb") as f:
                 _written = 0
                 while _data := (yield _written):
                     if not self._space_availability_event.is_set():
@@ -202,7 +202,7 @@ class CacheTracker:
         """
         err_count, _bytes_read = 0, 0
         try:
-            async with aiofiles.open(self.fpath, "rb", executor=self._executor) as f:
+            async with await open_file(self.fpath, "rb") as f:
                 while (
                     not self._writer_finished.is_set()
                     or _bytes_read < self._bytes_written

--- a/src/ota_proxy/cache_streaming.py
+++ b/src/ota_proxy/cache_streaming.py
@@ -22,7 +22,6 @@ import logging
 import os
 import threading
 import weakref
-from concurrent.futures import Executor
 from pathlib import Path
 from typing import AsyncGenerator, AsyncIterator, Callable, Coroutine
 
@@ -102,7 +101,6 @@ class CacheTracker:
         *,
         base_dir: StrOrPath,
         commit_cache_cb: _CACHE_ENTRY_REGISTER_CALLBACK,
-        executor: Executor,
         below_hard_limit_event: threading.Event,
     ):
         self.fpath = Path(base_dir) / self._tmp_file_naming(cache_identifier)
@@ -114,7 +112,6 @@ class CacheTracker:
         self._writer_finished = asyncio.Event()
         self._writer_failed = asyncio.Event()
 
-        self._executor = executor
         self._space_availability_event = below_hard_limit_event
 
         self._bytes_written = 0

--- a/src/ota_proxy/ota_cache.py
+++ b/src/ota_proxy/ota_cache.py
@@ -452,7 +452,7 @@ class OTACache:
         #       do the job. If cache is invalid, otaclient will use CacheControlHeader's retry_cache
         #       directory to indicate invalid cache.
         return (
-            read_file(cache_file, executor=self._executor),
+            read_file(cache_file),
             meta_db_entry.export_headers_to_client(),
         )
 
@@ -482,7 +482,7 @@ class OTACache:
                     file_compression_alg=cfg.EXTERNAL_CACHE_STORAGE_COMPRESS_ALG,
                 )
             )
-            return read_file(cache_file_zst, executor=self._executor), _header
+            return read_file(cache_file_zst), _header
 
         if cache_file.is_file():
             _header = CIMultiDict()
@@ -491,7 +491,7 @@ class OTACache:
                     file_sha256=cache_identifier
                 )
             )
-            return read_file(cache_file, executor=self._executor), _header
+            return read_file(cache_file), _header
 
     async def _retrieve_file_by_new_caching(
         self,

--- a/src/ota_proxy/utils.py
+++ b/src/ota_proxy/utils.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
-from concurrent.futures import Executor
 from hashlib import sha256
 from os import PathLike
 from typing import AsyncIterator
 
-import aiofiles
+from anyio import open_file
 
 from .config import config as cfg
 
 
-async def read_file(fpath: PathLike, *, executor: Executor) -> AsyncIterator[bytes]:
-    """Open and read a file asynchronously with aiofiles."""
-    async with aiofiles.open(fpath, "rb", executor=executor) as f:
+async def read_file(fpath: PathLike) -> AsyncIterator[bytes]:
+    """Open and read a file asynchronously."""
+    async with await open_file(fpath, "rb") as f:
         while data := await f.read(cfg.CHUNK_SIZE):
             yield data
 

--- a/src/otaclient/_otaproxy_ctx.py
+++ b/src/otaclient/_otaproxy_ctx.py
@@ -19,7 +19,6 @@ The API exposed by this module is meant to be controlled by otaproxy managing th
 
 from __future__ import annotations
 
-import asyncio
 import atexit
 import logging
 import multiprocessing as mp
@@ -78,18 +77,16 @@ def otaproxy_process(*, init_cache: bool) -> None:
         logger.info(f"wait for {upper_proxy=} online...")
         ensure_otaproxy_start(str(upper_proxy))
 
-    asyncio.run(
-        run_otaproxy(
-            host=host,
-            port=port,
-            init_cache=init_cache,
-            cache_dir=local_otaproxy_cfg.BASE_DIR,
-            cache_db_f=local_otaproxy_cfg.DB_FILE,
-            upper_proxy=upper_proxy,
-            enable_cache=proxy_info.enable_local_ota_proxy_cache,
-            enable_https=proxy_info.gateway_otaproxy,
-            external_cache_mnt_point=external_cache_mnt_point,
-        )
+    run_otaproxy(
+        host=host,
+        port=port,
+        init_cache=init_cache,
+        cache_dir=local_otaproxy_cfg.BASE_DIR,
+        cache_db_f=local_otaproxy_cfg.DB_FILE,
+        upper_proxy=upper_proxy,
+        enable_cache=proxy_info.enable_local_ota_proxy_cache,
+        enable_https=proxy_info.gateway_otaproxy,
+        external_cache_mnt_point=external_cache_mnt_point,
     )
 
 

--- a/tests/test_ota_proxy/test_cache_streaming.py
+++ b/tests/test_ota_proxy/test_cache_streaming.py
@@ -87,7 +87,6 @@ class TestOngoingCachingRegister:
         _tracker = CacheTracker(
             cache_identifier=self.URL,
             base_dir=self.base_dir,
-            executor=None,  # type: ignore
             commit_cache_cb=None,  # type: ignore
             below_hard_limit_event=None,  # type: ignore
         )

--- a/tests/test_ota_proxy/test_subprocess_launch_otaproxy.py
+++ b/tests/test_ota_proxy/test_subprocess_launch_otaproxy.py
@@ -15,7 +15,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import multiprocessing as mp
 import time
 from pathlib import Path
@@ -27,17 +26,15 @@ def otaproxy_process(cache_dir: str):
     ota_cache_dir = Path(cache_dir)
     ota_cache_db = ota_cache_dir / "cache_db"
 
-    asyncio.run(
-        run_otaproxy(
-            host="127.0.0.1",
-            port=8082,
-            init_cache=True,
-            cache_dir=str(ota_cache_dir),
-            cache_db_f=str(ota_cache_db),
-            upper_proxy="",
-            enable_cache=True,
-            enable_https=False,
-        ),
+    run_otaproxy(
+        host="127.0.0.1",
+        port=8082,
+        init_cache=True,
+        cache_dir=str(ota_cache_dir),
+        cache_db_f=str(ota_cache_db),
+        upper_proxy="",
+        enable_cache=True,
+        enable_https=False,
     )
 
 


### PR DESCRIPTION
## Introduction

This PR introduces to use anyio as asyncio environment for ota_proxy, drops the use of aiofiles to use async file operations supports from anyio.

Also this PR fixes the problem of ota_proxy launched by otaclient actually not using `uvloop` although we configure to use. The main entry `run_otaproxy` is fixed and now the ota_proxy will be properly launched with uvloop.

DEPS:
1. add anyio and drop aiofiles.
2. bump to use simple-sqlite3-orm v0.7.0.

## Tests

- [x] local pytest passed. 
- [x] normal full OTA, ensure no performance regression.
- [x] downloading with OTA server 
- [x] start/stop repeatedly to check unstable network handling.
- [x] download with all cached.
- [x] test cache rotating.