### PR TITLE
fix(otaclient v3.8.x): Add timeout when downloading "metadata.jwt" and *.pem files 

### DIFF
--- a/src/ota_metadata/legacy/parser.py
+++ b/src/ota_metadata/legacy/parser.py
@@ -76,6 +76,7 @@ from requests import Response
 from typing_extensions import Self
 
 from ota_proxy import OTAFileCacheControl
+from otaclient.app.configs import config as cfg
 from otaclient_common.common import urljoin_ensure_base
 from otaclient_common.downloader import Downloader
 from otaclient_common.proto_streamer import (
@@ -90,7 +91,6 @@ from otaclient_common.retry_task_map import (
 
 from . import SUPORTED_COMPRESSION_TYPES
 from .types import DirectoryInf, PersistentInf, RegularInf, SymbolicLinkInf
-from otaclient.app.configs import config as cfg
 
 logger = logging.getLogger(__name__)
 
@@ -659,7 +659,7 @@ class OTAMetadata:
         # download and parse metadata.jwt
         with NamedTemporaryFile(prefix="metadata_jwt", dir=self.run_dir) as meta_f:
             _downloaded_meta_f = Path(meta_f.name)
-            
+
             _retry_counter = 0
             while _retry_counter < cfg.DOWNLOAD_GROUP_INACTIVE_TIMEOUT:
                 try:

--- a/src/ota_metadata/legacy/parser.py
+++ b/src/ota_metadata/legacy/parser.py
@@ -661,7 +661,9 @@ class OTAMetadata:
             _downloaded_meta_f = Path(meta_f.name)
 
             _retry_duration = 0
-            while (not _shutdown) and (_retry_duration < cfg.DOWNLOAD_GROUP_INACTIVE_TIMEOUT):
+            while (not _shutdown) and (
+                _retry_duration < cfg.DOWNLOAD_GROUP_INACTIVE_TIMEOUT
+            ):
                 try:
                     self._downloader.download(
                         urljoin_ensure_base(self.url_base, self.METADATA_JWT),
@@ -706,7 +708,9 @@ class OTAMetadata:
             cert_file = Path(cert_f.name)
 
             _retry_duration = 0
-            while (not _shutdown) and (_retry_duration < cfg.DOWNLOAD_GROUP_INACTIVE_TIMEOUT):
+            while (not _shutdown) and (
+                _retry_duration < cfg.DOWNLOAD_GROUP_INACTIVE_TIMEOUT
+            ):
                 try:
                     self._downloader.download(
                         urljoin_ensure_base(self.url_base, cert_fname),

--- a/src/ota_metadata/legacy/parser.py
+++ b/src/ota_metadata/legacy/parser.py
@@ -660,8 +660,8 @@ class OTAMetadata:
         with NamedTemporaryFile(prefix="metadata_jwt", dir=self.run_dir) as meta_f:
             _downloaded_meta_f = Path(meta_f.name)
 
-            _retry_counter = 0
-            while _retry_counter < cfg.DOWNLOAD_GROUP_INACTIVE_TIMEOUT:
+            _retry_duration = 0
+            while (not _shutdown) and (_retry_duration < cfg.DOWNLOAD_GROUP_INACTIVE_TIMEOUT):
                 try:
                     self._downloader.download(
                         urljoin_ensure_base(self.url_base, self.METADATA_JWT),
@@ -690,7 +690,7 @@ class OTAMetadata:
                     logger.warning(
                         f"failed to download {_downloaded_meta_f}, retrying: {e!r}"
                     )
-                    _retry_counter += 1
+                    _retry_duration += self.retry_interval
                     time.sleep(self.retry_interval)
 
             _parser = _MetadataJWTParser(
@@ -705,8 +705,8 @@ class OTAMetadata:
             cert_fname, cert_hash = cert_info.file, cert_info.hash
             cert_file = Path(cert_f.name)
 
-            _retry_counter = 0
-            while _retry_counter < cfg.DOWNLOAD_GROUP_INACTIVE_TIMEOUT:
+            _retry_duration = 0
+            while (not _shutdown) and (_retry_duration < cfg.DOWNLOAD_GROUP_INACTIVE_TIMEOUT):
                 try:
                     self._downloader.download(
                         urljoin_ensure_base(self.url_base, cert_fname),
@@ -721,7 +721,7 @@ class OTAMetadata:
                     break
                 except Exception as e:
                     logger.warning(f"failed to download {cert_info}, retrying: {e!r}")
-                    _retry_counter += 1
+                    _retry_duration += self.retry_interval
                     time.sleep(self.retry_interval)
             _parser.verify_metadata(cert_file.read_bytes())
 


### PR DESCRIPTION
Related JIRA: [RT4-15059](https://tier4.atlassian.net/browse/RT4-15059)

### About the fix
At the beginning of OTA process, we will download "medata.jwt" file and then "certificate" pem file. 
There are cases that these files can not be downloaded correctly. 

For example:
  1, ECU network config is not correct. 
  2, The certificate file is not correct
  etc...
  
When it happens, current behavior is that "otaclient" keep retry endlessly. 
For the end user, he will not be aware of the error and will likely keep waiting for a long time. 

This fix will timeout the retrying process after 5 mins. 
End user will be informed OTA is not successful after that.


[RT4-15059]: https://tier4.atlassian.net/browse/RT4-15059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ