### PR TITLE
fix(otaclient main branch): Add timeout when downloading "metadata.jwt" and *.pem files

### DIFF
--- a/src/ota_metadata/legacy/_parser.py
+++ b/src/ota_metadata/legacy/_parser.py
@@ -638,8 +638,10 @@ class OTAMetadata:
         with NamedTemporaryFile(prefix="metadata_jwt", dir=self.run_dir) as meta_f:
             _downloaded_meta_f = Path(meta_f.name)
 
-            _retry_counter = 0
-            while _retry_counter <= cfg.DOWNLOAD_INACTIVE_TIMEOUT:
+            _retry_duration = 0
+            while (not _shutdown) and (
+                _retry_duration < cfg.DOWNLOAD_INACTIVE_TIMEOUT
+            ):
                 try:
                     self._downloader.download(
                         urljoin_ensure_base(self.url_base, self.METADATA_JWT),
@@ -656,7 +658,7 @@ class OTAMetadata:
                     logger.warning(
                         f"failed to download {_downloaded_meta_f}, retrying: {e!r}"
                     )
-                    _retry_counter += 1
+                    _retry_duration += self.retry_interval
                     time.sleep(self.retry_interval)
 
             _parser = _MetadataJWTParser(
@@ -672,8 +674,10 @@ class OTAMetadata:
             cert_fname, cert_hash = cert_info.file, cert_info.hash
             cert_file = Path(cert_f.name)
 
-            _retry_counter = 0
-            while _retry_counter <= cfg.DOWNLOAD_INACTIVE_TIMEOUT:
+            _retry_duration = 0
+            while (not _shutdown) and (
+                _retry_duration < cfg.DOWNLOAD_INACTIVE_TIMEOUT
+            ):
                 try:
                     self._downloader.download(
                         urljoin_ensure_base(self.url_base, cert_fname),
@@ -700,7 +704,7 @@ class OTAMetadata:
                             raise OTARequestsAuthTokenInvalid from e
 
                     logger.warning(f"failed to download {cert_info}, retrying: {e!r}")
-                    _retry_counter += 1
+                    _retry_duration += self.retry_interval
                     time.sleep(self.retry_interval)
 
             cert_bytes = cert_file.read_bytes()

--- a/src/ota_metadata/legacy/_parser.py
+++ b/src/ota_metadata/legacy/_parser.py
@@ -639,7 +639,7 @@ class OTAMetadata:
             _downloaded_meta_f = Path(meta_f.name)
 
             _retry_counter = 0
-            while not cfg.DOWNLOAD_INACTIVE_TIMEOUT:
+            while _retry_counter <= cfg.DOWNLOAD_INACTIVE_TIMEOUT:
                 try:
                     self._downloader.download(
                         urljoin_ensure_base(self.url_base, self.METADATA_JWT),
@@ -673,7 +673,7 @@ class OTAMetadata:
             cert_file = Path(cert_f.name)
 
             _retry_counter = 0
-            while not cfg.DOWNLOAD_INACTIVE_TIMEOUT:
+            while _retry_counter <= cfg.DOWNLOAD_INACTIVE_TIMEOUT:
                 try:
                     self._downloader.download(
                         urljoin_ensure_base(self.url_base, cert_fname),

--- a/src/ota_metadata/legacy/_parser.py
+++ b/src/ota_metadata/legacy/_parser.py
@@ -639,9 +639,7 @@ class OTAMetadata:
             _downloaded_meta_f = Path(meta_f.name)
 
             _retry_duration = 0
-            while (not _shutdown) and (
-                _retry_duration < cfg.DOWNLOAD_INACTIVE_TIMEOUT
-            ):
+            while (not _shutdown) and (_retry_duration < cfg.DOWNLOAD_INACTIVE_TIMEOUT):
                 try:
                     self._downloader.download(
                         urljoin_ensure_base(self.url_base, self.METADATA_JWT),
@@ -675,9 +673,7 @@ class OTAMetadata:
             cert_file = Path(cert_f.name)
 
             _retry_duration = 0
-            while (not _shutdown) and (
-                _retry_duration < cfg.DOWNLOAD_INACTIVE_TIMEOUT
-            ):
+            while (not _shutdown) and (_retry_duration < cfg.DOWNLOAD_INACTIVE_TIMEOUT):
                 try:
                     self._downloader.download(
                         urljoin_ensure_base(self.url_base, cert_fname),

--- a/src/ota_metadata/legacy2/metadata.py
+++ b/src/ota_metadata/legacy2/metadata.py
@@ -55,6 +55,7 @@ from ota_metadata.file_table._orm import (
     FileTableRegularORM,
 )
 from ota_metadata.utils.cert_store import CAChainStore
+from otaclient.configs.cfg import cfg
 from otaclient_common._typing import StrOrPath
 from otaclient_common.common import urljoin_ensure_base
 from otaclient_common.download_info import DownloadInfo
@@ -163,7 +164,7 @@ class OTAMetadata:
                     dst=_metadata_jwt_fpath,
                 )
             ]
-            condition.wait()  # wait for download finished
+            condition.wait(cfg.DOWNLOAD_INACTIVE_TIMEOUT)  # wait for download finished
 
         _parser = MetadataJWTParser(
             _metadata_jwt_fpath.read_text(),
@@ -188,7 +189,7 @@ class OTAMetadata:
                     digest=cert_hash,
                 )
             ]
-            condition.wait()
+            condition.wait(cfg.DOWNLOAD_INACTIVE_TIMEOUT)
 
         cert_bytes = _cert_fpath.read_bytes()
         _parser.verify_metadata_cert(cert_bytes)
@@ -263,7 +264,7 @@ class OTAMetadata:
             ]
             with condition:
                 yield _download_list
-                condition.wait()  # wait for download finished
+                condition.wait(cfg.DOWNLOAD_INACTIVE_TIMEOUT)  # wait for download finished
 
             # ------ parse metafiles ------ #
             self._total_regulars_num = regulars_num = parse_regulars_from_csv_file(
@@ -303,7 +304,7 @@ class OTAMetadata:
                     digest=persist_meta.hash,
                 )
             ]
-            condition.wait()
+            condition.wait(cfg.DOWNLOAD_INACTIVE_TIMEOUT)
 
         # save the persists.txt to session_dir for later use
         shutil.move(str(persist_meta_save_fpath), self._session_dir)

--- a/src/ota_metadata/legacy2/metadata.py
+++ b/src/ota_metadata/legacy2/metadata.py
@@ -264,7 +264,9 @@ class OTAMetadata:
             ]
             with condition:
                 yield _download_list
-                condition.wait(cfg.DOWNLOAD_INACTIVE_TIMEOUT)  # wait for download finished
+                condition.wait(
+                    cfg.DOWNLOAD_INACTIVE_TIMEOUT
+                )  # wait for download finished
 
             # ------ parse metafiles ------ #
             self._total_regulars_num = regulars_num = parse_regulars_from_csv_file(

--- a/src/otaclient_common/downloader.py
+++ b/src/otaclient_common/downloader.py
@@ -343,7 +343,6 @@ class Downloader:
         """
         self._session.close()
 
-
     def download(
         self,
         url: str,

--- a/src/otaclient_common/downloader.py
+++ b/src/otaclient_common/downloader.py
@@ -343,7 +343,7 @@ class Downloader:
         """
         self._session.close()
 
-    @retry_on_digest_mismatch
+
     def download(
         self,
         url: str,


### PR DESCRIPTION
Related JIRA: [RT4-15059](https://tier4.atlassian.net/browse/RT4-15059)

### About the fix
At the beginning of OTA process, we will download "medata.jwt" file and then "certificate" pem file. 
There are cases that these files can not be downloaded correctly. 

For example:
  1, ECU network config is not correct. 
  2, The certificate file is not correct
  etc...
  
When it happens, current behavior is that "otaclient" keep retry endlessly. 
For the end user, he will not be aware of the error and will likely keep waiting for a long time. 

This fix will timeout the retrying process after 5 mins. 
End user will be informed OTA is not successful after that.


[RT4-15059]: https://tier4.atlassian.net/browse/RT4-15059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
