### PR TITLE
feat: retry_task_map: supports exits on exceeding max_retry_on_entry  

### DIFF
--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -173,7 +173,7 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
         except Exception:  # if re-schedule doesn't happen, release se
             self._concurrent_semaphore.release()
 
-    def _fut_gen(self, interval: int) -> Generator[Future[Any]]:
+    def _fut_gen(self, interval: float) -> Generator[Future[Any]]:
         """Generator which yields the done future, controlled by the caller.
 
         Caller of ensure_tasks will directly cooperate with this generator.
@@ -227,7 +227,7 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
         func: Callable[[T], RT],
         iterable: Iterable[T],
         *,
-        ensure_tasks_pull_interval: int = 1,
+        ensure_tasks_pull_interval: float = 1,
     ) -> Generator[Future[RT]]:
         with self._lock:
             if self._started or self._rtm_lower_pool_shutdown:
@@ -324,7 +324,7 @@ if TYPE_CHECKING:
             func: Callable[[T], RT],
             iterable: Iterable[T],
             *,
-            ensure_tasks_pull_interval: int = 1,
+            ensure_tasks_pull_interval: float = 1,
         ) -> Generator[Future[RT]]:
             """Ensure all the items in <iterable> are processed by <func> in the pool.
 

--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -51,7 +51,7 @@ class _RetryOnEntryTracker:
     def register(self, entry: Any) -> int:
         with self._lock:
             _entry_id = id(entry)
-            self._register[_entry_id] =  _retries = self._register.get(_entry_id, 0) + 1
+            self._register[_entry_id] = _retries = self._register.get(_entry_id, 0) + 1
             self._register.move_to_end(_entry_id)
             if len(self._register) > self._max_entries:
                 self._register.popitem(last=False)

--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -65,7 +65,7 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
         max_concurrent: int,
         max_workers: Optional[int] = None,
         max_total_retry: Optional[int] = None,
-        max_continues_retry_on_entry: Optional[int] = None,
+        max_retry_on_entry: Optional[int] = None,
         thread_name_prefix: str = "",
         watchdog_funcs: Optional[list[Callable]] = None,
         watchdog_check_interval: int = 3,  # seconds
@@ -88,7 +88,7 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
         self.backoff_max = backoff_max
 
         self._entry_retry_tracker = _RetryOnEntryTracker(max_concurrent)
-        self._max_continues_retry_on_entry = max_continues_retry_on_entry
+        self._max_retry_on_entry = max_retry_on_entry
 
         self._total_retry_counter = itertools.count(start=1)
         self._concurrent_semaphore = threading.Semaphore(max_concurrent)
@@ -155,7 +155,7 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
         # check continues retry on the same entry
         _retry_on_entry = self._entry_retry_tracker.register(item)
         if (
-            _max_entry_retry := self._max_continues_retry_on_entry
+            _max_entry_retry := self._max_retry_on_entry
         ) is not None and _retry_on_entry > _max_entry_retry:
             _err_msg = (
                 f"{_retry_on_entry=} on {item=} exceed {_max_entry_retry=}, abort"
@@ -291,7 +291,7 @@ if TYPE_CHECKING:
             max_concurrent: int,
             max_workers: Optional[int] = None,
             max_total_retry: Optional[int] = None,
-            max_continues_retry_on_entry: Optional[int] = None,
+            max_retry_on_entry: Optional[int] = None,
             thread_name_prefix: str = "",
             watchdog_func: Optional[Callable] = None,
             watchdog_check_interval: int = 3,  # seconds
@@ -306,7 +306,7 @@ if TYPE_CHECKING:
                 max_concurrent (int): Limit the number pending scheduled tasks.
                 max_workers (Optional[int], optional): Max number of worker threads in the pool. Defaults to None.
                 max_total_retry (Optional[int], optional): Max total retry counts before abort. Defaults to None.
-                max_continues_retry_on_entry (Optional[int]): Max total retry on the same entry. Defaults to None.
+                max_retry_on_entry (Optional[int]): Max total retry on the same entry. Defaults to None.
                 thread_name_prefix (str, optional): Defaults to "".
                 watchdog_func (Optional[Callable]): A custom func to be called on watchdog thread, when
                     this func raises exception, the watchdog will interrupt the tasks execution. Defaults to None.

--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -51,7 +51,7 @@ class _RetryOnEntryTracker:
     def register(self, entry: Any) -> int:
         with self._lock:
             _entry_id = id(entry)
-            _retries = self._register.setdefault(_entry_id, 1)
+            self._register[_entry_id] =  _retries = self._register.get(_entry_id, 0) + 1
             self._register.move_to_end(_entry_id)
             if len(self._register) > self._max_entries:
                 self._register.popitem(last=False)

--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -75,6 +75,7 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
         backoff_max: float = 1,
     ) -> None:
         self._rtm_start_lock = threading.Lock()
+        # NOTE: ThreadPoolExecutor itself also has a _shutdown_lock!
         self._rtm_shutdown_lock = threading.Lock()
         self._rtm_started = False
         self._total_task_num = 0

--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -67,7 +67,7 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
         max_total_retry: Optional[int] = None,
         max_retry_on_entry: Optional[int] = None,
         thread_name_prefix: str = "",
-        watchdog_funcs: Optional[list[Callable]] = None,
+        watchdog_func: Optional[Callable] = None,
         watchdog_check_interval: int = 3,  # seconds
         initializer: Callable[..., Any] | None = None,
         initargs: tuple = (),
@@ -98,10 +98,8 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
         self._checker_funcs: list[Callable[[], Any]] = []
         self._max_total_retry = max_total_retry
 
-        if watchdog_funcs:
-            for _func in watchdog_funcs:
-                if callable(_func):
-                    self._checker_funcs.append(_func)
+        if callable(watchdog_func):
+            self._checker_funcs.append(watchdog_func)
 
         self._failure_msg = ""
         super().__init__(

--- a/tests/test_otaclient_common/test_retry_task_map.py
+++ b/tests/test_otaclient_common/test_retry_task_map.py
@@ -38,7 +38,7 @@ BACKOFF_MAX = 0.1
 
 
 class _RetryTaskMapTestErr(Exception):
-    def __init__(self,  idx: int, *args: object) -> None:
+    def __init__(self, idx: int, *args: object) -> None:
         self.idx = idx
         super().__init__(*args)
 
@@ -124,7 +124,7 @@ class TestRetryTaskMap:
 
     def test_retry_exceed_entry_retry_limit(self):
         MAX_RETRY_ON_ENTRY = 30
-        entry_failure_count: defaultdict[int, int] = defaultdict(lambda : 0)
+        entry_failure_count: defaultdict[int, int] = defaultdict(lambda: 0)
         with retry_task_map.ThreadPoolExecutorWithRetry(
             max_concurrent=16,
             max_retry_on_entry=MAX_RETRY_ON_ENTRY,
@@ -144,7 +144,10 @@ class TestRetryTaskMap:
                         assert isinstance(_exc, _RetryTaskMapTestErr)
                         entry_failure_count[_exc.idx] += 1
 
-        assert any(_failure_count > MAX_RETRY_ON_ENTRY for _failure_count in entry_failure_count.values())
+        assert any(
+            _failure_count > MAX_RETRY_ON_ENTRY
+            for _failure_count in entry_failure_count.values()
+        )
 
     def test_retry_finally_succeeded(self):
         count = 0

--- a/tests/test_otaclient_common/test_retry_task_map.py
+++ b/tests/test_otaclient_common/test_retry_task_map.py
@@ -115,7 +115,8 @@ class TestRetryTaskMap:
                 for _fut in executor.ensure_tasks(
                     self.workload_aways_failed,
                     range(TASKS_COUNT),
-                    ensure_tasks_pull_interval=0.001,
+                    # need to be faster enough, otherwise fut will come later than pool shutdown
+                    ensure_tasks_pull_interval=0.0001,
                 ):
                     if _fut.exception():
                         failure_count += 1

--- a/tests/test_otaclient_common/test_retry_task_map.py
+++ b/tests/test_otaclient_common/test_retry_task_map.py
@@ -120,9 +120,9 @@ class TestRetryTaskMap:
         assert failure_count >= MAX_TOTAL_RETRY
 
     def test_retry_exceed_entry_retry_limit(self):
-        MAX_RETRY_ON_ENTRY = 200
+        MAX_RETRY_ON_ENTRY = 30
         with retry_task_map.ThreadPoolExecutorWithRetry(
-            max_concurrent=MAX_CONCURRENT,
+            max_concurrent=16,
             max_retry_on_entry=MAX_RETRY_ON_ENTRY,
             initializer=_thread_initializer,
             initargs=(THREAD_INIT_MSG,),

--- a/tests/test_otaclient_common/test_retry_task_map.py
+++ b/tests/test_otaclient_common/test_retry_task_map.py
@@ -139,7 +139,7 @@ class TestRetryTaskMap:
                     self.workload_aways_failed,
                     range(TASKS_COUNT),
                     # need to be faster enough, otherwise fut will come later than pool shutdown
-                    ensure_tasks_pull_interval=0.0001,
+                    ensure_tasks_pull_interval=0.00001,
                 ):
                     if _exc := _fut.exception():
                         assert isinstance(_exc, _RetryTaskMapTestErr)


### PR DESCRIPTION
## Introduction

>[!NOTE]
> This is the preceding PR for supporting OTA interruption on specific OTA metafiles cannot be downloaded due to digest mismatch caused by OTA image broken/being tempered.

This PR introduces the support of exiting on specific entry's retry count exceeding `max_retry_on_entry` for `ThreadPoolExecutorWithRetry`. Also the internal implementation of `ThreadPoolExecutorWithRetry` is refined.

## Tests

- [x] tests covered the changes implemented.
- [x] local pytest passed.