### PR TITLE
fix: otaproxy_ctx: fix otaproxy life-cycle management thread exits at OTA failed

### DIFF
--- a/src/otaclient/_otaproxy_ctx.py
+++ b/src/otaclient/_otaproxy_ctx.py
@@ -42,6 +42,7 @@ _otaproxy_p: mp_ctx.SpawnProcess | None = None
 _global_shutdown: bool = False
 _global_shutdown_lock = threading.Lock()
 
+
 def _on_global_shutdown() -> None:
     global _global_shutdown
     _global_shutdown = True


### PR DESCRIPTION
## Introduction

By design, otaproxy life-cycle management thread should keep running at the background, start otaproxy when there is at least one ECU requires network, and shutdown otaproxy when there is no ECU requires network. 
When OTA failed and another OTA retry triggered, otaproxy ctx should start otaproxy again. However, due to otaproxy ctx thread calls **global_shutdown** when we need to close otaproxy, otaproxy ctx unexpectedly shutdown itself, and can no-longer start otaproxy anymore.

This PR fixes the above issue, only do otaproxy shutdown instead of global_shutdown when we don't need otaproxy for now, ensure that otaproxy ctx still keeps running at the background, and start/stop otaproxy in next time's OTA retry.

## Tests

- [x] test on VM: ensure that otaproxy ctx thread will keep running when OTA failed and start otaproxy at next OTA.