### PR TITLE
feat: support both http and grpc for logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "grpcio==1.70.0",
   "multidict<7.0,>=4.5",
   "msgpack>=1,<1.2",
+  "otaclient_iot_logging_server_pb2 @ https://github.com/tier4/otaclient-iot-logging-server/releases/download/v1.3.0/otaclient_iot_logging_server_pb2-1.0.0-py3-none-any.whl#sha256:e5a2e6474a8b6f5656679877a5df40891e6a65c29830a31faed3d47d9973be60",
   "protobuf>=4.21.12,<5.29",
   "pydantic<3,>=2.10",
   "pydantic-settings<3,>=2.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ cryptography==44.0.2
 grpcio==1.70.0
 multidict<7.0,>=4.5
 msgpack>=1,<1.2
+otaclient_iot_logging_server_pb2 @ https://github.com/tier4/otaclient-iot-logging-server/releases/download/v1.3.0/otaclient_iot_logging_server_pb2-1.0.0-py3-none-any.whl#sha256:e5a2e6474a8b6f5656679877a5df40891e6a65c29830a31faed3d47d9973be60
 protobuf>=4.21.12,<5.29
 pydantic<3,>=2.10
 pydantic-settings<3,>=2.3

--- a/samples/proxy_info.yaml
+++ b/samples/proxy_info.yaml
@@ -7,3 +7,4 @@ local_ota_proxy_listen_addr: 127.0.0.1
 local_ota_proxy_listen_port: 8082
 # if otaclient-logger is installed locally
 logging_server: "http://127.0.0.1:8083"
+logging_server_grpc: "http://127.0.0.1:8084"

--- a/src/otaclient/configs/_proxy_info.py
+++ b/src/otaclient/configs/_proxy_info.py
@@ -46,6 +46,7 @@ class ProxyInfo(BaseFixedConfig):
         upper_ota_proxy: the URL of upper OTA proxy used by local ota_proxy server
             or otaclient(proxy chain).
         logging_server: the URL of AWS IoT otaclient logs upload server.
+        logging_server_grpc: the URL of AWS IoT otaclient logs upload gRPC server.
     """
 
     format_version: int = 1
@@ -77,6 +78,11 @@ class ProxyInfo(BaseFixedConfig):
     #       check roles/ota_client/templates/run.sh.j2 in ecu_setup repo.
     logging_server: Optional[AnyHttpUrl] = AnyHttpUrl(
         f"http://127.0.0.1:{LOGGING_SERVER_PORT}"
+    )
+
+    LOGGING_SERVER_GRPC_PORT: ClassVar[int] = 8084
+    logging_server_grpc: Optional[AnyHttpUrl] = AnyHttpUrl(
+        f"http://127.0.0.1:{LOGGING_SERVER_GRPC_PORT}"
     )
 
     def get_proxy_for_local_ota(self) -> str | None:

--- a/tests/test_otaclient/test_configs/test_proxy_info.py
+++ b/tests/test_otaclient/test_configs/test_proxy_info.py
@@ -48,6 +48,7 @@ MODULE_NAME = _proxy_info_module.__name__
                 'upper_ota_proxy: "http://10.0.0.1:8082"\n'
                 "enable_local_ota_proxy_cache: true\n"
                 'logging_server: "http://10.0.0.1:8083"\n'
+                'logging_server_grpc: "http://10.0.0.1:8084"\n'
             ),
             (
                 True,
@@ -60,6 +61,7 @@ MODULE_NAME = _proxy_info_module.__name__
                         "local_ota_proxy_listen_addr": "0.0.0.0",
                         "local_ota_proxy_listen_port": 8082,
                         "logging_server": "http://10.0.0.1:8083",
+                        "logging_server_grpc": "http://10.0.0.1:8084",
                     }
                 ),
             ),

--- a/tests/test_otaclient/test_logging.py
+++ b/tests/test_otaclient/test_logging.py
@@ -1,0 +1,202 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from dataclasses import dataclass
+from queue import Queue
+from urllib.parse import urlparse
+
+import grpc
+import pytest
+import pytest_asyncio
+from otaclient_iot_logging_server_pb2.v1 import (
+    otaclient_iot_logging_server_v1_pb2 as log_pb2,
+)
+from otaclient_iot_logging_server_pb2.v1 import (
+    otaclient_iot_logging_server_v1_pb2_grpc as log_v1_grpc,
+)
+from pydantic import AnyHttpUrl
+from pytest_mock import MockerFixture
+
+import otaclient._logging as _logging
+from otaclient._logging import LogType, configure_logging
+from otaclient.configs._cfg_configurable import _OTAClientSettings
+from otaclient.configs._ecu_info import ECUInfo
+from otaclient.configs._proxy_info import ProxyInfo
+
+logger = logging.getLogger(__name__)
+
+MODULE = _logging.__name__
+
+
+@dataclass
+class DummyQueueData:
+    ecu_id: str
+    log_type: log_pb2.LogType
+    message: str
+
+
+class DummyLogServerService(log_v1_grpc.OTAClientIoTLoggingServiceServicer):
+    def __init__(self, test_queue, data_ready):
+        self._test_queue = test_queue
+        self._data_ready = data_ready
+
+    async def Check(self, request: log_pb2.HealthCheckRequest, context):
+        """
+        Dummy gRPC method for health check.
+        """
+        return log_pb2.HealthCheckResponse(
+            status=log_pb2.HealthCheckResponse.ServingStatus.SERVING
+        )
+
+    async def PutLog(self, request: log_pb2.PutLogRequest, context):
+        """
+        Dummy gRPC method to put a log message to the queue.
+        """
+        self._test_queue.put_nowait(
+            DummyQueueData(
+                ecu_id=request.ecu_id,
+                log_type=request.log_type,
+                message=request.message,
+            )
+        )
+        self._data_ready.set()
+        return log_pb2.PutLogResponse(code=log_pb2.NO_FAILURE)
+
+
+class TestLogClient:
+    OTA_CLIENT_LOGGING_SERVER = "http://127.0.0.1:8083"
+    OTA_CLIENT_LOGGING_SERVER_GRPC = "http://127.0.0.1:8084"
+    ECU_ID = "testclient"
+
+    @pytest.fixture(autouse=True)
+    async def initialize_queue(self):
+        self.test_queue: Queue[DummyQueueData] = Queue()
+        self.data_ready = asyncio.Event()
+
+    @pytest.fixture(autouse=True)
+    def mock_cfg(self, mocker: MockerFixture):
+        self._cfg = _OTAClientSettings(
+            LOG_LEVEL_TABLE={__name__: "INFO"},
+            LOG_FORMAT="[%(asctime)s][%(levelname)s]-%(name)s:%(funcName)s:%(lineno)d,%(message)s",
+        )
+        mocker.patch(f"{MODULE}.cfg", self._cfg)
+
+    @pytest.fixture(autouse=True)
+    def mock_ecu_info(self, mocker: MockerFixture):
+        self._ecu_info = ECUInfo(ecu_id=TestLogClient.ECU_ID)
+        mocker.patch(f"{MODULE}.ecu_info", self._ecu_info)
+
+    @pytest.fixture(autouse=True)
+    def mock_proxy_info(self, mocker: MockerFixture):
+        self._proxy_info = ProxyInfo(
+            logging_server=AnyHttpUrl(TestLogClient.OTA_CLIENT_LOGGING_SERVER),
+            logging_server_grpc=AnyHttpUrl(
+                TestLogClient.OTA_CLIENT_LOGGING_SERVER_GRPC
+            ),
+        )
+        mocker.patch(f"{MODULE}.proxy_info", self._proxy_info)
+
+    @pytest_asyncio.fixture
+    async def launch_grpc_server(self):
+        server = grpc.aio.server()
+        log_v1_grpc.add_OTAClientIoTLoggingServiceServicer_to_server(
+            servicer=DummyLogServerService(self.test_queue, self.data_ready),
+            server=server,
+        )
+        parsed_url = urlparse(TestLogClient.OTA_CLIENT_LOGGING_SERVER)
+        server.add_insecure_port(parsed_url.netloc)
+        try:
+            await server.start()
+            yield
+        finally:
+            await server.stop(None)
+            await server.wait_for_termination()
+
+    @pytest.fixture
+    def restore_logging(self):
+        # confiure_logging() is called in the test, so we need to restore the original logging configuration
+        # Save the current logging configuration
+        original_handlers = logging.root.handlers[:]
+        original_level = logging.root.level
+        original_formatters = [handler.formatter for handler in logging.root.handlers]
+
+        yield
+
+        # Restore the original logging configuration
+        logging.root.handlers = original_handlers
+        logging.root.level = original_level
+        for handler, formatter in zip(logging.root.handlers, original_formatters):
+            handler.setFormatter(formatter)
+
+    @pytest.mark.parametrize(
+        "log_message, extra, expected_log_type",
+        [
+            (
+                "some log message without extra",
+                {},
+                log_pb2.LogType.LOG,
+            ),
+            (
+                "some log message",
+                {"log_type": LogType.LOG},
+                log_pb2.LogType.LOG,
+            ),
+            (
+                "some metrics message",
+                {"log_type": LogType.METRICS},
+                log_pb2.LogType.METRICS,
+            ),
+        ],
+    )
+    async def test_grpc_logging(
+        self,
+        launch_grpc_server,
+        restore_logging,
+        log_message,
+        extra,
+        expected_log_type,
+    ):
+        configure_logging()
+        # send a test log message
+        logger.error(log_message, extra=extra)
+        # wait for the log message to be received
+        await self.data_ready.wait()
+        self.data_ready.clear()
+
+        try:
+            _response = self.test_queue.get_nowait()
+        except Exception as e:
+            pytest.fail(f"Failed to get a log message from the queue: {e}")
+
+        assert _response.ecu_id == TestLogClient.ECU_ID
+        assert _response.log_type == expected_log_type
+
+        if _response.log_type == log_pb2.LogType.LOG:
+            # Extract the message part from the log format
+            # e.g. [2022-01-01 00:00:00,000][ERROR]-test_log_client:test_log_client:123,some log message
+            log_format_regex = r"\[.*?\]\[.*?\]-.*?:.*?:\d+,(.*)"
+            match = re.match(log_format_regex, _response.message)
+            assert match is not None, "Log message format does not match"
+            extracted_message = match.group(1)
+            assert extracted_message == log_message
+        elif _response.log_type == log_pb2.LogType.METRICS:
+            # Expect the message to be the same as the input
+            assert _response.message == log_message
+        else:
+            pytest.fail(f"Unexpected log type: {_response.log_type}")


### PR DESCRIPTION
## Description
### Why
- currently, otaclient doesn't wait for logging server waking up. It cause log lost.
- otaclient support only HTTP interface for logging even though logging server supports both gRPC and HTTP.

### What
- wait for logging server up with HTTP empty message before starting log transmission
- support both http and grpc for logging.
  - otaclient try to use gRPC first. If it is not available, fallback to use HTTP. 
  - In gRPC, support two types(`LOG` and `METRICS`) logging.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file(s) that covers the change(s) is implemented.
- [x] local test is passed.
- [x] design docs/implementation docs are prepared.
https://tier4.atlassian.net/wiki/spaces/OTA/pages/3481894920/OTA+Metrics

### verified test cases
- verified the following matrix test cases

|  | otaclient v3.8.6 | otaclient with this PR |
|:---|:---:|---:|
|iot-logger v1.2.0 | (HTTP) | HTTP |
|iot-logger v1.3.0 | HTTP | gRPC |

- verified that otaclient wait for iot-logger wake up with this PR.

## Documents

https://tier4.atlassian.net/wiki/spaces/OTA/pages/3481894920/OTA+Metrics

## Changes
- wait for logging server up with HTTP empty message before starting log transmission.
- if gRPC server is available, use gRPC to output log. Otherwise, use the existing HTTP.
- support two types logging
    - `LOG`
    the purpose is to collect execution log. the log will follow `LOG_FORMAT` format.
    - `METRICS`
    the purpose is to collect metrics log. the metrics log is raw format without applying any formatting.
    To emit metrics log, `extra` argument and "log_type" key is necessary.
    The actual METRICS caller part will be implemented in the later PR.
    ```
    (`logging.level(message, extra = {"log_type": _logging.LogType.METRICS})`)
    ```

## Behavior changes

Does this PR introduce behavior change(s)?

- [x] Yes, internal behaivor (will not impact user experience).
- [ ] Yes, external behaivor (will impact user experience).
- [ ] No.

### Previous behavior

<!-- Behaivor before the PR is introduced -->

### Behavior with this PR

<!-- Behavior after the PR is introduced -->

## Breaking change

Does this PR introduce breaking change?

- [ ] Yes.
- [x] No.

<!-- List the breaking change(s) -->

## Related links & tickets
