### PR TITLE
feat: split active slot and host root mount points in client package

### DIFF
--- a/docker/app_img/Dockerfile
+++ b/docker/app_img/Dockerfile
@@ -50,7 +50,7 @@ ENV OTACLIENT_INSTALLATION=${OTACLIENT_INSTALLATION}
 ENV OTACLIENT_VENV=${OTACLIENT_INSTALLATION}/venv
 
 # Add necessary directories for OTA
-RUN mkdir -p /mnt /ota-cache
+RUN mkdir -p /mnt /ota-cache /host_root
 
 RUN set -eux; \
     apt-get update -qq; \

--- a/src/otaclient/client_package.py
+++ b/src/otaclient/client_package.py
@@ -30,7 +30,6 @@ from typing import Generator, Optional
 
 from ota_metadata.legacy2.metadata import OTAMetadata
 from otaclient import __version__
-from otaclient.configs.cfg import cfg
 from otaclient_common import cmdhelper
 from otaclient_common._typing import StrOrPath
 from otaclient_common.common import (
@@ -63,7 +62,7 @@ class OTAClientPackageDownloader:
 
     """
 
-    ENTRY_POINT = cfg.OTACLIENT_INSTALLATION_RELEASE + "/manifest.json"
+    ENTRY_POINT_FILE_NAME = "manifest.json"
     ARCHITECTURE_X86_64 = "x86_64"
     ARCHITECTURE_ARM64 = "arm64"
     PACKAGE_TYPE_SQUASHFS = "squashfs"
@@ -75,12 +74,16 @@ class OTAClientPackageDownloader:
         base_url: str,
         ota_metadata: OTAMetadata,
         session_dir: StrOrPath,
+        package_install_dir: StrOrPath,
+        squashfs_file: StrOrPath,
     ) -> None:
         self._base_url = base_url
         self._ota_metadata = ota_metadata
         self._session_dir = Path(session_dir)
         self._download_dir = self._session_dir / f".download_{os.urandom(4).hex()}"
         self._download_dir.mkdir(exist_ok=True, parents=True)
+        self._package_install_dir = package_install_dir
+        self._squashfs_file = squashfs_file
 
         self._manifest = None
         self.package = None
@@ -101,12 +104,15 @@ class OTAClientPackageDownloader:
     ) -> Generator[list[DownloadInfo]]:
         """Download raw manifest.json and parse it."""
         # ------ step 1: download manifest.json ------ #
-        _client_manifest_fpath = self._download_dir / Path(self.ENTRY_POINT).name
+        _entry_point_path = Path(self._package_install_dir) / Path(
+            self.ENTRY_POINT_FILE_NAME
+        )
+        _client_manifest_fpath = self._download_dir / _entry_point_path.name
         with condition:
             yield [
                 DownloadInfo(
                     url=urljoin_ensure_base(
-                        self._rootfs_url, self.ENTRY_POINT.lstrip("/")
+                        self._rootfs_url, str(_entry_point_path).lstrip("/")
                     ),
                     dst=_client_manifest_fpath,
                 )
@@ -129,7 +135,7 @@ class OTAClientPackageDownloader:
 
         # ------ step 2: download the target package ------ #
         _package_filename = _available_package_metadata.filename
-        _package_file = cfg.OTACLIENT_INSTALLATION_RELEASE + "/" + _package_filename
+        _package_file = str(self._package_install_dir) + "/" + _package_filename
         _downloaded_package_path = self._download_dir / _package_filename
         with condition:
             yield [
@@ -163,8 +169,7 @@ class OTAClientPackageDownloader:
 
         # ------ step 2: check if squahfs package exists ------ #
         self.current_squashfs_path = (
-            Path(cfg.OTACLIENT_INSTALLATION_RELEASE)
-            / Path(cfg.DYNAMIC_CLIENT_SQUASHFS_FILE).name
+            Path(self._package_install_dir) / Path(self._squashfs_file).name
         )
         _is_squashfs_exists = self.current_squashfs_path.is_file()
         _is_zstd_supported = shutil.which("zstd") is not None
@@ -202,7 +207,7 @@ class OTAClientPackageDownloader:
 
         if self.package.type == self.PACKAGE_TYPE_PATCH:
             _target_squashfs_path = (
-                Path(self._session_dir) / Path(cfg.DYNAMIC_CLIENT_SQUASHFS_FILE).name
+                Path(self._session_dir) / Path(self._squashfs_file).name
             )
             if not _target_squashfs_path.is_file():
                 self._create_squashfs_from_patch(_target_squashfs_path)
@@ -295,28 +300,42 @@ class OTAClientPackageDownloader:
 
     def copy_client_package(self) -> None:
         """Copy the client package."""
-        _squashfs_file = cfg.DYNAMIC_CLIENT_SQUASHFS_FILE
         # copy the squashfs file
-        os.makedirs(os.path.dirname(_squashfs_file), exist_ok=True)
-        shutil.copy(self._get_target_squashfs_path(), _squashfs_file)
+        os.makedirs(os.path.dirname(self._squashfs_file), exist_ok=True)
+        shutil.copy(self._get_target_squashfs_path(), self._squashfs_file)
 
 
 class OTAClientPackagePreparer:
 
-    def _cleanup_mount_point(self, mount_base: StrOrPath) -> None:
+    def __init__(
+        self,
+        squashfs_file: StrOrPath,
+        mount_base: StrOrPath,
+        active_root: StrOrPath,
+        active_slot_mnt_point: StrOrPath,
+        host_root_mnt_point: StrOrPath,
+    ) -> None:
+        """Initialize the OTA client package preparer."""
+        self._squashfs_file = squashfs_file
+        self._mount_base = mount_base
+        self._active_root = active_root
+        self._active_slot_mnt_point = active_slot_mnt_point
+        self._host_root_mnt_point = host_root_mnt_point
+
+    def _cleanup_mount_point(self) -> None:
         """Cleanup the mount point."""
         try:
             # unmount the dynamic client mount point
-            cmdhelper.ensure_mointpoint(mount_base, ignore_error=True)
+            cmdhelper.ensure_mointpoint(self._mount_base, ignore_error=True)
             cmdhelper.ensure_umount(
-                mount_base, ignore_error=False, max_retry=0, retry_interval=0
+                self._mount_base, ignore_error=False, max_retry=0, retry_interval=0
             )
         except Exception as e:
             logger.warning(f"error while unmounting dynamic client mount point: {e}")
 
         try:
             # remove the dynamic client mount point
-            shutil.rmtree(mount_base, ignore_errors=False)
+            shutil.rmtree(self._mount_base, ignore_errors=False)
         except Exception as e:
             logger.warning(f"error while removing dynamic client mount point: {e}")
 
@@ -345,34 +364,30 @@ class OTAClientPackagePreparer:
                     errno, f"Failed to unshare mount namespace: {os.strerror(errno)}"
                 )
 
-    def _mount_squashfs_file(
-        self,
-        squashfs_file: StrOrPath,
-        mount_base: StrOrPath,
-    ) -> None:
+    def _mount_squashfs_file(self) -> None:
         """Mount the squashfs file to the mount base."""
         # check if the squashfs file exists
-        if not os.path.exists(squashfs_file):
-            raise ValueError(f"Squashfs file does not exist: {squashfs_file}")
+        if not os.path.exists(self._squashfs_file):
+            raise ValueError(f"Squashfs file does not exist: {self._squashfs_file}")
 
         # mount the squashfs file
         cmdhelper.ensure_mointpoint(
-            mount_base,
+            self._mount_base,
             ignore_error=False,
         )
 
         cmdhelper.ensure_mount(
-            target=squashfs_file,
-            mnt_point=mount_base,
+            target=self._squashfs_file,
+            mnt_point=self._mount_base,
             mount_func=cmdhelper.mount_squashfs,
             raise_exception=True,
         )
 
-    def _bind_mount_host_dirs(self, mount_base: StrOrPath) -> None:
+    def _bind_mount_host_dirs(self) -> None:
         """Bind mount the host directories to the mount base."""
         # check if the mount base exists
-        if not os.path.exists(mount_base):
-            raise ValueError(f"Mount base does not exist: {mount_base}")
+        if not os.path.exists(self._mount_base):
+            raise ValueError(f"Mount base does not exist: {self._mount_base}")
 
         def bind_paths(paths: list[str], mount_base: StrOrPath, mount_func) -> None:
             for _path in paths:
@@ -414,33 +429,52 @@ class OTAClientPackagePreparer:
         ]
 
         bind_paths(
-            paths=RW_PATHS, mount_base=mount_base, mount_func=cmdhelper.bind_mount_rw
+            paths=RW_PATHS,
+            mount_base=self._mount_base,
+            mount_func=cmdhelper.bind_mount_rw,
         )
 
-    def _rbind_mount_active_slot(self, mount_base: StrOrPath) -> None:
-        """Mount the active slot to the mount base."""
+    def _bind_mount_active_slot(self) -> None:
+        """Mount the active slot to the mount base for Update command."""
         # After chroot, the active slot root is not accessible from the chroot environment.
         # So we need to bind mount the active slot before chroot.
 
-        # TODO: currently, this mount point is used for both host chroot and OTA update
-        # These should be split into two mount points: one for the host chroot and one for OTA updates.
-        # The reason is that in rebuild mode with full disk scanning,
-        # we don't want the otaclient to scan inside the mounted directories.
-        # Therefore, the active slot mount point used as a delta source should not use the rbind flag.
-
         # check if the mount base exists
-        if not os.path.exists(mount_base):
-            raise ValueError(f"Mount base does not exist: {mount_base}")
+        if not os.path.exists(self._mount_base):
+            raise ValueError(f"Mount base does not exist: {self._mount_base}")
 
-        _mount_point = f"{mount_base}{cfg.ACTIVE_SLOT_MNT}"
-        logger.info(f"mounting {cfg.ACTIVE_ROOT} to {_mount_point}")
+        _mount_point = f"{self._mount_base}{self._active_slot_mnt_point}"
+        logger.info(f"mounting {self._active_root} to {_mount_point}")
         cmdhelper.ensure_mointpoint(
             _mount_point,
             ignore_error=True,
         )
 
         cmdhelper.ensure_mount(
-            target=cfg.ACTIVE_ROOT,
+            target=self._active_root,
+            mnt_point=_mount_point,
+            mount_func=cmdhelper.bind_mount_ro,
+            raise_exception=True,
+        )
+
+    def _rbind_mount_host_root(self) -> None:
+        """Rbind mount the host root to the mount base to execute host binaries"""
+        # This is used to make sure the host system directories are accessible from the chroot environment.
+        # This is necessary for the otaclient to run properly in the chroot environment.
+
+        # check if the mount base exists
+        if not os.path.exists(self._mount_base):
+            raise ValueError(f"Mount base does not exist: {self._mount_base}")
+
+        _mount_point = f"{self._mount_base}{self._host_root_mnt_point}"
+        logger.info(f"mounting {self._active_root} to {_mount_point}")
+        cmdhelper.ensure_mointpoint(
+            _mount_point,
+            ignore_error=True,
+        )
+
+        cmdhelper.ensure_mount(
+            target=self._active_root,
             mnt_point=_mount_point,
             mount_func=cmdhelper.rbind_mount_ro,
             raise_exception=True,
@@ -450,17 +484,14 @@ class OTAClientPackagePreparer:
 
     def mount_client_package(self) -> None:
         """Mount the client package to the mount base."""
-        _squashfs_file = cfg.DYNAMIC_CLIENT_SQUASHFS_FILE
-
-        _mount_base = cfg.DYNAMIC_CLIENT_MNT
-        os.makedirs(_mount_base, exist_ok=True)
         try:
-            logger.info(f"mounting {_squashfs_file} to {_mount_base}")
-            self._cleanup_mount_point(_mount_base)
+            logger.info(f"mounting {self._squashfs_file} to {self._mount_base}")
+            self._cleanup_mount_point()
             self._create_mount_namespaces()
-            self._mount_squashfs_file(_squashfs_file, _mount_base)
-            self._bind_mount_host_dirs(_mount_base)
-            self._rbind_mount_active_slot(_mount_base)
+            self._mount_squashfs_file()
+            self._bind_mount_host_dirs()
+            self._bind_mount_active_slot()
+            self._rbind_mount_host_root()
 
             logger.info("mounted squashfs successfully")
         except subprocess.CalledProcessError as e:

--- a/src/otaclient/configs/_cfg_consts.py
+++ b/src/otaclient/configs/_cfg_consts.py
@@ -50,6 +50,8 @@ class Consts:
 
     # mount point for downloaded otaclient
     DYNAMIC_CLIENT_MNT = "/run/otaclient/mnt/dynamic_otaclient"
+    # mount point for host(original) root in dynamic client
+    DYNAMIC_CLIENT_MNT_HOST_ROOT = "/host_root"
     # downloaded squashfs location in local filesystem
     # this path should not be included in the mounted rootfs
     DYNAMIC_CLIENT_SQUASHFS_FILE = "/.otaclient.squashfs"

--- a/src/otaclient/main.py
+++ b/src/otaclient/main.py
@@ -112,7 +112,13 @@ def main() -> None:  # pragma: no cover
         logger.info("preparing downloaded dynamic ota client ...")
         try:
             logger.info("mounting dynamic client squashfs ...")
-            client_package_prepareter = OTAClientPackagePreparer()
+            client_package_prepareter = OTAClientPackagePreparer(
+                squashfs_file=cfg.DYNAMIC_CLIENT_SQUASHFS_FILE,
+                mount_base=cfg.DYNAMIC_CLIENT_MNT,
+                active_root=cfg.ACTIVE_ROOT,
+                active_slot_mnt_point=cfg.ACTIVE_SLOT_MNT,
+                host_root_mnt_point=cfg.DYNAMIC_CLIENT_MNT_HOST_ROOT,
+            )
             client_package_prepareter.mount_client_package()
 
             _mount_base = cfg.DYNAMIC_CLIENT_MNT

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -871,6 +871,8 @@ class _OTAClientUpdater(_OTAUpdateOperator):
             base_url=self.url_base,
             ota_metadata=self._ota_metadata,
             session_dir=self._session_workdir,
+            package_install_dir=cfg.OTACLIENT_INSTALLATION_RELEASE,
+            squashfs_file=cfg.DYNAMIC_CLIENT_SQUASHFS_FILE,
         )
 
     def _execute_client_update(self):

--- a/src/otaclient_common/_env.py
+++ b/src/otaclient_common/_env.py
@@ -40,5 +40,5 @@ def is_dynamic_client_running() -> bool:
 def get_dynamic_client_chroot_path() -> Optional[str]:
     """Get the chroot path."""
     if is_dynamic_client_running():
-        return cfg.ACTIVE_SLOT_MNT
+        return cfg.DYNAMIC_CLIENT_MNT_HOST_ROOT
     return None

--- a/tests/test_otaclient/test_client_package.py
+++ b/tests/test_otaclient/test_client_package.py
@@ -24,8 +24,8 @@ from typing import Optional
 from unittest.mock import MagicMock, PropertyMock, mock_open, patch
 
 import pytest
-
 from _otaclient_version import __version__
+
 from otaclient.client_package import (
     Manifest,
     OTAClientPackageDownloader,


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce.

For better understanding, adding reason/motivation of this PR are also recommended.

-->

### Why
This is follow up PR of https://github.com/tier4/ota-client/pull/522 ([comment](https://github.com/tier4/ota-client/pull/522#discussion_r2126068533)).
Currently, the same mount point is used for both host chroot and OTA update by rbind. It will take time in rebuild mode with full disk scanning, so we don't want otaclient to scan into mount points in active slot mount point as delta source.

### What
split "active slot" and "host root" mount points. The detail is described in Changes section. 

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [ ] test file(s) that covers the change(s) is implemented.
- [ ] local test is passed.
- [ ] design docs/implementation docs are prepared.

### Tests
Verified that the expected mount points are used in dynamic client and OTA was succeeded.
```
(venv) root@autoware-ecu:/opt/ota/client# cat /proc/147513/mountinfo 
...
669 664 8:4 / /run/otaclient/mnt/active_slot ro,relatime unbindable - ext4 /dev/sda4 rw
756 664 8:3 / /run/otaclient/mnt/standby_slot rw,relatime unbindable - ext4 /dev/sda3 rw
...
670 654 8:4 / /host_root rw,relatime - ext4 /dev/sda4 rw
```

## Documents

<!-- For feature PR, design document is required. -->

## Changes

<!-- A list of code change(s) that introduced by this PR. -->

split the followings.

| name | purpose | target | mount point | mount options |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| active slot  | for delta scan in Update | `/` |  `/run/otaclient/mnt/active_slot` | bind |
| host root  | to execute host binaries with chroot in Update | `/` | `/host_root` | rbind |

## Behavior changes

Does this PR introduce behavior change(s)?

- [x] Yes, internal behaivor (will not impact user experience).
- [ ] Yes, external behaivor (will impact user experience).
- [ ] No.

### Previous behavior

<!-- Behaivor before the PR is introduced -->

### Behavior with this PR

<!-- Behavior after the PR is introduced -->

## Breaking change

Does this PR introduce breaking change?

- [ ] Yes.
- [x] No.

<!-- List the breaking change(s) -->

## Related links & tickets
