### PR TITLE
fix: ota-client : Update grpcio version 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "anyio>=4.5.1,<5",
   "aiohttp>=3.10.11,<3.12",
   "cryptography==44.0.2",
-  "grpcio==1.71.0",
+  "grpcio==1.70.0",
   "multidict<7.0,>=4.5",
   "msgpack>=1,<1.2",
   "protobuf>=4.21.12,<5.29",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "anyio>=4.5.1,<5",
   "aiohttp>=3.10.11,<3.12",
   "cryptography==44.0.2",
-  "grpcio>=1.53.2,<1.69",
+  "grpcio==1.71.0",
   "multidict<7.0,>=4.5",
   "msgpack>=1,<1.2",
   "protobuf>=4.21.12,<5.29",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 anyio>=4.5.1,<5
 aiohttp>=3.10.11,<3.12
 cryptography==44.0.2
-grpcio>=1.53.2,<1.69
+grpcio==1.71.0
 multidict<7.0,>=4.5
 msgpack>=1,<1.2
 protobuf>=4.21.12,<5.29

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 anyio>=4.5.1,<5
 aiohttp>=3.10.11,<3.12
 cryptography==44.0.2
-grpcio==1.71.0
+grpcio==1.70.0
 multidict<7.0,>=4.5
 msgpack>=1,<1.2
 protobuf>=4.21.12,<5.29


### PR DESCRIPTION
### Related JIRA
https://tier4.atlassian.net/browse/RT4-15432

### About This Fix
As being adviced here
https://security.snyk.io/vuln/SNYK-PYTHON-GRPCIO-9486468
![image](https://github.com/user-attachments/assets/9fb09ca9-e6b3-42cd-9409-8b7351528beb)


Change grpcio to version listed here
https://pypi.org/project/grpcio/#history

### Note : 
lastest version is : 1.71.0
But it is not supported for ubuntu 18.04 and 20.04. 
So we use 1.70.0

