### PR TITLE
refactor: encapsulate data of ecu status

### DIFF
--- a/tests/test_otaclient/test_grpc/test_api_v2/test_ecu_status.py
+++ b/tests/test_otaclient/test_grpc/test_api_v2/test_ecu_status.py
@@ -501,7 +501,9 @@ class TestECUStatusStorage:
 
         # --- assertion --- #
         for k, v in properties_dict.items():
-            assert getattr(self.ecu_storage, k) == v, f"status_report attr {k} mismatch"
+            assert (
+                getattr(self.ecu_storage._state, k) == v
+            ), f"status_report attr {k} mismatch"
 
         for k, v in flags_status.items():
             assert getattr(self.ecu_status_flags, k).is_set() == v
@@ -647,7 +649,9 @@ class TestECUStatusStorage:
 
         # --- assertion --- #
         for k, v in properties_dict.items():
-            assert getattr(self.ecu_storage, k) == v, f"status_report attr {k} mismatch"
+            assert (
+                getattr(self.ecu_storage._state, k) == v
+            ), f"status_report attr {k} mismatch"
 
         for k, v in flags_status.items():
             assert getattr(self.ecu_status_flags, k).is_set() == v


### PR DESCRIPTION
### Why
For ota client update, need to pass ECU status from the previous process to next process. So better to encapsulate data for process communication.

### What
Create new  ` _ECUStatusState` class and encapsulate necessary data.

### Tests
Confirmed to pass unit tests.