### PR TITLE
feat: status_monitor: log otaclient status every 60s when active OTA ongoing

### DIFF
--- a/src/otaclient/_status_monitor.py
+++ b/src/otaclient/_status_monitor.py
@@ -43,6 +43,8 @@ burst_suppressed_logger = get_burst_suppressed_logger(f"{__name__}.shm_push")
 
 _status_report_queue: queue.Queue | None = None
 
+LOG_OTA_PROGRESS_INTERVAL = 60  # seconds
+
 
 def _global_shutdown():
     if _status_report_queue:
@@ -329,17 +331,29 @@ class OTAClientStatusCollector:
             except queue.Empty:
                 time.sleep(self.min_collect_interval)
 
+    def _ota_status_logging_thread(self) -> None:
+        while True:
+            # when in active OTA, log OTA progress very <LOG_OTA_PROGRESS_INTERVAL>
+            if (
+                _cur_status := self._status
+            ) and _cur_status.ota_status == OTAStatus.UPDATING:
+                logger.info(f"ongoing OTA: {_cur_status}")
+            time.sleep(LOG_OTA_PROGRESS_INTERVAL)
+
     # API
 
-    def start(self) -> Thread:
+    def start(self) -> None:
         """Start the status_monitor thread."""
-        t = Thread(
+        Thread(
             target=self._status_collector_thread,
             daemon=True,
             name="otaclient_status_monitor",
-        )
-        t.start()
-        return t
+        ).start()
+        Thread(
+            target=self._ota_status_logging_thread,
+            daemon=True,
+            name="otaclient_status_logging",
+        ).start()
 
     @property
     def otaclient_status(self) -> OTAClientStatus | None:

--- a/src/otaclient/_status_monitor.py
+++ b/src/otaclient/_status_monitor.py
@@ -342,18 +342,24 @@ class OTAClientStatusCollector:
 
     # API
 
-    def start(self) -> None:
+    def start(self) -> Thread:
         """Start the status_monitor thread."""
-        Thread(
+        t = Thread(
             target=self._status_collector_thread,
             daemon=True,
             name="otaclient_status_monitor",
-        ).start()
-        Thread(
+        )
+        t.start()
+        return t
+
+    def start_log_thread(self) -> Thread:
+        t = Thread(
             target=self._ota_status_logging_thread,
             daemon=True,
             name="otaclient_status_logging",
-        ).start()
+        )
+        t.start()
+        return t
 
     @property
     def otaclient_status(self) -> OTAClientStatus | None:

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -1013,6 +1013,7 @@ def ota_core_process(
         max_traceback_size=max_traceback_size,
     )
     _status_monitor.start()
+    _status_monitor.start_log_thread()
 
     _ota_core = OTAClient(
         ecu_status_flags=ecu_status_flags,


### PR DESCRIPTION
## Introduction

This PR introduces an extra background thread for status_monitor, when active OTA is ongoing, it will log the otaclient status every 60seconds.