### PR TITLE
fix: delta_gen: fix semaphore not being reclaimed in full disk scan mode

### DIFF
--- a/docker/test_base/Dockerfile
+++ b/docker/test_base/Dockerfile
@@ -11,13 +11,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV SPECIAL_FILE="path;adf.ae?qu.er\y=str#fragファイルement"
 # NOTE(20250225): for PR#492, add a folder that contains 5000 empty files
 ENV EMPTY_FILE_FOLDER="/usr/empty_files"
+ENV EMPTY_FILES_COUNT=1024
 
 # special treatment to the ota-image: create file that needs url escaping
 # NOTE: include special identifiers #?; into the pathname
 RUN set -eux; \
     echo -n "${SPECIAL_FILE}" > "/${SPECIAL_FILE}"; \
     # create special folder containing a lot of empty files
-    mkdir -p ${EMPTY_FILE_FOLDER}; for i in $(seq 0 4999); do touch "${EMPTY_FILE_FOLDER}/$i"; done; \
+    mkdir -p ${EMPTY_FILE_FOLDER}; for i in $(seq 1 ${EMPTY_FILES_COUNT}); do touch "${EMPTY_FILE_FOLDER}/$i"; done; \
     # install required packages
     apt-get update -qq; \
     apt-get install -y linux-image-generic; \

--- a/docker/test_base/Dockerfile
+++ b/docker/test_base/Dockerfile
@@ -17,7 +17,7 @@ ENV EMPTY_FILE_FOLDER="/usr/empty_files"
 RUN set -eux; \
     echo -n "${SPECIAL_FILE}" > "/${SPECIAL_FILE}"; \
     # create special folder containing a lot of empty files
-    for i in $(seq 0 4999); do touch "${EMPTY_FILE_FOLDER}/$i"; done; \
+    mkdir -p ${EMPTY_FILE_FOLDER}; for i in $(seq 0 4999); do touch "${EMPTY_FILE_FOLDER}/$i"; done; \
     # install required packages
     apt-get update -qq; \
     apt-get install -y linux-image-generic; \

--- a/docker/test_base/Dockerfile
+++ b/docker/test_base/Dockerfile
@@ -9,11 +9,15 @@ FROM ${UBUNTU_BASE} AS image_build
 SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 ENV SPECIAL_FILE="path;adf.ae?qu.er\y=str#fragファイルement"
+# NOTE(20250225): for PR#492, add a folder that contains 5000 empty files
+ENV EMPTY_FILE_FOLDER="/usr/empty_files"
 
 # special treatment to the ota-image: create file that needs url escaping
 # NOTE: include special identifiers #?; into the pathname
 RUN set -eux; \
     echo -n "${SPECIAL_FILE}" > "/${SPECIAL_FILE}"; \
+    # create special folder containing a lot of empty files
+    for i in $(seq 0 4999); do touch "${EMPTY_FILE_FOLDER}/$i"; done; \
     # install required packages
     apt-get update -qq; \
     apt-get install -y linux-image-generic; \

--- a/src/otaclient/create_standby/_delta_gen.py
+++ b/src/otaclient/create_standby/_delta_gen.py
@@ -218,10 +218,10 @@ class DeltaGenFullDiskScan(DeltaGenerator):
         fully_scan: bool,
         thread_local,
     ) -> None:
-        if fpath.stat().st_size == 0:
-            return  # skip empty file
-
         try:
+            if not fpath.is_file() or fpath.stat().st_size == 0:
+                return  # skip empty file
+
             # in default match_only mode, if the fpath doesn't exist in new, ignore
             if not fully_scan and not self._ft_regular_orm.orm_check_entry_exist(
                 path=str(canonical_fpath)


### PR DESCRIPTION
## Introduction

This PR fixes an issue which In `_delta_gen.DeltaGenFullDiskScan._process_file`, if src file is an empty file, the method will return directly without releasing the semaphore.

Tests that cover this condition has been added by adding a folder with a lot of empty files in the generated OTA image.