### PR TITLE
refactor: otaclient_common.logging: add get_burst_suppressed_logger helper for creating burst_suppressed logger

### DIFF
--- a/src/ota_proxy/lru_cache_helper.py
+++ b/src/ota_proxy/lru_cache_helper.py
@@ -17,27 +17,17 @@
 from __future__ import annotations
 
 import bisect
-import logging
 import sqlite3
 import time
 from pathlib import Path
 
 from simple_sqlite3_orm import utils
 
-from otaclient_common.logging import BurstSuppressFilter
+from otaclient_common.logging import get_burst_suppressed_logger
 
 from .db import AsyncCacheMetaORM, CacheMeta
 
-burst_suppressed_logger = logging.getLogger(f"{__name__}.db_error")
-# NOTE: for request_error, only allow max 6 lines of logging per 30 seconds
-burst_suppressed_logger.addFilter(
-    BurstSuppressFilter(
-        f"{__name__}.db_error",
-        upper_logger_name=__name__,
-        burst_round_length=30,
-        burst_max=6,
-    )
-)
+burst_suppressed_logger = get_burst_suppressed_logger(f"{__name__}.db_error")
 
 
 class LRUCacheHelper:

--- a/src/ota_proxy/server_app.py
+++ b/src/ota_proxy/server_app.py
@@ -23,7 +23,7 @@ from urllib.parse import urlparse
 import aiohttp
 from multidict import CIMultiDict, CIMultiDictProxy
 
-from otaclient_common.logging import BurstSuppressFilter
+from otaclient_common.logging import get_burst_suppressed_logger
 
 from ._consts import (
     BHEADER_AUTHORIZATION,
@@ -46,16 +46,8 @@ from .errors import BaseOTACacheError
 from .ota_cache import OTACache
 
 logger = logging.getLogger(__name__)
-burst_suppressed_logger = logging.getLogger(f"{__name__}.request_error")
 # NOTE: for request_error, only allow max 6 lines of logging per 30 seconds
-burst_suppressed_logger.addFilter(
-    BurstSuppressFilter(
-        f"{__name__}.request_error",
-        upper_logger_name=__name__,
-        burst_round_length=30,
-        burst_max=6,
-    )
-)
+burst_suppressed_logger = get_burst_suppressed_logger(f"{__name__}.request_error")
 
 # only expose app
 __all__ = ("App",)

--- a/src/otaclient/_status_monitor.py
+++ b/src/otaclient/_status_monitor.py
@@ -35,19 +35,11 @@ from otaclient._types import (
     UpdateTiming,
 )
 from otaclient._utils import SharedOTAClientStatusWriter
-from otaclient_common.logging import BurstSuppressFilter
+from otaclient_common.logging import get_burst_suppressed_logger
 
 logger = logging.getLogger(__name__)
-burst_suppressed_logger = logging.getLogger(f"{__name__}.shm_push")
-# NOTE: for request_error, only allow max 6 lines of logging per 30 seconds
-burst_suppressed_logger.addFilter(
-    BurstSuppressFilter(
-        f"{__name__}.shm_push",
-        upper_logger_name=__name__,
-        burst_round_length=30,
-        burst_max=6,
-    )
-)
+# NOTE: suppress error logging for pushing OTA status to shm
+burst_suppressed_logger = get_burst_suppressed_logger(f"{__name__}.shm_push")
 
 _status_report_queue: queue.Queue | None = None
 

--- a/src/otaclient/grpc/api_v2/ecu_tracker.py
+++ b/src/otaclient/grpc/api_v2/ecu_tracker.py
@@ -27,19 +27,11 @@ from otaclient.configs.cfg import cfg, ecu_info
 from otaclient.grpc.api_v2.ecu_status import ECUStatusStorage
 from otaclient_api.v2 import types as api_types
 from otaclient_api.v2.api_caller import ECUNoResponse, OTAClientCall
-from otaclient_common.logging import BurstSuppressFilter
+from otaclient_common.logging import get_burst_suppressed_logger
 
 logger = logging.getLogger(__name__)
-burst_suppressed_logger = logging.getLogger(f"{__name__}.local_ecu_check")
-# NOTE: for request_error, only allow max 6 lines of logging per 30 seconds
-burst_suppressed_logger.addFilter(
-    BurstSuppressFilter(
-        f"{__name__}.local_ecu_check",
-        upper_logger_name=__name__,
-        burst_round_length=30,
-        burst_max=6,
-    )
-)
+# NOTE: suppress error loggings from checking local ECU's status shm
+burst_suppressed_logger = get_burst_suppressed_logger(f"{__name__}.local_ecu_check")
 
 # actively polling ECUs status until we get the first valid response
 #   when otaclient is just starting.

--- a/src/otaclient_common/logging.py
+++ b/src/otaclient_common/logging.py
@@ -69,7 +69,7 @@ def get_burst_suppressed_logger(
     *,
     upper_logger_name: str | None = None,
     burst_max: int = 6,
-    burst_round_length: int = 30,
+    burst_round_length: int = 16,
 ) -> logging.Logger:
     """Configure the logger by <_logger> and attach a burst_suppressed_filter to it
 

--- a/src/otaclient_common/logging.py
+++ b/src/otaclient_common/logging.py
@@ -88,7 +88,11 @@ def get_burst_suppressed_logger(
         this_logger_name = _logger.name
 
     if not isinstance(upper_logger_name, str):
-        upper_logger_name = this_logger_name.split(".")[0]
+        _parents = this_logger_name.split(".")[:-1]
+        if _parents:
+            upper_logger_name = _parents[-1]
+        else:  # NOTE: will be the root logger
+            upper_logger_name = None
 
     this_logger.addFilter(
         BurstSuppressFilter(

--- a/src/otaclient_common/logging.py
+++ b/src/otaclient_common/logging.py
@@ -70,7 +70,7 @@ def get_burst_suppressed_logger(
     upper_logger_name: str | None = None,
     burst_max: int = 6,
     burst_round_length: int = 30,
-) -> None:
+) -> logging.Logger:
     """Configure the logger by <_logger> and attach a burst_suppressed_filter to it
 
     Args:
@@ -98,3 +98,4 @@ def get_burst_suppressed_logger(
             burst_round_length=burst_round_length,
         )
     )
+    return this_logger

--- a/src/otaclient_common/logging.py
+++ b/src/otaclient_common/logging.py
@@ -90,7 +90,7 @@ def get_burst_suppressed_logger(
     if not isinstance(upper_logger_name, str):
         _parents = this_logger_name.split(".")[:-1]
         if _parents:
-            upper_logger_name = _parents[-1]
+            upper_logger_name = ".".join(_parents)
         else:  # NOTE: will be the root logger
             upper_logger_name = None
 

--- a/tests/test_otaclient_common/test_logging.py
+++ b/tests/test_otaclient_common/test_logging.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-import logging
 import time
 
 from pytest import LogCaptureFixture
@@ -21,16 +20,14 @@ from pytest import LogCaptureFixture
 from otaclient_common import logging as _logging
 
 
-def test_BurstSuppressFilter(caplog: LogCaptureFixture):
+def test_burst_logging(caplog: LogCaptureFixture):
     logger_name = "test_BurstSuppressFilter"
-    logger = logging.getLogger(logger_name)
     burst_round_length = 1
-    logger.addFilter(
-        _logging.BurstSuppressFilter(
-            logger_name,
-            burst_max=1,
-            burst_round_length=burst_round_length,
-        )
+
+    logger = _logging.get_burst_suppressed_logger(
+        logger_name,
+        burst_max=1,
+        burst_round_length=burst_round_length,
     )
 
     # test loggging suppressing

--- a/tests/test_otaclient_common/test_logging.py
+++ b/tests/test_otaclient_common/test_logging.py
@@ -19,6 +19,9 @@ from pytest import LogCaptureFixture
 
 from otaclient_common import logging as _logging
 
+TEST_ROUND = 10
+TEST_LOGGINGS_NUM = 3000
+
 
 def test_burst_logging(caplog: LogCaptureFixture):
     logger_name = "upper_logger.intermediate_logger.this_logger"
@@ -37,17 +40,20 @@ def test_burst_logging(caplog: LogCaptureFixture):
     # NOTE: outer loop ensures that suppression only works
     #       within each burst_round, and should be refresed
     #       in new round.
-    for _ in range(2):
-        for idx in range(2000):
+    for _ in range(TEST_ROUND):
+        for idx in range(TEST_LOGGINGS_NUM):
             logger.error(idx)
         time.sleep(burst_round_length * 2)
         logger.error("burst_round end")
 
-        # the four logging lines are:
+        # For each round, the loggings will be as follow:
         #   1. logger.error(idx) # idx==0
         #   2. a warning of exceeded loggings are suppressed
         #   3. a warning of how many loggings are suppressed
         #   4. logger.error("burst_round end")
+        # NOTE that the logger.error("burst_round end") will be included in the
+        #   next burst_suppressing roud, so excepts for the first round, we will
+        #   only have three records.
         assert len(records := caplog.records) <= 4
         # warning msg comes from upper_logger
         assert records[1].name == upper_logger

--- a/tests/test_otaclient_common/test_logging.py
+++ b/tests/test_otaclient_common/test_logging.py
@@ -51,5 +51,4 @@ def test_burst_logging(caplog: LogCaptureFixture):
         assert len(records := caplog.records) <= 4
         # warning msg comes from upper_logger
         assert records[1].name == upper_logger
-        assert records[2].name == upper_logger
         caplog.clear()

--- a/tests/test_otaclient_common/test_logging.py
+++ b/tests/test_otaclient_common/test_logging.py
@@ -21,11 +21,14 @@ from otaclient_common import logging as _logging
 
 
 def test_burst_logging(caplog: LogCaptureFixture):
-    logger_name = "test_BurstSuppressFilter"
+    logger_name = "upper_logger.intermediate_logger.this_logger"
+    upper_logger = "upper_logger.intermediate_logger"
+
     burst_round_length = 1
 
     logger = _logging.get_burst_suppressed_logger(
         logger_name,
+        # NOTE: test upper_logger_name calculated from logger_name
         burst_max=1,
         burst_round_length=burst_round_length,
     )
@@ -45,5 +48,8 @@ def test_burst_logging(caplog: LogCaptureFixture):
         #   2. a warning of exceeded loggings are suppressed
         #   3. a warning of how many loggings are suppressed
         #   4. logger.error("burst_round end")
-        assert len(caplog.records) <= 4
+        assert len(records := caplog.records) <= 4
+        # warning msg comes from upper_logger
+        assert records[1].name == upper_logger
+        assert records[2].name == upper_logger
         caplog.clear()


### PR DESCRIPTION
## Introduction

This PR adds a helper method get_burst_suppressed_logger for creating burst_suppressed logger with ease.

Changes of integration:
1. ota_proxy: use get_burst_suppressed_logger.
2. otaclient.api_v2: use get_burst_suppressed_logger.