### PR TITLE
fix(v3.8.x): rpi_boot: fix backward compatibility issue when OTA downgrade from otaclient v3.8.x to v3.7.1

### DIFF
--- a/src/otaclient/boot_control/_rpi_boot.py
+++ b/src/otaclient/boot_control/_rpi_boot.py
@@ -359,11 +359,6 @@ class _RPIBootControl:
                     initrd_img,
                     get_sysboot_files_fpath(INITRD_IMG, target_slot),
                 )
-
-            # NOTE(20240603): for backward compatibility(downgrade), still create the flag file.
-            #   The present of flag files means the firmware is updated.
-            flag_file = Path(cfg.SYSTEM_BOOT_MOUNT_POINT) / cfg.SWITCH_BOOT_FLAG_FILE
-            flag_file.write_text("")
             os.sync()
         except Exception as e:
             _err_msg = f"failed to apply new kernel,initrd.img for {target_slot}: {e!r}"

--- a/src/otaclient/boot_control/_rpi_boot.py
+++ b/src/otaclient/boot_control/_rpi_boot.py
@@ -359,6 +359,12 @@ class _RPIBootControl:
                     initrd_img,
                     get_sysboot_files_fpath(INITRD_IMG, target_slot),
                 )
+
+            # NOTE(20250403): previously, we will write the flag file used by otaclient v3.7.1 and older
+            #   after firmware update as the flag file was designed to indicate firmware update is finished.
+            #   But that will cause problem when we downgrade from otaclient v3.8.x back to v3.7.1, 
+            #   as on 1st reboot processing for v3.7.1, slot switch finalizing(config file writing) will also occurs.
+            #   Skipping 1st reboot processing when downgrade to v3.7.1 will result in slot switch finalizing being skipped! 
             os.sync()
         except Exception as e:
             _err_msg = f"failed to apply new kernel,initrd.img for {target_slot}: {e!r}"

--- a/src/otaclient/boot_control/_rpi_boot.py
+++ b/src/otaclient/boot_control/_rpi_boot.py
@@ -362,9 +362,9 @@ class _RPIBootControl:
 
             # NOTE(20250403): previously, we will write the flag file used by otaclient v3.7.1 and older
             #   after firmware update as the flag file was designed to indicate firmware update is finished.
-            #   But that will cause problem when we downgrade from otaclient v3.8.x back to v3.7.1, 
+            #   But that will cause problem when we downgrade from otaclient v3.8.x back to v3.7.1,
             #   as on 1st reboot processing for v3.7.1, slot switch finalizing(config file writing) will also occurs.
-            #   Skipping 1st reboot processing when downgrade to v3.7.1 will result in slot switch finalizing being skipped! 
+            #   Skipping 1st reboot processing when downgrade to v3.7.1 will result in slot switch finalizing being skipped!
             os.sync()
         except Exception as e:
             _err_msg = f"failed to apply new kernel,initrd.img for {target_slot}: {e!r}"


### PR DESCRIPTION
## Introduction

On raspberry pi based ECU, when OTA downgrading from otaclient v3.8.x to v3.7.1, ECU will not be able to finish up slot switching, and will boot back to previous slot.

This only happen when doing OTA downgrading.
1. OTA from otaclient v3.7.1 to v3.8.5 will work.
2. OTA from otaclient v3.8.5 to v3.8.5 will work.

This is caused by raspberry pi firmware update mechanism incompatible with old and new otaclient.
In otaclient v3.7.1, a two-stage reboot mechanism will be used to update firmware:
1. first-reboot: otaclient will do `flash-kernel` and **finalizing slot switching(critical)**, touch a flag file to indicate first-reboot finished.
2. second-reboot: basically do nothing, only clear the flag file and set OTA_STATUS to SUCCESS.

In otaclient v3.8.x, the two-stage reboot mechanism is replaced with doing update firmware with chroot in post-OTA phase, no need to do second reboot anymore. 
otaclient v3.8.x will also create the first-reboot done flag(as the firmware update has already done), but this will let otaclient v3.7.1 **skips slot switching finalizing**, resulting in boot back to old slot. 

This PR fixes the above issue, no longer create first-reboot done flag anymore.

## Tests

On the bench environment, I confirm with this PR, we can do the following update paths:
1. otaclient v3.7.1 -> otaclient with this PR.
2. otaclient with this PR -> otaclient v3.7.1. 