### PR TITLE
refactor: ota_metadata.file_table: add ft_resource table, refine iter_common_digest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "pydantic-settings<3,>=2.3",
   "pyyaml<7,>=6.0.1",
   "requests<2.33,>=2.32",
-  "simple-sqlite3-orm==0.11.0rc0",
+  "simple-sqlite3-orm==0.11.0rc1",
   "typing-extensions>=4.6.3",
   "urllib3>=2.2.2,<2.4",
   "uvicorn[standard]>=0.30,<0.35",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "pydantic-settings<3,>=2.3",
   "pyyaml<7,>=6.0.1",
   "requests<2.33,>=2.32",
-  "simple-sqlite3-orm==0.11.0rc1",
+  "simple-sqlite3-orm<0.12,>=0.11",
   "typing-extensions>=4.6.3",
   "urllib3>=2.2.2,<2.4",
   "uvicorn[standard]>=0.30,<0.35",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "pydantic-settings<3,>=2.3",
   "pyyaml<7,>=6.0.1",
   "requests<2.33,>=2.32",
-  "simple-sqlite3-orm<0.11,>=0.10",
+  "simple-sqlite3-orm==0.11.0rc0",
   "typing-extensions>=4.6.3",
   "urllib3>=2.2.2,<2.4",
   "uvicorn[standard]>=0.30,<0.35",

--- a/src/ota_metadata/file_table/__init__.py
+++ b/src/ota_metadata/file_table/__init__.py
@@ -14,10 +14,13 @@
 
 
 from ._orm import (
+    FT_DIR_TABLE_NAME,
+    FT_NON_REGULAR_TABLE_NAME,
     FT_REGULAR_TABLE_NAME,
     FT_RESOURCE_TABLE_NAME,
     FileEntryToScan,
     FileTableDirORM,
+    FileTableDirORMPool,
     FileTableNonRegularORM,
     FileTableRegularORM,
     FileTableRegularORMPool,
@@ -47,4 +50,7 @@ __all__ = [
     "FileEntryToScan",
     "FileTableResourceORM",
     "FileTableResource",
+    "FT_DIR_TABLE_NAME",
+    "FT_NON_REGULAR_TABLE_NAME",
+    "FileTableDirORMPool",
 ]

--- a/src/ota_metadata/file_table/__init__.py
+++ b/src/ota_metadata/file_table/__init__.py
@@ -21,11 +21,13 @@ from ._orm import (
     FileTableNonRegularORM,
     FileTableRegularORM,
     FileTableRegularORMPool,
+    FileTableResourceORM,
 )
 from ._table import (
     FileTableDirectories,
     FileTableNonRegularFiles,
     FileTableRegularFiles,
+    FileTableResource,
     RegularFileEntry,
 )
 from ._types import FileEntryAttrs
@@ -43,4 +45,6 @@ __all__ = [
     "FT_REGULAR_TABLE_NAME",
     "FT_RESOURCE_TABLE_NAME",
     "FileEntryToScan",
+    "FileTableResourceORM",
+    "FileTableResource",
 ]

--- a/src/ota_metadata/file_table/__init__.py
+++ b/src/ota_metadata/file_table/__init__.py
@@ -14,6 +14,9 @@
 
 
 from ._orm import (
+    FT_REGULAR_TABLE_NAME,
+    FT_RESOURCE_TABLE_NAME,
+    FileEntryToScan,
     FileTableDirORM,
     FileTableNonRegularORM,
     FileTableRegularORM,
@@ -23,6 +26,7 @@ from ._table import (
     FileTableDirectories,
     FileTableNonRegularFiles,
     FileTableRegularFiles,
+    RegularFileEntry,
 )
 from ._types import FileEntryAttrs
 
@@ -35,4 +39,8 @@ __all__ = [
     "FileTableRegularFiles",
     "FileTableDirectories",
     "FileEntryAttrs",
+    "RegularFileEntry",
+    "FT_REGULAR_TABLE_NAME",
+    "FT_RESOURCE_TABLE_NAME",
+    "FileEntryToScan",
 ]

--- a/src/ota_metadata/file_table/_orm.py
+++ b/src/ota_metadata/file_table/_orm.py
@@ -43,6 +43,7 @@ MAX_ENTRIES_PER_DIGEST = 10
 
 
 class FileEntryToScan(NamedTuple):
+    """A helper type for typing output result of iter_common_by_digest."""
 
     path: str
     digest: bytes

--- a/src/ota_metadata/file_table/_orm.py
+++ b/src/ota_metadata/file_table/_orm.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import logging
 import sqlite3
+import textwrap
 from typing import Any, Generator, NamedTuple
 
 from simple_sqlite3_orm import CreateIndexParams, ORMBase, ORMThreadPoolBase
@@ -73,7 +74,8 @@ class FileTableRegularORM(ORMBase[FileTableRegularFiles]):
                 f"detect {sqlite3.sqlite_version_info=} < 3.25, use fallback query"
             )
 
-            stmt = f"""\
+            stmt = textwrap.dedent(
+                f"""\
             WITH common_digests AS (
                 SELECT db1.digest
                 FROM {FT_RESOURCE_TABLE_NAME} AS db1
@@ -86,8 +88,10 @@ class FileTableRegularORM(ORMBase[FileTableRegularFiles]):
             JOIN common_digests ON {FT_RESOURCE_TABLE_NAME}.digest = common_digests.digest
             ORDER BY {FT_RESOURCE_TABLE_NAME}.digest;
             """
+            )
         else:
-            stmt = f"""\
+            stmt = textwrap.dedent(
+                f"""\
             WITH common_digests AS (
                 SELECT db1.digest
                 FROM {FT_RESOURCE_TABLE_NAME} AS db1
@@ -109,6 +113,7 @@ class FileTableRegularORM(ORMBase[FileTableRegularFiles]):
             WHERE row_num <= {max_entries_per_digest}
             ORDER BY digest;
             """
+            )
         orm_conn = self.orm_con
 
         orm_conn.execute(f"ATTACH '{other_db}' AS {attached_db_schema};")

--- a/src/ota_metadata/file_table/_orm.py
+++ b/src/ota_metadata/file_table/_orm.py
@@ -105,9 +105,9 @@ class FileTableRegularORM(ORMBase[FileTableRegularFiles]):
                     INNER JOIN base.{FT_RESOURCE_TABLE_NAME} USING(digest)
                     WHERE digest != {wrap_value(EMPTY_FILE_SHA256_BYTE)}
                 ), ranked_results AS (
-                    SELECT 
-                        base_ft_regular.path, 
-                        base_ft_rs.digest, 
+                    SELECT
+                        base_ft_regular.path,
+                        base_ft_rs.digest,
                         base_ft_rs.size,
                         ROW_NUMBER() OVER (PARTITION BY base_ft_rs.digest) AS row_num
                     FROM base.{FT_REGULAR_TABLE_NAME} AS base_ft_regular

--- a/src/ota_metadata/file_table/_orm.py
+++ b/src/ota_metadata/file_table/_orm.py
@@ -17,10 +17,11 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-from typing import Generator
+from typing import Any, Generator, NamedTuple
 
 from simple_sqlite3_orm import CreateIndexParams, ORMBase, ORMThreadPoolBase
 from simple_sqlite3_orm.utils import wrap_value
+from typing_extensions import Self
 
 from otaclient_common import EMPTY_FILE_SHA256_BYTE
 
@@ -28,6 +29,7 @@ from ._table import (
     FileTableDirectories,
     FileTableNonRegularFiles,
     FileTableRegularFiles,
+    FileTableResource,
 )
 
 logger = logging.getLogger(__name__)
@@ -35,7 +37,19 @@ logger = logging.getLogger(__name__)
 FT_REGULAR_TABLE_NAME = "ft_regular"
 FT_NON_REGULAR_TABLE_NAME = "ft_non_regular"
 FT_DIR_TABLE_NAME = "ft_dir"
+FT_RESOURCE_TABLE_NAME = "ft_resource"
 MAX_ENTRIES_PER_DIGEST = 10
+
+
+class FileEntryToScan(NamedTuple):
+
+    path: str
+    digest: bytes
+    size: int
+
+    @classmethod
+    def row_factory(cls, _cursor, _row: tuple[Any, ...] | Any) -> Self:
+        return cls(*_row)
 
 
 class FileTableRegularORM(ORMBase[FileTableRegularFiles]):
@@ -47,7 +61,7 @@ class FileTableRegularORM(ORMBase[FileTableRegularFiles]):
 
     def iter_common_by_digest(
         self, other_db: str, *, max_entries_per_digest: int = MAX_ENTRIES_PER_DIGEST
-    ) -> Generator[FileTableRegularFiles]:
+    ) -> Generator[FileEntryToScan]:
         """Yield entries from <other_db>.ft_table which digest presented in this ft.
 
         This is for assisting faster delta_calculation without full disk scan.
@@ -60,28 +74,40 @@ class FileTableRegularORM(ORMBase[FileTableRegularFiles]):
             )
 
             stmt = f"""\
-            SELECT d2.*
-            FROM base.{FT_REGULAR_TABLE_NAME} AS d2
-            INNER JOIN (
-                SELECT digest
-                FROM main.{FT_REGULAR_TABLE_NAME}
+            WITH common_digests AS (
+                SELECT db1.digest
+                FROM {FT_RESOURCE_TABLE_NAME} AS db1
+                INNER JOIN base.{FT_RESOURCE_TABLE_NAME} AS db2 USING(digest)
                 WHERE digest != {wrap_value(EMPTY_FILE_SHA256_BYTE)}
-                GROUP BY digest
-            ) AS d1 USING(digest) ORDER BY digest;
+            )
+            SELECT {FT_REGULAR_TABLE_NAME}.path, {FT_RESOURCE_TABLE_NAME}.digest, {FT_RESOURCE_TABLE_NAME}.size
+            FROM {FT_REGULAR_TABLE_NAME}
+            JOIN {FT_RESOURCE_TABLE_NAME} ON {FT_REGULAR_TABLE_NAME}.resource_id = {FT_RESOURCE_TABLE_NAME}.resource_id
+            JOIN common_digests ON {FT_RESOURCE_TABLE_NAME}.digest = common_digests.digest
+            ORDER BY {FT_RESOURCE_TABLE_NAME}.digest;
             """
         else:
             stmt = f"""\
-            WITH ranked AS (
-                SELECT d2.*, ROW_NUMBER() OVER (PARTITION BY d2.digest) AS rown
-                FROM base.{FT_REGULAR_TABLE_NAME} AS d2
-                INNER JOIN (
-                    SELECT digest
-                    FROM main.{FT_REGULAR_TABLE_NAME}
-                    WHERE digest != {wrap_value(EMPTY_FILE_SHA256_BYTE)}
-                    GROUP BY digest
-                ) AS d1 USING(digest) ORDER BY digest
+            WITH common_digests AS (
+                SELECT db1.digest
+                FROM {FT_RESOURCE_TABLE_NAME} AS db1
+                INNER JOIN base.{FT_RESOURCE_TABLE_NAME} AS db2 USING(digest)
+                WHERE digest != {wrap_value(EMPTY_FILE_SHA256_BYTE)}
+            ), ranked_results AS (
+                SELECT 
+                    {FT_REGULAR_TABLE_NAME}.path, 
+                    {FT_RESOURCE_TABLE_NAME}.digest, 
+                    {FT_RESOURCE_TABLE_NAME}.size,
+                    ROW_NUMBER() OVER (PARTITION BY {FT_RESOURCE_TABLE_NAME}.digest ORDER BY {FT_RESOURCE_TABLE_NAME}.path) AS row_num
+                FROM {FT_REGULAR_TABLE_NAME}
+                JOIN {FT_RESOURCE_TABLE_NAME} USING(resource_id)
+                JOIN common_digests USING(digest)
             )
-            SELECT * FROM ranked WHERE rown <= {max_entries_per_digest};
+
+            SELECT path, digest, size
+            FROM ranked_results
+            WHERE row_num <= {max_entries_per_digest}
+            ORDER BY digest;
             """
         orm_conn = self.orm_con
 
@@ -89,7 +115,7 @@ class FileTableRegularORM(ORMBase[FileTableRegularFiles]):
         try:
             with orm_conn:
                 cur = orm_conn.execute(stmt)
-                cur.row_factory = self.orm_table_spec.table_row_factory2
+                cur.row_factory = FileEntryToScan.row_factory
                 yield from cur
         finally:
             orm_conn.execute(f"DETACH DATABASE {attached_db_schema};")
@@ -113,3 +139,11 @@ class FileTableDirORM(ORMBase[FileTableDirectories]):
 class FileTableDirORMPool(ORMThreadPoolBase[FileTableDirectories]):
 
     orm_bootstrap_table_name = FT_DIR_TABLE_NAME
+
+
+class FileTableResourceORM(ORMBase[FileTableResource]):
+
+    orm_bootstrap_table_name = FT_RESOURCE_TABLE_NAME
+    orm_bootstrap_indexes_params = [
+        CreateIndexParams(index_name="digest_index", index_cols=("digest",))
+    ]

--- a/src/ota_metadata/file_table/_orm.py
+++ b/src/ota_metadata/file_table/_orm.py
@@ -58,7 +58,7 @@ class FileTableRegularORM(ORMBase[FileTableRegularFiles]):
 
     orm_bootstrap_table_name = FT_REGULAR_TABLE_NAME
     orm_bootstrap_indexes_params = [
-        CreateIndexParams(index_name="digest_index", index_cols=("digest",))
+        CreateIndexParams(index_name="resource_id_index", index_cols=("resource_id",))
     ]
 
     def iter_common_by_digest(

--- a/src/ota_metadata/file_table/_orm.py
+++ b/src/ota_metadata/file_table/_orm.py
@@ -20,7 +20,12 @@ import sqlite3
 import textwrap
 from typing import Any, Generator, NamedTuple
 
-from simple_sqlite3_orm import CreateIndexParams, ORMBase, ORMThreadPoolBase
+from simple_sqlite3_orm import (
+    CreateIndexParams,
+    CreateTableParams,
+    ORMBase,
+    ORMThreadPoolBase,
+)
 from simple_sqlite3_orm.utils import wrap_value
 from typing_extensions import Self
 
@@ -57,6 +62,7 @@ class FileEntryToScan(NamedTuple):
 class FileTableRegularORM(ORMBase[FileTableRegularFiles]):
 
     orm_bootstrap_table_name = FT_REGULAR_TABLE_NAME
+    orm_bootstrap_create_table_params = CreateTableParams(without_rowid=True)
     orm_bootstrap_indexes_params = [
         CreateIndexParams(index_name="resource_id_index", index_cols=("resource_id",))
     ]
@@ -135,11 +141,13 @@ class FileTableRegularORMPool(ORMThreadPoolBase[FileTableRegularFiles]):
 class FileTableNonRegularORM(ORMBase[FileTableNonRegularFiles]):
 
     orm_bootstrap_table_name = FT_NON_REGULAR_TABLE_NAME
+    orm_bootstrap_create_table_params = CreateTableParams(without_rowid=True)
 
 
 class FileTableDirORM(ORMBase[FileTableDirectories]):
 
     orm_bootstrap_table_name = FT_DIR_TABLE_NAME
+    orm_bootstrap_create_table_params = CreateTableParams(without_rowid=True)
 
 
 class FileTableDirORMPool(ORMThreadPoolBase[FileTableDirectories]):
@@ -150,6 +158,7 @@ class FileTableDirORMPool(ORMThreadPoolBase[FileTableDirectories]):
 class FileTableResourceORM(ORMBase[FileTableResource]):
 
     orm_bootstrap_table_name = FT_RESOURCE_TABLE_NAME
+    orm_bootstrap_create_table_params = CreateTableParams(without_rowid=True)
     orm_bootstrap_indexes_params = [
         CreateIndexParams(index_name="digest_index", index_cols=("digest",))
     ]

--- a/src/ota_metadata/file_table/_orm.py
+++ b/src/ota_metadata/file_table/_orm.py
@@ -103,7 +103,7 @@ class FileTableRegularORM(ORMBase[FileTableRegularFiles]):
                     {FT_REGULAR_TABLE_NAME}.path, 
                     {FT_RESOURCE_TABLE_NAME}.digest, 
                     {FT_RESOURCE_TABLE_NAME}.size,
-                    ROW_NUMBER() OVER (PARTITION BY {FT_RESOURCE_TABLE_NAME}.digest ORDER BY {FT_RESOURCE_TABLE_NAME}.path) AS row_num
+                    ROW_NUMBER() OVER (PARTITION BY {FT_RESOURCE_TABLE_NAME}.digest) AS row_num
                 FROM {FT_REGULAR_TABLE_NAME}
                 JOIN {FT_RESOURCE_TABLE_NAME} USING(resource_id)
                 JOIN common_digests USING(digest)

--- a/src/ota_metadata/file_table/_orm.py
+++ b/src/ota_metadata/file_table/_orm.py
@@ -91,8 +91,8 @@ class FileTableRegularORM(ORMBase[FileTableRegularFiles]):
                 )
                 SELECT base_ft_regular.path, base_ft_rs.digest, base_ft_rs.size
                 FROM base.{FT_REGULAR_TABLE_NAME} AS base_ft_regular
-                JOIN base.{FT_RESOURCE_TABLE_NAME} AS base_ft_rs USING(resource_id)
-                JOIN common_digests USING(digest)
+                INNER JOIN base.{FT_RESOURCE_TABLE_NAME} AS base_ft_rs USING(resource_id)
+                INNER JOIN common_digests USING(digest)
                 ORDER BY base_ft_rs.digest;
                 """
             )
@@ -111,8 +111,8 @@ class FileTableRegularORM(ORMBase[FileTableRegularFiles]):
                         base_ft_rs.size,
                         ROW_NUMBER() OVER (PARTITION BY base_ft_rs.digest) AS row_num
                     FROM base.{FT_REGULAR_TABLE_NAME} AS base_ft_regular
-                    JOIN base.{FT_RESOURCE_TABLE_NAME} AS base_ft_rs USING(resource_id)
-                    JOIN common_digests USING(digest)
+                    INNER JOIN base.{FT_RESOURCE_TABLE_NAME} AS base_ft_rs USING(resource_id)
+                    INNER JOIN common_digests USING(digest)
                 )
 
                 SELECT path, digest, size

--- a/src/ota_metadata/file_table/_table.py
+++ b/src/ota_metadata/file_table/_table.py
@@ -139,6 +139,12 @@ class FileTableRegularFiles(TableSpec, FileTableBase):
             raise
 
 
+class RegularFileEntry(FileTableRegularFiles):
+    """A helper class for joined ft_regular and ft_resource."""
+
+    digest: bytes
+
+
 class FileTableNonRegularFiles(TableSpec, FileTableBase):
     """DB table for non-regular file entries.
 

--- a/src/ota_metadata/file_table/_table.py
+++ b/src/ota_metadata/file_table/_table.py
@@ -140,7 +140,7 @@ class FileTableRegularFiles(TableSpec, FileTableBase):
 
 
 class RegularFileEntry(FileTableRegularFiles):
-    """A helper class for joined ft_regular and ft_resource."""
+    """Subtype of FileTableRegularFiles, used forjoined ft_regular and ft_resource."""
 
     digest: bytes
 

--- a/src/ota_metadata/file_table/_table.py
+++ b/src/ota_metadata/file_table/_table.py
@@ -100,11 +100,7 @@ class FileTableBase(BaseModel):
 class FileTableRegularFiles(TableSpec, FileTableBase):
     """DB table for regular file entries."""
 
-    digest: Annotated[
-        bytes,
-        TypeAffinityRepr(bytes),
-        SkipValidation,
-    ]
+    resource_id: Annotated[int, SkipValidation]
 
     def prepare_target(
         self,
@@ -220,3 +216,10 @@ class FileTableDirectories(TableSpec, FileTableBase):
         except Exception as e:
             burst_suppressed_logger.exception(f"failed on preparing {self!r}: {e!r}")
             raise
+
+
+class FileTableResource(TableSpec):
+
+    resource_id: Annotated[int, ConstrainRepr("PRIMARY KEY"), SkipValidation]
+    digest: Annotated[bytes, SkipValidation]
+    size: Annotated[int, SkipValidation]

--- a/src/ota_metadata/legacy2/csv_parser.py
+++ b/src/ota_metadata/legacy2/csv_parser.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import logging
 import re
 import stat
+from typing import NamedTuple
 
 from ota_metadata.file_table import (
     FileEntryAttrs,
@@ -29,6 +30,8 @@ from ota_metadata.file_table import (
     FileTableRegularFiles,
     FileTableRegularORM,
 )
+from ota_metadata.file_table._orm import FileTableResourceORM
+from ota_metadata.file_table._table import FileTableResource
 from otaclient_common._typing import StrOrPath
 
 from .rs_table import ResourceTable, ResourceTableORM
@@ -165,7 +168,7 @@ REGINF_CSV_PATTERN = re.compile(
 )
 
 
-def parse_regulars_csv_line(line: str) -> tuple[FileTableRegularFiles, ResourceTable]:
+def parse_regular_csv_line(line: str) -> re.Match:
     """Regular file entry's CSV pattern.
 
     Note that <compressed_alg> only has `zst` now.
@@ -178,7 +181,25 @@ def parse_regulars_csv_line(line: str) -> tuple[FileTableRegularFiles, ResourceT
     """
     _ma = REGINF_CSV_PATTERN.match(line.strip())
     assert _ma is not None, f"matching reg_inf failed for {line}"
+    return _ma
 
+
+class DigestSize(NamedTuple):
+    digest: bytes
+    size: int
+
+
+def parser_create_file_table_rs_entry(_ma: re.Match) -> DigestSize:
+    sha256hash = bytes.fromhex(_ma.group("hash"))
+    size = 0
+    if _size := _ma.group("size"):
+        size = int(_size)
+    return DigestSize(sha256hash, size)
+
+
+def parse_create_file_table_row(
+    _ma: re.Match, resource_id: int
+) -> tuple[FileTableRegularFiles, ResourceTable]:
     # NOTE: the ota-metadata generator strips away the file type bits.
     mode = int(_ma.group("mode"), 8) | stat.S_IFREG
     uid = int(_ma.group("uid"))
@@ -207,7 +228,7 @@ def parse_regulars_csv_line(line: str) -> tuple[FileTableRegularFiles, ResourceT
             size=size,
             inode=inode,
         ),
-        digest=sha256hash,
+        resource_id=resource_id,
     )
 
     # NOTE: in rev4 of OTA image metadata we add compression support, and compressed version of resource
@@ -227,25 +248,36 @@ def parse_regulars_csv_line(line: str) -> tuple[FileTableRegularFiles, ResourceT
         compression_alg=compressed_alg,
         original_size=size or 0,
     )
-
     return _new, _new_rs
 
 
 def parse_regulars_from_csv_file(
     _fpath: StrOrPath,
     _orm: FileTableRegularORM,
+    _orm_ft_resource: FileTableResourceORM,
     _orm_rs: ResourceTableORM,
 ) -> int:
     """Compatibility to the plaintext regulars.txt."""
+    digest_resources: dict[DigestSize, int] = {}
+
     _batch, _batch_rs, _batch_cnt = [], [], 0
     with open(_fpath, "r") as f:
-        _idx = 0
-        for _idx, line in enumerate(f, start=1):
-            _new, _new_rs = parse_regulars_csv_line(line)
+        regular_file_entry_count = 0
+        for regular_file_entry_count, line in enumerate(f, start=1):
+            _line_match = parse_regular_csv_line(line)
+            _digest_size = parser_create_file_table_rs_entry(_line_match)
+            _resource_id = digest_resources.setdefault(
+                _digest_size, len(digest_resources)
+            )
+
+            _new, _new_rs = parse_create_file_table_row(_line_match, _resource_id)
+
             _batch.append(_new)
             _batch_rs.append(_new_rs)
 
-            if (_this_batch := _idx // ENTRIES_PROCESS_BATCH_SIZE) > _batch_cnt:
+            if (
+                _this_batch := regular_file_entry_count // ENTRIES_PROCESS_BATCH_SIZE
+            ) > _batch_cnt:
                 _batch_cnt = _this_batch
                 _orm.orm_insert_entries(_batch)
                 # NOTE: ignore entries with same digest
@@ -255,7 +287,16 @@ def parse_regulars_from_csv_file(
         _orm.orm_insert_entries(_batch)
         _orm_rs.orm_insert_entries(_batch_rs, or_option="ignore")
 
-        return _idx
+    # prepare the ft_resource
+    _orm_ft_resource.orm_insert_entries(
+        (
+            FileTableResource(
+                resource_id=_rs_id, digest=_digest_size.digest, size=_digest_size.size
+            )
+            for _digest_size, _rs_id in digest_resources.items()
+        )
+    )
+    return regular_file_entry_count
 
 
 #

--- a/src/ota_metadata/legacy2/csv_parser.py
+++ b/src/ota_metadata/legacy2/csv_parser.py
@@ -29,9 +29,9 @@ from ota_metadata.file_table import (
     FileTableNonRegularORM,
     FileTableRegularFiles,
     FileTableRegularORM,
+    FileTableResource,
+    FileTableResourceORM,
 )
-from ota_metadata.file_table._orm import FileTableResourceORM
-from ota_metadata.file_table._table import FileTableResource
 from otaclient_common._typing import StrOrPath
 
 from .rs_table import ResourceTable, ResourceTableORM

--- a/src/ota_metadata/legacy2/metadata.py
+++ b/src/ota_metadata/legacy2/metadata.py
@@ -50,9 +50,9 @@ from ota_metadata.file_table import (
     FileTableNonRegularFiles,
     FileTableNonRegularORM,
     FileTableRegularORM,
+    FileTableResourceORM,
     RegularFileEntry,
 )
-from ota_metadata.file_table._orm import FileTableResourceORM
 from ota_metadata.utils import DownloadInfo
 from ota_metadata.utils.cert_store import CAChainStore
 from otaclient_common._typing import StrOrPath

--- a/src/ota_metadata/legacy2/metadata.py
+++ b/src/ota_metadata/legacy2/metadata.py
@@ -359,19 +359,17 @@ class OTAMetadata:
             for line in f:
                 yield line.strip()[1:-1]
 
-    def iter_dir_entries(self, *, batch_size: int) -> Generator[FileTableDirectories]:
+    def iter_dir_entries(self) -> Generator[FileTableDirectories]:
         with FileTableDirORM(self.connect_fstable()) as orm:
-            yield from orm.orm_select_all_with_pagination(batch_size=batch_size)
+            yield from orm.orm_select_entries()
 
-    def iter_non_regular_entries(
-        self, *, batch_size: int
-    ) -> Generator[FileTableNonRegularFiles]:
+    def iter_non_regular_entries(self) -> Generator[FileTableNonRegularFiles]:
         """Yield entries from base file_table which digest presented in OTA image's file_table.
 
         This is for assisting faster delta_calculation without full disk scan.
         """
         with FileTableNonRegularORM(self.connect_fstable()) as orm:
-            yield from orm.orm_select_all_with_pagination(batch_size=batch_size)
+            yield from orm.orm_select_entries()
 
     def iter_common_regular_entries_by_digest(
         self,

--- a/src/ota_metadata/legacy2/metadata.py
+++ b/src/ota_metadata/legacy2/metadata.py
@@ -390,7 +390,6 @@ class OTAMetadata:
                 yield _hash, _cur
 
     def iter_regular_entries(self) -> Generator[FileTableRegularFiles]:
-        # NOTE: do the dispatch at a thread
         with FileTableRegularORM(self.connect_fstable()) as orm:
             yield from orm.orm_select_entries(_order_by=("digest",))
 

--- a/src/ota_metadata/legacy2/metadata.py
+++ b/src/ota_metadata/legacy2/metadata.py
@@ -52,6 +52,7 @@ from ota_metadata.file_table import (
     FileTableRegularORM,
     RegularFileEntry,
 )
+from ota_metadata.file_table._orm import FileTableResourceORM
 from ota_metadata.utils import DownloadInfo
 from ota_metadata.utils.cert_store import CAChainStore
 from otaclient_common._typing import StrOrPath
@@ -218,6 +219,8 @@ class OTAMetadata:
             ft_dir_orm.orm_bootstrap_db()
             ft_non_regular_orm = FileTableNonRegularORM(fst_conn)
             ft_non_regular_orm.orm_bootstrap_db()
+            ft_resource_orm = FileTableResourceORM(fst_conn)
+            ft_resource_orm.orm_bootstrap_db()
 
             rs_orm = ResourceTableORM(rst_conn)
             rs_orm.orm_bootstrap_db()
@@ -267,6 +270,7 @@ class OTAMetadata:
             self._total_regulars_num = regulars_num = parse_regulars_from_csv_file(
                 _fpath=regular_save_fpath,
                 _orm=ft_regular_orm,
+                _orm_ft_resource=ft_resource_orm,
                 _orm_rs=rs_orm,
             )
             regular_save_fpath.unlink(missing_ok=True)

--- a/src/ota_metadata/legacy2/metadata.py
+++ b/src/ota_metadata/legacy2/metadata.py
@@ -359,7 +359,6 @@ class OTAMetadata:
                 _fs_conn.backup(conn)
 
             with _dst_conn as conn:
-                conn.execute("VACUUM;")
                 # change the journal_mode back to DELETE to make db file on read-only mount work.
                 # see https://www.sqlite.org/wal.html#read_only_databases for more details.
                 conn.execute("PRAGMA journal_mode=DELETE;")

--- a/src/ota_metadata/legacy2/metadata.py
+++ b/src/ota_metadata/legacy2/metadata.py
@@ -402,6 +402,7 @@ class OTAMetadata:
                     SELECT {FT_REGULAR_TABLE_NAME}.*, {FT_RESOURCE_TABLE_NAME}.digest
                     FROM {FT_REGULAR_TABLE_NAME}
                     INNER JOIN {FT_RESOURCE_TABLE_NAME} USING(resource_id)
+                    ORDER BY digest
             """
             )
 

--- a/src/ota_metadata/legacy2/rs_table.py
+++ b/src/ota_metadata/legacy2/rs_table.py
@@ -22,6 +22,7 @@ from typing import Any, ClassVar, Generator, Literal, Optional
 from pydantic import SkipValidation
 from simple_sqlite3_orm import (
     ConstrainRepr,
+    CreateTableParams,
     ORMBase,
     ORMThreadPoolBase,
     TableSpec,
@@ -73,6 +74,7 @@ class ResourceTable(TableSpec):
 class ResourceTableORM(ORMBase[ResourceTable]):
 
     orm_bootstrap_table_name = RSTABLE_NAME
+    orm_bootstrap_create_table_params = CreateTableParams(without_rowid=True)
 
     def iter_all_with_shuffle(self, *, batch_size: int) -> Generator[ResourceTable]:
         """Iter all entries with seek method by rowid, shuffle each batch before yield.
@@ -80,7 +82,7 @@ class ResourceTableORM(ORMBase[ResourceTable]):
         NOTE: the target table must has rowid defined!
         """
         _this_batch = []
-        for _entry in self.orm_select_all_with_pagination(batch_size=batch_size):
+        for _entry in self.orm_select_entries():
             _this_batch.append(_entry)
             if len(_this_batch) >= batch_size:
                 random.shuffle(_this_batch)

--- a/src/otaclient/create_standby/_delta_gen.py
+++ b/src/otaclient/create_standby/_delta_gen.py
@@ -27,10 +27,10 @@ from pathlib import Path
 from queue import Queue
 
 from ota_metadata.file_table._orm import (
+    FileEntryToScan,
     FileTableDirORMPool,
     FileTableRegularORMPool,
 )
-from ota_metadata.file_table._table import FileTableRegularFiles
 from ota_metadata.legacy2.metadata import OTAMetadata
 from ota_metadata.legacy2.rs_table import ResourceTableORMPool
 from otaclient._status_monitor import StatusReport, UpdateProgressReport
@@ -107,7 +107,7 @@ class DeltaGenerator:
 class DeltaGenWithFileTable(DeltaGenerator):
 
     def _process_file(
-        self, _input: tuple[bytes, list[FileTableRegularFiles]], thread_local
+        self, _input: tuple[bytes, list[FileEntryToScan]], thread_local
     ) -> None:
         expected_digest, entries = _input
         dst_f = self._copy_dst / expected_digest.hex()
@@ -137,7 +137,7 @@ class DeltaGenWithFileTable(DeltaGenerator):
                         StatusReport(
                             payload=UpdateProgressReport(
                                 operation=UpdateProgressReport.Type.PREPARE_LOCAL_COPY,
-                                processed_file_size=entry.entry_attrs.size or 0,
+                                processed_file_size=entry.size or 0,
                                 processed_file_num=1,
                             ),
                             session_id=self.session_id,

--- a/src/otaclient/create_standby/_delta_gen.py
+++ b/src/otaclient/create_standby/_delta_gen.py
@@ -26,7 +26,7 @@ from hashlib import sha256
 from pathlib import Path
 from queue import Queue
 
-from ota_metadata.file_table._orm import (
+from ota_metadata.file_table import (
     FileEntryToScan,
     FileTableDirORMPool,
     FileTableRegularORMPool,

--- a/src/otaclient/create_standby/rebuild_mode.py
+++ b/src/otaclient/create_standby/rebuild_mode.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from queue import Queue
 from typing import Generator
 
-from ota_metadata.file_table._table import (
+from ota_metadata.file_table import (
     FileTableDirectories,
     FileTableNonRegularFiles,
     RegularFileEntry,

--- a/src/otaclient/create_standby/rebuild_mode.py
+++ b/src/otaclient/create_standby/rebuild_mode.py
@@ -52,8 +52,6 @@ burst_suppressed_logger.addFilter(
 PROCESS_FILES_REPORT_BATCH = 256
 PROCESS_FILES_REPORT_INTERVAL = 1  # second
 
-PROCESS_DIRS_BATCH_SIZE = 32
-PROCESS_NON_REGULAR_FILES_BATCH_SIZE = 128
 PROCESS_FILES_CONCURRENCY = 64
 PROCESS_FILES_WORKER = cfg.MAX_PROCESS_FILE_THREAD  # 6
 
@@ -235,34 +233,26 @@ class RebuildMode:
                 )
             )
 
-    def _process_dir_entries(
-        self,
-        *,
-        batch_size: int = PROCESS_DIRS_BATCH_SIZE,
-    ) -> None:
+    def _process_dir_entries(self) -> None:
         logger.info("start to process directory entries ...")
         _func = partial(
             FileTableDirectories.prepare_target,
             target_mnt=self._standby_slot_mp,
         )
-        for entry in self._ota_metadata.iter_dir_entries(batch_size=batch_size):
+        for entry in self._ota_metadata.iter_dir_entries():
             try:
                 _func(entry)
             except Exception as e:
                 burst_suppressed_logger.exception(f"failed to process {entry=}: {e!r}")
                 raise
 
-    def _process_non_regular_files(
-        self,
-        *,
-        batch_size: int = PROCESS_NON_REGULAR_FILES_BATCH_SIZE,
-    ) -> None:
+    def _process_non_regular_files(self) -> None:
         logger.info("start to process non-regular entries ...")
         _func = partial(
             FileTableNonRegularFiles.prepare_target,
             target_mnt=self._standby_slot_mp,
         )
-        for entry in self._ota_metadata.iter_non_regular_entries(batch_size=batch_size):
+        for entry in self._ota_metadata.iter_non_regular_entries():
             try:
                 _func(entry)
             except Exception as e:

--- a/src/otaclient/create_standby/rebuild_mode.py
+++ b/src/otaclient/create_standby/rebuild_mode.py
@@ -25,7 +25,7 @@ from typing import Generator
 from ota_metadata.file_table._table import (
     FileTableDirectories,
     FileTableNonRegularFiles,
-    FileTableRegularFiles,
+    RegularFileEntry,
 )
 from ota_metadata.legacy2.metadata import OTAMetadata
 from otaclient._status_monitor import StatusReport, UpdateProgressReport
@@ -79,12 +79,12 @@ class RebuildMode:
 
     def _preprocess_regular_file_entries(
         self,
-    ) -> Generator[tuple[bytes, list[FileTableRegularFiles]]]:
+    ) -> Generator[tuple[bytes, list[RegularFileEntry]]]:
         """Yield a group of regular file entries which have the same digest each time.
 
         NOTE: it depends on the regular file table is sorted by digest!
         """
-        cur_digest_group: list[FileTableRegularFiles] = []
+        cur_digest_group: list[RegularFileEntry] = []
         cur_digest: bytes = b""
         for _entry in self._ota_metadata.iter_regular_entries():
             _this_digest = _entry.digest
@@ -105,7 +105,7 @@ class RebuildMode:
         yield cur_digest, cur_digest_group
 
     def _process_one_regular_files_group(  # NOSONAR
-        self, _input: tuple[bytes, list[FileTableRegularFiles]]
+        self, _input: tuple[bytes, list[RegularFileEntry]]
     ) -> tuple[int, int]:
         """Process a group of regular_files with the same digest.
 
@@ -125,8 +125,8 @@ class RebuildMode:
 
             _rs = self._resource_dir / digest.hex()
 
-            _hardlinked: dict[int, list[FileTableRegularFiles]] = {}
-            _normal: list[FileTableRegularFiles] = []
+            _hardlinked: dict[int, list[RegularFileEntry]] = {}
+            _normal: list[RegularFileEntry] = []
 
             for entry in entries:
                 if (_inode_group := entry.entry_attrs.inode) is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ from ota_metadata.file_table._orm import (
     FileTableDirORM,
     FileTableNonRegularORM,
     FileTableRegularORM,
+    FileTableResourceORM,
 )
 from ota_metadata.legacy2 import csv_parser
 from ota_metadata.legacy2.metadata import OTAMetadata
@@ -172,6 +173,8 @@ def ota_image_ft_db() -> Path:
         ft_dir_orm.orm_bootstrap_db()
         ft_non_regular_orm = FileTableNonRegularORM(fst_conn)
         ft_non_regular_orm.orm_bootstrap_db()
+        ft_resource_orm = FileTableResourceORM(fst_conn)
+        ft_resource_orm.orm_bootstrap_db()
 
         rs_orm = ResourceTableORM(rst_conn)
         rs_orm.orm_bootstrap_db()
@@ -179,6 +182,7 @@ def ota_image_ft_db() -> Path:
         csv_parser.parse_regulars_from_csv_file(
             _fpath=ota_image_dir / "regulars.txt",
             _orm=ft_regular_orm,
+            _orm_ft_resource=ft_resource_orm,
             _orm_rs=rs_orm,
         )
         csv_parser.parse_dirs_from_csv_file(ota_image_dir / "dirs.txt", ft_dir_orm)

--- a/tests/test_ota_metadata/test_file_table/test__table.py
+++ b/tests/test_ota_metadata/test_file_table/test__table.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import os
-from hashlib import sha256
 from pathlib import Path
 
 import pytest
@@ -109,7 +108,7 @@ TEST_FILE_SIZE = 64  # bytes
             file_contents := os.urandom(TEST_FILE_SIZE),
             FileTableRegularFiles(
                 path="/a/b/c/d/e.bin",
-                digest=sha256(file_contents).digest(),
+                resource_id=1,
                 entry_attrs=FileEntryAttrs(
                     mode=0o100644,
                     uid=1000,
@@ -124,7 +123,7 @@ TEST_FILE_SIZE = 64  # bytes
             file_contents := os.urandom(TEST_FILE_SIZE),
             FileTableRegularFiles(
                 path="/a/b/c/d/e.bin",
-                digest=sha256(file_contents).digest(),
+                resource_id=1,
                 entry_attrs=FileEntryAttrs(
                     mode=0o100644,
                     uid=1000,
@@ -144,7 +143,7 @@ TEST_FILE_SIZE = 64  # bytes
             file_contents := os.urandom(TEST_FILE_SIZE),
             FileTableRegularFiles(
                 path="/a/b/c/d/e.bin",
-                digest=sha256(file_contents).digest(),
+                resource_id=1,
                 entry_attrs=FileEntryAttrs(
                     mode=0o100644,
                     uid=1000,
@@ -163,7 +162,7 @@ TEST_FILE_SIZE = 64  # bytes
             file_contents := os.urandom(TEST_FILE_SIZE),
             FileTableRegularFiles(
                 path="/α/β/γ/ζ.bin",
-                digest=sha256(file_contents).digest(),
+                resource_id=1,
                 entry_attrs=FileEntryAttrs(
                     mode=0o100644,
                     uid=1000,


### PR DESCRIPTION
## Introduction

Inspired by new OTA image, this PR introduces to add `ft_resource` table into the file_table database, and use `resource_id` instead of actual digest in `ft_regular` table to make the file_table database more efficient.

## Tests

- [x] local pytest passed.
- [x] OTA e2e with VM passed.

https://tier4.atlassian.net/browse/RT4-14861