### PR TITLE
fix: create mount points for raspi

### DIFF
--- a/src/otaclient/boot_control/_rpi_boot.py
+++ b/src/otaclient/boot_control/_rpi_boot.py
@@ -161,6 +161,7 @@ class _RPIBootControl:
             _err_msg = f"system-boot is not mounted at {self.system_boot_mp}, try to mount it..."
             logger.warning(_err_msg)
 
+            self.system_boot_mp.mkdir(exist_ok=True, parents=True)
             try:
                 cmdhelper.mount(
                     system_boot_partition,
@@ -285,19 +286,19 @@ class _RPIBootControl:
         flash-kernel requires at least these mounts to work properly.
         """
         target_slot_mp = Path(target_slot_mp)
-        mounts: dict[str, str] = {}
+        mounts: dict[Path, Path] = {}
 
         # we need to mount /proc, /sys and /boot/firmware to make flash-kernel works
         system_boot_mp = target_slot_mp / Path(
             boot_cfg.SYSTEM_BOOT_MOUNT_POINT
         ).relative_to("/")
-        mounts[str(system_boot_mp)] = boot_cfg.SYSTEM_BOOT_MOUNT_POINT
+        mounts[system_boot_mp] = Path(boot_cfg.SYSTEM_BOOT_MOUNT_POINT)
 
         proc_mp = target_slot_mp / "proc"
-        mounts[str(proc_mp)] = "/proc"
+        mounts[proc_mp] = Path("/proc")
 
         sys_mp = target_slot_mp / "sys"
-        mounts[str(sys_mp)] = "/sys"
+        mounts[sys_mp] = Path("/sys")
 
         # NOTE(20250314): ensure that tmp folder exists on standby slot
         _tmp_on_standby = target_slot_mp / "tmp"
@@ -308,6 +309,7 @@ class _RPIBootControl:
 
         try:
             for _mp, _src in mounts.items():
+                _mp.mkdir(exist_ok=True, parents=True)
                 cmdhelper.mount(
                     _src,
                     _mp,

--- a/tests/test_otaclient/test_boot_control/test_rpi_boot.py
+++ b/tests/test_otaclient/test_boot_control/test_rpi_boot.py
@@ -249,6 +249,31 @@ class TestRPIBootControl:
             mocker.MagicMock(return_value=mp_control_mock),
         )
 
+    def test_prepare_flash_kernel(
+        self, mocker: pytest_mock.MockerFixture, tmp_path: Path
+    ):
+        # Setup
+        target_slot_mp = tmp_path / "target_slot"
+        target_slot_mp.mkdir()
+
+        mock_cmdhelper = mocker.patch(f"{RPI_BOOT_MODULE_PATH}.cmdhelper")
+
+        # Execute
+        with _rpi_boot._RPIBootControl._prepare_flash_kernel(target_slot_mp):
+            pass
+
+        # Verify directories were created
+        assert (target_slot_mp / "boot" / "firmware").exists()
+        assert (target_slot_mp / "proc").exists()
+        assert (target_slot_mp / "sys").exists()
+        assert (target_slot_mp / "tmp").exists()
+
+        # Verify mount was called 3 times (system-boot, proc, sys)
+        assert mock_cmdhelper.mount.call_count == 3
+
+        # Verify umount was called 3 times in cleanup
+        assert mock_cmdhelper.umount.call_count == 3
+
     def test_rpi_boot_normal_update(self, mocker: pytest_mock.MockerFixture):
         # ------ patch rpi_boot_cfg for boot_controller_inst1.stage 1~3 ------#
         _mock_rpi_boot_cfg = RPIBootControlConfig()


### PR DESCRIPTION
## Description
### Why
This issues was found in Raspberry PI.
When standby slot is blank(like brand new USB memory), the expected mount points in standby slot are not created in advance.
This cause mount failure.
```
Jun 14 17:13:09 voice-system run.sh[854]: ------ exception traceback ------
Jun 14 17:13:09 voice-system run.sh[854]: Traceback (most recent call last):
Jun 14 17:13:09 voice-system run.sh[854]:   File "/opt/ota/client/venv/lib/python3.10/site-packages/otaclient/boot_control/_rpi_boot.py", line 333, in update_firmware
Jun 14 17:13:09 voice-system run.sh[854]:     with self._prepare_flash_kernel(target_slot_mp):
Jun 14 17:13:09 voice-system run.sh[854]:   File "/usr/lib/python3.10/contextlib.py", line 135, in __enter__
Jun 14 17:13:09 voice-system run.sh[854]:     return next(self.gen)
Jun 14 17:13:09 voice-system run.sh[854]:   File "/opt/ota/client/venv/lib/python3.10/site-packages/otaclient/boot_control/_rpi_boot.py", line 311, in _prepare_flash_kernel
Jun 14 17:13:09 voice-system run.sh[854]:     CMDHelperFuncs.mount(
Jun 14 17:13:09 voice-system run.sh[854]:   File "/opt/ota/client/venv/lib/python3.10/site-packages/otaclient/boot_control/_common.py", line 266, in mount
Jun 14 17:13:09 voice-system run.sh[854]:     subprocess_call(cmd, raise_exception=raise_exception)
Jun 14 17:13:09 voice-system run.sh[854]:   File "/opt/ota/client/venv/lib/python3.10/site-packages/otaclient_common/common.py", line 157, in subprocess_call
Jun 14 17:13:09 voice-system run.sh[854]:     subprocess_run_wrapper(cmd, check=True, check_output=False, timeout=timeout)
Jun 14 17:13:09 voice-system run.sh[854]:   File "/opt/ota/client/venv/lib/python3.10/site-packages/otaclient_common/linux.py", line 200, in subprocess_run_wrapper
Jun 14 17:13:09 voice-system run.sh[854]:     return subprocess.run(
Jun 14 17:13:09 voice-system run.sh[854]:   File "/usr/lib/python3.10/subprocess.py", line 524, in run
Jun 14 17:13:09 voice-system run.sh[854]:     raise CalledProcessError(retcode, process.args,
Jun 14 17:13:09 voice-system run.sh[854]: subprocess.CalledProcessError: Command '['mount', '-o', 'bind', '--make-unbindable', '/boot/firmware', '/mnt/standby/boot/firmware']' returned non-zero exit status 32.

$ root@voice-system:/home/autoware# mount -o bind --make-unbindable /boot/firmware /mnt/standby/boot/firmware 
mount: /mnt/standby/boot/firmware: mount point does not exist.
```

### What
Create mount points before executing mount

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file that covers the bug case(s) is implemented.
- [x] local test is passed.

## Bug fix

### Current behavior
If mount points doesn't exist, the update will be failed.

### Behaivor after fix
mount points will be created and the update will be passed.

## Related links & ticket

<!-- List of tickets or links related to this PR -->
