### PR TITLE
fix: increase wait seconds before reboot

### DIFF
--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -100,7 +100,9 @@ from otaclient_common.retry_task_map import (
 logger = logging.getLogger(__name__)
 
 DEFAULT_STATUS_QUERY_INTERVAL = 1
-WAIT_BEFORE_REBOOT = 6
+# This time should be larger than the frequency of FMS status notification(currently 10s)
+# Otherwise, the final status might not be showed on FMS Console.
+WAIT_BEFORE_REBOOT = 12  # seconds
 DOWNLOAD_STATS_REPORT_BATCH = 300
 DOWNLOAD_REPORT_INTERVAL = 1  # second
 


### PR DESCRIPTION
## Description
### Why
Sometimes, ECU starts reboot after OTA without showing 100% on FMS.
This is because: 
- FMS
  - get status every 1 sec
  - notify the status to upper every 10 sec
- OTA
  - wait 6 sec before rebooting

Example Sequence
1. FMS notifies the latest status(e.g 86%), then wait for 10 seconds for next notification
2. OTA finishes finalizing, wait for 6 seconds, then trigger reboot
3. on FMS console, still 86% is shown until WebAutoAgent update is finished

There are several approaches to resolve this issue.
1. add new "Reboot" gRPC API between Edge and ota-client
-> Clean, but will be over-engineering for this purpose.
2. Show 100% on FrontEnd when WebAutoAgent starts updating
-> progress is handled by Edge and ota-client currently. This option disperse the responsibility.
3. Increase current frequency(10 sec) on FMS
-> might affect the performance on FrontEnd / BackEnd side
4. Increase reboot waiting time(6 sec) on OTA
-> Easy. a few sec extension will not be matter for OTA user experience.


### What
Suggest to 4. Increase reboot waiting time from 6 sec to 12 sec in ota-client side.


<!-- Summarize the change this PR wants to introduce. -->

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file that covers the bug case(s) is implemented.
- [x] local test is passed.

## Bug fix

### Current behavior

### Behaivor after fix

## Related links & ticket
https://tier4.atlassian.net/browse/RT4-17548

<!-- List of tickets or links related to this PR -->
