### PR TITLE
fix: cmdhelper.reboot: ensure to call sys.exit(0) after reboot subprocess call

### DIFF
--- a/src/otaclient/boot_control/_grub.py
+++ b/src/otaclient/boot_control/_grub.py
@@ -30,7 +30,6 @@ NOTE(20231027) A workaround fix is applied to handle the edge case of rootfs not
     still expecting new mechanism to fundamentally resolve this issue.
 """
 
-
 from __future__ import annotations
 
 import logging
@@ -932,14 +931,7 @@ class GrubController(BootControllerProtocol):
             ) from e
 
     def finalizing_update(self, *, chroot: str | None = None) -> NoReturn:
-        try:
-            cmdhelper.reboot(chroot=chroot)
-        except Exception as e:
-            _err_msg = f"reboot failed: {e!r}"
-            logger.error(_err_msg)
-            raise ota_errors.BootControlPostUpdateFailed(
-                _err_msg, module=__name__
-            ) from e
+        cmdhelper.reboot(chroot=chroot)
 
     def pre_rollback(self):
         try:

--- a/src/otaclient/boot_control/_jetson_cboot.py
+++ b/src/otaclient/boot_control/_jetson_cboot.py
@@ -16,7 +16,6 @@
 Supports BSP version < R34.
 """
 
-
 from __future__ import annotations
 
 import logging
@@ -712,14 +711,7 @@ class JetsonCBootControl(BootControllerProtocol):
             ) from e
 
     def finalizing_update(self, *, chroot: str | None = None) -> NoReturn:
-        try:
-            cmdhelper.reboot(chroot=chroot)
-        except Exception as e:
-            _err_msg = f"reboot failed: {e!r}"
-            logger.error(_err_msg)
-            raise ota_errors.BootControlPostUpdateFailed(
-                _err_msg, module=__name__
-            ) from e
+        cmdhelper.reboot(chroot=chroot)
 
     def pre_rollback(self):
         try:

--- a/src/otaclient/boot_control/_jetson_uefi.py
+++ b/src/otaclient/boot_control/_jetson_uefi.py
@@ -17,7 +17,6 @@ jetson-uefi module currently support BSP version >= R34(which UEFI is introduced
 But firmware update is only supported after BSP R35.2.
 """
 
-
 from __future__ import annotations
 
 import contextlib
@@ -511,9 +510,9 @@ class UEFIFirmwareUpdater:
 
             try:
                 _digest = cal_file_digest(capsule_fpath, algorithm=capsule_digest_alg)
-                assert (
-                    _digest == capsule_digest_value
-                ), f"{capsule_digest_alg} validation failed, expect {capsule_digest_value}, get {_digest}"
+                assert _digest == capsule_digest_value, (
+                    f"{capsule_digest_alg} validation failed, expect {capsule_digest_value}, get {_digest}"
+                )
 
                 shutil.copy(
                     src=capsule_fpath,
@@ -565,9 +564,9 @@ class UEFIFirmwareUpdater:
                 _digest = cal_file_digest(
                     ota_image_bootaa64, algorithm=payload_digest_alg
                 )
-                assert (
-                    _digest == payload_digest_value
-                ), f"{payload_digest_alg} validation failed, expect {payload_digest_value}, get {_digest}"
+                assert _digest == payload_digest_value, (
+                    f"{payload_digest_alg} validation failed, expect {payload_digest_value}, get {_digest}"
+                )
 
                 shutil.copy(self.bootaa64_at_esp, self.bootaa64_at_esp_bak)
                 shutil.copy(ota_image_bootaa64, self.bootaa64_at_esp)
@@ -1083,14 +1082,7 @@ class JetsonUEFIBootControl(BootControllerProtocol):
             ) from e
 
     def finalizing_update(self, *, chroot: str | None = None) -> NoReturn:
-        try:
-            cmdhelper.reboot(chroot=chroot)
-        except Exception as e:
-            _err_msg = f"reboot failed: {e!r}"
-            logger.error(_err_msg)
-            raise ota_errors.BootControlPostUpdateFailed(
-                _err_msg, module=__name__
-            ) from e
+        cmdhelper.reboot(chroot=chroot)
 
     def pre_rollback(self):
         try:

--- a/src/otaclient/boot_control/_rpi_boot.py
+++ b/src/otaclient/boot_control/_rpi_boot.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Boot control support for Raspberry pi 4 Model B."""
 
-
 from __future__ import annotations
 
 import contextlib
@@ -421,16 +420,11 @@ class _RPIBootControl:
             logger.error(_err_msg)
             raise _RPIBootControllerError(_err_msg) from e
 
-    def reboot_tryboot(self, *, chroot: str | None = None):
+    def reboot_tryboot(self, *, chroot: str | None = None) -> NoReturn:
         """Reboot with tryboot flag."""
         logger.info(f"tryboot reboot to standby slot({self.standby_slot})...")
-        try:
-            # NOTE: "0 tryboot" is a single param.
-            cmdhelper.reboot(args=["0 tryboot"], chroot=chroot)
-        except Exception as e:
-            _err_msg = "failed to reboot"
-            logger.exception(_err_msg)
-            raise _RPIBootControllerError(_err_msg) from e
+        # NOTE: "0 tryboot" is a single param.
+        cmdhelper.reboot(args=["0 tryboot"], chroot=chroot)
 
 
 class RPIBootController(BootControllerProtocol):
@@ -557,14 +551,7 @@ class RPIBootController(BootControllerProtocol):
             ) from e
 
     def finalizing_update(self, *, chroot: str | None = None) -> NoReturn:
-        try:
-            self._rpiboot_control.reboot_tryboot(chroot=chroot)
-        except Exception as e:
-            _err_msg = f"reboot failed: {e!r}"
-            logger.error(_err_msg)
-            raise ota_errors.BootControlPostUpdateFailed(
-                _err_msg, module=__name__
-            ) from e
+        self._rpiboot_control.reboot_tryboot(chroot=chroot)
 
     finalizing_rollback = finalizing_update
 

--- a/src/otaclient_common/cmdhelper.py
+++ b/src/otaclient_common/cmdhelper.py
@@ -314,8 +314,10 @@ def reboot(
         cmd.extend(args)
 
     logger.warning("system will reboot now!")
-    subprocess_call(cmd, raise_exception=False, chroot=chroot)
-    sys.exit(0)
+    try:
+        subprocess_call(cmd, raise_exception=False, chroot=chroot)
+    finally:
+        sys.exit(0)
 
 
 #

--- a/src/otaclient_common/cmdhelper.py
+++ b/src/otaclient_common/cmdhelper.py
@@ -18,7 +18,6 @@ When underlying subprocess call failed and <raise_exception> is True,
     to the upper caller.
 """
 
-
 from __future__ import annotations
 
 import logging
@@ -307,7 +306,7 @@ def reboot(
         chroot (str | None, optional): the chroot path to use. Defaults to None.
 
     Raises:
-        CalledProcessError for the reboot call, or SystemExit on sys.exit(0).
+        SystemExit by sys.exit(0).
     """
     cmd = ["reboot"]
     if args:
@@ -315,7 +314,7 @@ def reboot(
         cmd.extend(args)
 
     logger.warning("system will reboot now!")
-    subprocess_call(cmd, raise_exception=True, chroot=chroot)
+    subprocess_call(cmd, raise_exception=False, chroot=chroot)
     sys.exit(0)
 
 


### PR DESCRIPTION
## Motivation

During bench test, I found that on relatively slow device(comparing to main ECU), the `reboot` command might failed with `SIGTERM` even it actually does the `reboot`, causing the `cmdhelper.reboot` raises Exception unexpectedly. 
Turns out when device is not fast enough, python subprocess call might not be able to return after `reboot` command executed, and being killed by the `reboot` execution. 
We actually don't need to check `reboot` command's result as it will certainly do its job(signalling systemd to do `reboot`).

## Introdution

This PR fixes a potential issue of otaclient reboot procedure being interrupted unexpectedly due to subprocess call to `reboot` killed by `reboot` cmd. Now `cmdhelper.reboot` will not check the result of subprocess `reboot` call, and immediately do sys.exit(0), ensuring a clean exit.