### PR TITLE
test: fix flaky logging test

### DIFF
--- a/tests/test_otaclient/test_logging.py
+++ b/tests/test_otaclient/test_logging.py
@@ -181,6 +181,9 @@ class TestLogClient:
         )
         configure_logging()
 
+        # Give some time for the logging handler to be fully set up
+        await asyncio.sleep(0.1)
+
         # send a test log message
         logger.error(log_message, extra=extra)
         # wait for the log message to be received


### PR DESCRIPTION
### Why
test_logging.py is falky([example](https://github.com/tier4/ota-client/actions/runs/15584533943/job/43887390590)).
Because pytest doesn't dispatch to logging thread in `asyncio.wait_for` function.

### What
add `asyncio.sleep(0.1)` and wait for logging setup clearly.


### Tests
Executed the target test in local for 10 times, then never meet the timeout.