### PR TITLE
fix(v3.8.x): rpi_boot.update_firmware: ensure `/tmp` folder exists when doing flash-kernel

### DIFF
--- a/src/otaclient/boot_control/_rpi_boot.py
+++ b/src/otaclient/boot_control/_rpi_boot.py
@@ -298,6 +298,9 @@ class _RPIBootControl:
         sys_mp = target_slot_mp / "sys"
         mounts[str(sys_mp)] = "/sys"
 
+        # NOTE(20250314): ensure that tmp folder exists on standby slot
+        (target_slot_mp / "tmp").mkdir(exist_ok=True)
+
         try:
             for _mp, _src in mounts.items():
                 CMDHelperFuncs.mount(

--- a/src/otaclient/boot_control/_rpi_boot.py
+++ b/src/otaclient/boot_control/_rpi_boot.py
@@ -335,6 +335,7 @@ class _RPIBootControl:
                     env={"FK_FORCE": "yes"},
                 )
                 os.sync()
+                logger.info("flash-kernel succeeded!")
         except subprocess.CalledProcessError as e:
             _err_msg = f"flash-kernel failed: {e!r}\nstderr: {e.stderr.decode()}\nstdout: {e.stdout.decode()}"
             logger.error(_err_msg)

--- a/src/otaclient/boot_control/_rpi_boot.py
+++ b/src/otaclient/boot_control/_rpi_boot.py
@@ -300,7 +300,11 @@ class _RPIBootControl:
         mounts[str(sys_mp)] = "/sys"
 
         # NOTE(20250314): ensure that tmp folder exists on standby slot
-        (target_slot_mp / "tmp").mkdir(exist_ok=True)
+        _tmp_on_standby = target_slot_mp / "tmp"
+        # also handle the case when /tmp is a symlink
+        if _tmp_on_standby.is_symlink():
+            _tmp_on_standby = _tmp_on_standby.resolve()
+        _tmp_on_standby.mkdir(exist_ok=True, parents=True)
 
         try:
             for _mp, _src in mounts.items():

--- a/src/otaclient/boot_control/_rpi_boot.py
+++ b/src/otaclient/boot_control/_rpi_boot.py
@@ -417,7 +417,9 @@ class _RPIBootControl:
 
     def reboot_tryboot(self, *, reboot_wait: int = 6):
         """Reboot with tryboot flag."""
-        logger.info(f"tryboot reboot to standby slot({self.standby_slot}) in {reboot_wait=}s ...")
+        logger.info(
+            f"tryboot reboot to standby slot({self.standby_slot}) in {reboot_wait=}s ..."
+        )
         time.sleep(reboot_wait)
         try:
             # NOTE: "0 tryboot" is a single param.

--- a/src/otaclient/boot_control/_rpi_boot.py
+++ b/src/otaclient/boot_control/_rpi_boot.py
@@ -20,6 +20,7 @@ import contextlib
 import logging
 import os
 import subprocess
+import time
 from pathlib import Path
 from string import Template
 from typing import Any, Generator, Literal
@@ -414,11 +415,13 @@ class _RPIBootControl:
             logger.error(_err_msg)
             raise _RPIBootControllerError(_err_msg) from e
 
-    def reboot_tryboot(self):
+    def reboot_tryboot(self, *, reboot_wait: int = 6):
         """Reboot with tryboot flag."""
-        logger.info(f"tryboot reboot to standby slot({self.standby_slot})...")
+        logger.info(f"tryboot reboot to standby slot({self.standby_slot}) in {reboot_wait=}s ...")
+        time.sleep(reboot_wait)
         try:
             # NOTE: "0 tryboot" is a single param.
+            logger.info("system will reboot now!")
             CMDHelperFuncs.reboot(args=["0 tryboot"])
         except Exception as e:
             _err_msg = "failed to reboot"


### PR DESCRIPTION
## Introduction

Starting from otaclient v3.8.x, a new mechanism is used to replace the previous two-stage reboot mechanism for executing `flash-kernel`. This new mechanism will chroot into the standby slot, and call `flash-kernel` on standby slot directly to deploy new dtbs, kernel and initrd img.

However, current OTA image is configured to ignore with pattern `/tmp`, which means even the top-level `/tmp` folder will be ignored. When OTA just updates the standby slot, there will be no `/tmp` folder existed on it, causing `flash-kernel` failed due to `flash-kernel` needs `/tmp` folder during execution.

This PR fixes this problem by ensuring `/tmp` folder on standby slot.

Other changes:
1. now rpi_boot will wait for 6 seconds, and issue a logging before rebooting.

## Tests

- [x] test passes on directly executing the rpi_boot control flow.