### PR TITLE
fix: ota_core: Add timeout for when downloading metadata file

### DIFF
--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -341,6 +341,7 @@ class _OTAUpdateOperator:
         _mapper = ThreadPoolExecutorWithRetry(
             max_concurrent=cfg.MAX_CONCURRENT_DOWNLOAD_TASKS,
             max_workers=cfg.DOWNLOAD_THREADS,
+            max_retry_on_entry=cfg.DOWNLOAD_INACTIVE_TIMEOUT,
             thread_name_prefix=thread_name_prefix,
             initializer=self._downloader_workder_initializer,
             watchdog_func=partial(


### PR DESCRIPTION
### Related JIRA:
https://tier4.atlassian.net/browse/RT4-15059

### What is the fix:
When downloading OTA metadata files. (metadata.jwt, certificate.pem, regulars.txt, dirs.txt, symlinks.txt, persistents.txt), we might encounters some errors.
Current behavior of main branch is as following:
1, When "Connection Error", download will timeout in 5 minutes. (Good Behavior)
2, When “Hash Verification Error“, download will retry forever (NOT Good behavior)

This fix will fix 2, and make it timeout in 5 minutes.

