### PR TITLE
ci: separate api release(follow-up)

### DIFF
--- a/.github/workflows/release_api.yml
+++ b/.github/workflows/release_api.yml
@@ -35,6 +35,7 @@ jobs:
           pushd proto
           hatch build -t wheel
           popd
+          mkdir -p dist
           cp proto/dist/*.whl dist
 
       - name: upload artifacts


### PR DESCRIPTION
This is the follow up PR of https://github.com/tier4/ota-client/pull/531

### Why
In new release CI, directory is not created before uploading.
NOTE: we can't trigger and can't verify the new CI behavior on Github Actions before merging the original PR into `main`. Thus this is expected as follow-up PR. But I noticed I should test by using other existing workflow...


### What
Create directory before uploading artifact.

### Test
Verified that new Release CI passed.
https://github.com/tier4/ota-client/actions/runs/15334371280