### PR TITLE
chore: bump up API proto version to 0.8.0

### DIFF
--- a/proto/pyproject.toml
+++ b/proto/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
 
 [project]
 name = "otaclient-pb2"
-version = "0.7.2"
+version = "0.8.0"
 readme = "README.md"
 requires-python = ">=3.8"
 classifiers = [


### PR DESCRIPTION
### Why
To release API protocol buffer

### What
Bun up it's version to `0.8.0`.