### PR TITLE
feat: mount tmpfs for each update_session

### DIFF
--- a/src/ota_metadata/legacy2/metadata.py
+++ b/src/ota_metadata/legacy2/metadata.py
@@ -353,6 +353,9 @@ class OTAMetadata:
     def prepare_fstable(self) -> None:
         """Optimize the file_table to be ready for delta generation use."""
         _orm = FileTableRegularORM(self.connect_fstable)
+
+        # NOTE: the below function will take 2 times of file_table db size
+        #       during execution!
         sort_and_replace(
             _orm,
             table_name=_orm.orm_table_name,

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -209,7 +209,7 @@ class _OTAUpdater:
 
         self._session_workdir = SessionWorkdir(
             suffix=session_id,
-            prefix="update_session-",
+            prefix="update_session",
             base_dir=cfg.RUN_DIR,
         )
 

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -80,6 +80,7 @@ from otaclient.create_standby._delta_gen import (
 )
 from otaclient.create_standby.rebuild_mode import RebuildMode
 from otaclient_common import EMPTY_FILE_SHA256, human_readable_size, replace_root
+from otaclient_common.cmdhelper import SessionWorkdir
 from otaclient_common.common import ensure_otaproxy_start
 from otaclient_common.downloader import (
     Downloader,
@@ -87,7 +88,6 @@ from otaclient_common.downloader import (
     DownloadPoolWatchdogFuncContext,
     DownloadResult,
 )
-from otaclient_common.linux import SessionWorkdir
 from otaclient_common.persist_file_handling import PersistFilesHandler
 from otaclient_common.retry_task_map import (
     TasksEnsureFailed,

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -209,7 +209,7 @@ class _OTAUpdater:
 
         self._session_workdir = SessionWorkdir(
             suffix=session_id,
-            prefix="update_session",
+            prefix="update_session-",
             base_dir=cfg.RUN_DIR,
         )
 

--- a/src/otaclient_common/cmdhelper.py
+++ b/src/otaclient_common/cmdhelper.py
@@ -597,7 +597,10 @@ def ensure_mointpoint(
 # ------ session tmpfs mount ------ #
 #
 
-DEFAULT_SESSION_TMPFS_SIZE = 700 * 1024**2  # 700MiB
+# NOTE: tmpfs is thin provisioned, so the size here is just the upper-bound limit.
+# NOTE: ota_metadata.legacy2.OTAMetadata.prepare_fstable will take instantaneous peak memory consumption
+#       of 2 times of file_table size, set the upper-bound high enough for it.
+DEFAULT_SESSION_TMPFS_SIZE = 800 * 1024**2  # 800MiB
 
 
 # NOTE: we cannot call mount within test environment, also its functionality is

--- a/src/otaclient_common/cmdhelper.py
+++ b/src/otaclient_common/cmdhelper.py
@@ -22,10 +22,14 @@ When underlying subprocess call failed and <raise_exception> is True,
 from __future__ import annotations
 
 import logging
+import shutil
 import sys
 import time
+import warnings
+import weakref
 from pathlib import Path
 from subprocess import CalledProcessError
+from tempfile import TemporaryDirectory, mkdtemp
 from typing import Literal, NoReturn, Protocol
 
 from otaclient_common._typing import StrOrPath
@@ -587,3 +591,66 @@ def ensure_mointpoint(
                 f"But still use {mnt_point} and override the previous mount"
             )
         )
+
+
+#
+# ------ session tmpfs mount ------ #
+#
+
+DEFAULT_SESSION_TMPFS_SIZE = 300 * 1024**2  # 300MiB
+
+
+# NOTE: we cannot call mount within test environment, also its functionality is
+#       the same as TemporaryDirectory except we directly mounting tmpfs on tmp,
+#       so skip testing the SessionWorkdir class
+class SessionWorkdir(TemporaryDirectory):  # pragma: no cover
+    def __init__(
+        self,
+        suffix: str | None = None,
+        prefix: str | None = "session-tmp-",
+        base_dir: StrOrPath | None = None,
+        *,
+        tmpfs_size: int = DEFAULT_SESSION_TMPFS_SIZE,
+    ) -> None:
+        self.name = mkdtemp(suffix, prefix, base_dir)
+        mount(
+            target="tmpfs",
+            mount_point=self.name,
+            options=["rw", "nosuid", "nodev", "noexec", f"size={tmpfs_size}"],
+            params=["-t", "tmpfs"],
+        )
+
+        self._finalizer = weakref.finalize(
+            self,
+            self._cleanup,
+            self.name,
+            warn_message="Implicitly cleaning up {!r}".format(self),
+        )
+
+    # NOTE: since _cleanup and _rmtree are not exposed API, we implement these internal APIs
+    #       again to avoid depending on them.
+
+    @classmethod
+    def _cleanup(cls, name, warn_message):
+        cls._rmtree(name)
+        warnings.warn(warn_message, ResourceWarning, stacklevel=1)
+
+    def cleanup(self) -> None:
+        if self._finalizer.detach():
+            self._rmtree(self.name)
+
+    @classmethod
+    def _rmtree(cls, name):
+        try:
+            ensure_umount(name, ignore_error=False)
+            logger.info(f"successfully umount session tmpfs at {name}")
+        except Exception as e:
+            logger.warning(f"failed to umount the tmpfs at {name}: {e!r}")
+
+        try:
+            # NOTE: not an exposed API
+            _upper_rmtree = TemporaryDirectory._rmtree  # type: ignore
+        except AttributeError:
+            _upper_rmtree = shutil.rmtree
+
+        _upper_rmtree(name)

--- a/src/otaclient_common/cmdhelper.py
+++ b/src/otaclient_common/cmdhelper.py
@@ -598,9 +598,9 @@ def ensure_mointpoint(
 #
 
 # NOTE: tmpfs is thin provisioned, so the size here is just the upper-bound limit.
-# NOTE: ota_metadata.legacy2.OTAMetadata.prepare_fstable will take instantaneous peak memory consumption
-#       of 2 times of file_table size, set the upper-bound high enough for it.
-DEFAULT_SESSION_TMPFS_SIZE = 800 * 1024**2  # 800MiB
+# NOTE: ota_metadata.legacy2.OTAMetadata.prepare_fstable might take some extra space during OTA,
+#       make sure we set a higher enough upper-bound.
+DEFAULT_SESSION_TMPFS_SIZE = 700 * 1024**2  # 700MiB
 
 
 # NOTE: we cannot call mount within test environment, also its functionality is

--- a/src/otaclient_common/cmdhelper.py
+++ b/src/otaclient_common/cmdhelper.py
@@ -597,7 +597,7 @@ def ensure_mointpoint(
 # ------ session tmpfs mount ------ #
 #
 
-DEFAULT_SESSION_TMPFS_SIZE = 300 * 1024**2  # 300MiB
+DEFAULT_SESSION_TMPFS_SIZE = 700 * 1024**2  # 700MiB
 
 
 # NOTE: we cannot call mount within test environment, also its functionality is

--- a/src/otaclient_common/linux.py
+++ b/src/otaclient_common/linux.py
@@ -223,7 +223,10 @@ def subprocess_run_wrapper(
 DEFAULT_SESSION_TMPFS_SIZE = 300 * 1024**2  # 300MiB
 
 
-class SessionWorkdir(TemporaryDirectory):
+# NOTE: we cannot call mount within test environment, also its functionality is
+#       the same as TemporaryDirectory except we directly mounting tmpfs on tmp,
+#       so skip testing the SessionWorkdir class
+class SessionWorkdir(TemporaryDirectory):  # pragma: no cover
     def __init__(
         self,
         suffix: str | None = None,

--- a/src/otaclient_common/linux.py
+++ b/src/otaclient_common/linux.py
@@ -15,14 +15,22 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import shlex
+import shutil
 import subprocess
+import warnings
+import weakref
 from pathlib import Path
 from subprocess import check_call
+from tempfile import TemporaryDirectory, mkdtemp
 from typing import Any, Callable, Optional
 
 from otaclient_common._typing import StrOrPath
+from otaclient_common.cmdhelper import ensure_umount, mount
+
+logger = logging.getLogger(__name__)
 
 #
 # ------ swapfile handling ------ #
@@ -206,3 +214,63 @@ def subprocess_run_wrapper(
         preexec_fn=preexec_fn,
         env=env,
     )
+
+
+#
+# ------ session tmpfs mount ------ #
+#
+
+DEFAULT_SESSION_TMPFS_SIZE = 300 * 1024**2  # 300MiB
+
+
+class SessionWorkdir(TemporaryDirectory):
+    def __init__(
+        self,
+        suffix: str | None = None,
+        prefix: str | None = "session-tmp-",
+        base_dir: StrOrPath | None = None,
+        *,
+        tmpfs_size: int = DEFAULT_SESSION_TMPFS_SIZE,
+    ) -> None:
+        self.name = mkdtemp(suffix, prefix, base_dir)
+        mount(
+            target="tmpfs",
+            mount_point=self.name,
+            options=["rw", "nosuid", "nodev", "noexec", f"size={tmpfs_size}"],
+            params=["-t", "tmpfs"],
+        )
+
+        self._finalizer = weakref.finalize(
+            self,
+            self._cleanup,
+            self.name,
+            warn_message="Implicitly cleaning up {!r}".format(self),
+        )
+
+    # NOTE: since _cleanup and _rmtree are not exposed API, we implement these internal APIs
+    #       again to avoid depending on them.
+
+    @classmethod
+    def _cleanup(cls, name, warn_message):
+        cls._rmtree(name)
+        warnings.warn(warn_message, ResourceWarning, stacklevel=1)
+
+    def cleanup(self) -> None:
+        if self._finalizer.detach():
+            self._rmtree(self.name)
+
+    @classmethod
+    def _rmtree(cls, name):
+        try:
+            ensure_umount(name, ignore_error=False)
+            logger.info(f"successfully umount session tmpfs at {name}")
+        except Exception as e:
+            logger.warning(f"failed to umount the tmpfs at {name}: {e!r}")
+
+        try:
+            # NOTE: not an exposed API
+            _upper_rmtree = TemporaryDirectory._rmtree  # type: ignore
+        except AttributeError:
+            _upper_rmtree = shutil.rmtree
+
+        _upper_rmtree(name)


### PR DESCRIPTION
## Introduction

Previously, otaclient uses `/run/otaclient` as run dir, and for each update session creates a `update_session-xxx` folder to store the file_table and resource_table, occupying the system `/run` tmpfs mount point space. 
To avoid using up the `/run` space, this PR introduces to use tmpfs for each update session.  