### PR TITLE
fix: fix mount option in bind with R/W for dynamic client

### DIFF
--- a/src/otaclient/client_package.py
+++ b/src/otaclient/client_package.py
@@ -401,6 +401,7 @@ class OTAClientPackagePreparer:
                     mnt_point=_mount_point,
                     mount_func=mount_func,
                     raise_exception=True,
+                    set_unbindable=False,
                 )
 
         # bind necessary directories
@@ -474,6 +475,7 @@ class OTAClientPackagePreparer:
             mnt_point=_mount_point,
             mount_func=cmdhelper.rbind_mount_ro,
             raise_exception=True,
+            set_unbindable=False,
         )
 
     # APIs

--- a/src/otaclient_common/cmdhelper.py
+++ b/src/otaclient_common/cmdhelper.py
@@ -340,6 +340,7 @@ class MountHelper(Protocol):
         mount_point: StrOrPath,
         *,
         raise_exception: bool = True,
+        set_unbindable: bool = True,
     ) -> None: ...
 
 
@@ -373,17 +374,23 @@ def mount(
 
 
 def bind_mount_rw(
-    target: StrOrPath, mount_point: StrOrPath, *, raise_exception: bool = True
+    target: StrOrPath,
+    mount_point: StrOrPath,
+    *,
+    raise_exception: bool = True,
+    set_unbindable: bool = True,
 ) -> None:  # pragma: no cover
     """Bind mount the <target> to <mount_point> read-write.
 
     This is implemented by calling:
-        mount -o bind,rw --make-private <target> <mount_point>
+        mount -o bind,rw --make-private --make-unbindable <target> <mount_point>
 
     Args:
         target (StrOrPath): target to be mounted.
         mount_point (StrOrPath): mount point to mount to.
         raise_exception (bool, optional): raise exception on subprocess call failed.
+            Defaults to True.
+        set_unbindable (bool, optional): whether to set the mount point as unbindable.
             Defaults to True.
     """
     # fmt: off
@@ -391,15 +398,23 @@ def bind_mount_rw(
         "mount",
         "-o", "bind,rw",
         "--make-private",
-        str(target),
-        str(mount_point)
     ]
+    if set_unbindable:
+        cmd.append("--make-unbindable")
+    cmd.extend([
+        str(target),
+        str(mount_point),
+    ])
     # fmt: on
     subprocess_call(cmd, raise_exception=raise_exception)
 
 
 def mount_rw(
-    target: StrOrPath, mount_point: StrOrPath, *, raise_exception: bool = True
+    target: StrOrPath,
+    mount_point: StrOrPath,
+    *,
+    raise_exception: bool = True,
+    set_unbindable: bool = True,
 ) -> None:  # pragma: no cover
     """Mount the <target> to <mount_point> read-write.
 
@@ -414,21 +429,31 @@ def mount_rw(
         mount_point (StrOrPath): mount point to mount to.
         raise_exception (bool, optional): raise exception on subprocess call failed.
             Defaults to True.
+        set_unbindable (bool, optional): whether to set the mount point as unbindable.
+            Defaults to True.
     """
     # fmt: off
     cmd = [
         "mount",
         "-o", "rw",
-        "--make-private", "--make-unbindable",
+        "--make-private",
+    ]
+    if set_unbindable:
+        cmd.append("--make-unbindable")
+    cmd.extend([
         str(target),
         str(mount_point),
-    ]
+    ])
     # fmt: on
     subprocess_call(cmd, raise_exception=raise_exception)
 
 
 def bind_mount_ro(
-    target: StrOrPath, mount_point: StrOrPath, *, raise_exception: bool = True
+    target: StrOrPath,
+    mount_point: StrOrPath,
+    *,
+    raise_exception: bool = True,
+    set_unbindable: bool = True,
 ) -> None:  # pragma: no cover
     """Bind mount the <target> to <mount_point> read-only.
 
@@ -440,31 +465,43 @@ def bind_mount_ro(
         mount_point (StrOrPath): mount point to mount to.
         raise_exception (bool, optional): raise exception on subprocess call failed.
             Defaults to True.
+        set_unbindable (bool, optional): whether to set the mount point as unbindable.
+            Defaults to True.
     """
     # fmt: off
     cmd = [
         "mount",
         "-o", "bind,ro",
-        "--make-private", "--make-unbindable",
-        str(target),
-        str(mount_point)
+        "--make-private",
     ]
+    if set_unbindable:
+        cmd.append("--make-unbindable")
+    cmd.extend([
+        str(target),
+        str(mount_point),
+    ])
     # fmt: on
     subprocess_call(cmd, raise_exception=raise_exception)
 
 
 def rbind_mount_ro(
-    target: StrOrPath, mount_point: StrOrPath, *, raise_exception: bool = True
+    target: StrOrPath,
+    mount_point: StrOrPath,
+    *,
+    raise_exception: bool = True,
+    set_unbindable: bool = True,
 ) -> None:  # pragma: no cover
     """Rbind mount the <target> to <mount_point> read-only.
 
     This is implemented by calling:
-        mount -o bind,ro --make-private <target> <mount_point>
+        mount -o bind,ro --make-private --make-unbindable <target> <mount_point>
 
     Args:
         target (StrOrPath): target to be mounted.
         mount_point (StrOrPath): mount point to mount to.
         raise_exception (bool, optional): raise exception on subprocess call failed.
+            Defaults to True.
+        set_unbindable (bool, optional): whether to set the mount point as unbindable.
             Defaults to True.
     """
     # fmt: off
@@ -472,15 +509,23 @@ def rbind_mount_ro(
         "mount",
         "--rbind",
         "--make-private",
-        str(target),
-        str(mount_point)
     ]
+    if set_unbindable:
+        cmd.append("--make-unbindable")
+    cmd.extend([
+        str(target),
+        str(mount_point),
+    ])
     # fmt: on
     subprocess_call(cmd, raise_exception=raise_exception)
 
 
 def mount_ro(
-    target: StrOrPath, mount_point: StrOrPath, *, raise_exception: bool = True
+    target: StrOrPath,
+    mount_point: StrOrPath,
+    *,
+    raise_exception: bool = True,
+    set_unbindable: bool = True,
 ) -> None:  # pragma: no cover
     """Mount <target> to <mount_point> read-only.
 
@@ -492,6 +537,8 @@ def mount_ro(
         mount_point (StrOrPath): mount point to mount to.
         raise_exception (bool, optional): raise exception on subprocess call failed.
             Defaults to True.
+        set_unbindable (bool, optional): whether to set the mount point as unbindable.
+            Defaults to True.
     """
     # NOTE: set raise_exception to false to allow not mounted
     #       not mounted dev will have empty return str
@@ -502,6 +549,7 @@ def mount_ro(
             _active_mount_point,
             mount_point,
             raise_exception=raise_exception,
+            set_unbindable=set_unbindable,
         )
     else:
         # target is not mounted, we mount it by ourself
@@ -509,21 +557,29 @@ def mount_ro(
         cmd = [
             "mount",
             "-o", "ro",
-            "--make-private", "--make-unbindable",
+            "--make-private",
+        ]
+        if set_unbindable:
+            cmd.append("--make-unbindable")
+        cmd.extend([
             str(target),
             str(mount_point),
-        ]
+        ])
         # fmt: on
         subprocess_call(cmd, raise_exception=raise_exception)
 
 
 def mount_squashfs(
-    target: StrOrPath, mount_point: StrOrPath, *, raise_exception: bool = True
+    target: StrOrPath,
+    mount_point: StrOrPath,
+    *,
+    raise_exception: bool = True,
+    set_unbindable: bool = True,
 ) -> None:  # pragma: no cover
     """Mount the <target> sqiashfs to <mount_point>.
 
     This is implemented by calling:
-        mount --make-private --make-unbindable -o ro -t squashfs <target> <mount_point>
+        mount -o ro -t squashfs --make-private --make-unbindable <target> <mount_point>
 
     NOTE: pass args = ["--make-private", "--make-unbindable"] to prevent
             mount events propagation to/from this mount point.
@@ -533,16 +589,22 @@ def mount_squashfs(
         mount_point (StrOrPath): mount point to mount to.
         raise_exception (bool, optional): raise exception on subprocess call failed.
             Defaults to True.
+        set_unbindable (bool, optional): whether to set the mount point as unbindable.
+            Defaults to True.
     """
     # fmt: off
     cmd = [
         "mount",
-        "--make-private", "--make-unbindable",
         "-o", "ro",
         "-t", "squashfs",
+        "--make-private",
+    ]
+    if set_unbindable:
+        cmd.append("--make-unbindable")
+    cmd.extend([
         str(target),
         str(mount_point),
-    ]
+    ])
     # fmt: on
     subprocess_call(cmd, raise_exception=raise_exception)
 
@@ -579,6 +641,7 @@ def ensure_mount(
     *,
     mount_func: MountHelper,
     raise_exception: bool,
+    set_unbindable: bool = True,
     max_retry: int = MAX_RETRY_COUNT,
     retry_interval: int = RETRY_INTERVAL,
 ) -> None:  # pragma: no cover
@@ -589,7 +652,9 @@ def ensure_mount(
     """
     for _retry in range(max_retry + 1):
         try:
-            mount_func(target=target, mount_point=mnt_point)
+            mount_func(
+                target=target, mount_point=mnt_point, set_unbindable=set_unbindable
+            )
             is_target_mounted(mnt_point, raise_exception=True)
             return
         except CalledProcessError as e:

--- a/src/otaclient_common/cmdhelper.py
+++ b/src/otaclient_common/cmdhelper.py
@@ -378,7 +378,7 @@ def bind_mount_rw(
     """Bind mount the <target> to <mount_point> read-write.
 
     This is implemented by calling:
-        mount -o bind,rw --make-private --make-unbindable <target> <mount_point>
+        mount -o bind,rw --make-private <target> <mount_point>
 
     Args:
         target (StrOrPath): target to be mounted.
@@ -390,7 +390,7 @@ def bind_mount_rw(
     cmd = [
         "mount",
         "-o", "bind,rw",
-        "--make-private", "--make-unbindable",
+        "--make-private",
         str(target),
         str(mount_point)
     ]

--- a/tests/test_otaclient_common/test_cmdhelper.py
+++ b/tests/test_otaclient_common/test_cmdhelper.py
@@ -1,0 +1,143 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+from otaclient_common import cmdhelper
+
+
+class TestMkfsExt4:
+    def test_mkfs_ext4_with_fslabel_and_fsuuid(self):
+        with mock.patch(
+            "otaclient_common.cmdhelper.subprocess_call"
+        ) as mock_subprocess:
+            cmdhelper.mkfs_ext4("/dev/sda1", fslabel="test-label", fsuuid="test-uuid")
+            expected_cmd = [
+                "mkfs.ext4",
+                "-F",
+                "-U",
+                "test-uuid",
+                "-L",
+                "test-label",
+                "/dev/sda1",
+            ]
+            mock_subprocess.assert_called_once_with(expected_cmd, raise_exception=True)
+
+    def test_mkfs_ext4_preserve_existing_attributes(self):
+        with mock.patch(
+            "otaclient_common.cmdhelper.subprocess_call"
+        ) as mock_subprocess:
+            with mock.patch(
+                "otaclient_common.cmdhelper.get_attrs_by_dev"
+            ) as mock_get_attrs:
+                mock_get_attrs.side_effect = ["existing-uuid", "existing-label"]
+                cmdhelper.mkfs_ext4("/dev/sda1")
+                expected_cmd = [
+                    "mkfs.ext4",
+                    "-F",
+                    "-U",
+                    "existing-uuid",
+                    "-L",
+                    "existing-label",
+                    "/dev/sda1",
+                ]
+                mock_subprocess.assert_called_once_with(
+                    expected_cmd, raise_exception=True
+                )
+
+
+class TestEnsureMount:
+    def test_ensure_mount_with_custom_parameters(self):
+        """Test ensure_mount with custom retry parameters."""
+        mock_mount_func = mock.Mock()
+
+        with mock.patch(
+            "otaclient_common.cmdhelper.is_target_mounted"
+        ) as mock_is_mounted:
+            mock_is_mounted.return_value = True
+
+            cmdhelper.ensure_mount(
+                target="/dev/nvme0n1p1",
+                mnt_point="/mnt/custom",
+                mount_func=mock_mount_func,
+                raise_exception=False,
+                set_unbindable=False,
+                max_retry=10,
+                retry_interval=5,
+            )
+
+            mock_mount_func.assert_called_once_with(
+                target="/dev/nvme0n1p1", mount_point="/mnt/custom", set_unbindable=False
+            )
+
+
+class TestEnsureUmount:
+    def test_ensure_umount_mounted_target(self):
+        with mock.patch(
+            "otaclient_common.cmdhelper.is_target_mounted"
+        ) as mock_is_mounted:
+            with mock.patch(
+                "otaclient_common.cmdhelper.subprocess_call"
+            ) as mock_subprocess:
+                mock_is_mounted.return_value = True
+                cmdhelper.umount("/mnt")
+                mock_subprocess.assert_called_once()
+
+    def test_ensure_umount_not_mounted_target(self):
+        with mock.patch(
+            "otaclient_common.cmdhelper.is_target_mounted"
+        ) as mock_is_mounted:
+            with mock.patch(
+                "otaclient_common.cmdhelper.subprocess_call"
+            ) as mock_subprocess:
+                mock_is_mounted.return_value = False
+                cmdhelper.umount("/mnt")
+                mock_subprocess.assert_not_called()
+
+
+class TestEnsureMountpoint:
+    def test_ensure_mountpoint_create_directory(self):
+        with mock.patch("pathlib.Path.exists") as mock_exists:
+            with mock.patch("pathlib.Path.mkdir") as mock_mkdir:
+                with mock.patch(
+                    "otaclient_common.cmdhelper.ensure_umount"
+                ) as mock_umount:
+                    mock_exists.return_value = False
+                    cmdhelper.ensure_mointpoint("/test/mount", ignore_error=False)
+                    mock_mkdir.assert_called_once_with(exist_ok=True, parents=True)
+                    mock_umount.assert_not_called()
+
+    def test_ensure_mountpoint_umount_existing(self):
+        with mock.patch("pathlib.Path.exists") as mock_exists:
+            with mock.patch("pathlib.Path.is_symlink") as mock_is_symlink:
+                with mock.patch("pathlib.Path.is_dir") as mock_is_dir:
+                    with mock.patch(
+                        "otaclient_common.cmdhelper.ensure_umount"
+                    ) as mock_umount:
+                        mock_exists.return_value = True
+                        mock_is_symlink.return_value = False
+                        mock_is_dir.return_value = True
+                        cmdhelper.ensure_mointpoint("/test/mount", ignore_error=False)
+                        mock_umount.assert_called_once()
+
+    def test_ensure_mountpoint_remove_symlink(self):
+        with mock.patch("pathlib.Path.is_symlink") as mock_is_symlink:
+            with mock.patch("pathlib.Path.unlink") as mock_unlink:
+                with mock.patch("pathlib.Path.exists") as mock_exists:
+                    with mock.patch("pathlib.Path.mkdir") as mock_mkdir:
+                        mock_is_symlink.return_value = True
+                        mock_exists.return_value = False
+                        cmdhelper.ensure_mointpoint("/test/mount", ignore_error=False)
+                        mock_unlink.assert_called_once_with(missing_ok=True)
+                        mock_mkdir.assert_called_once_with(exist_ok=True, parents=True)


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->
### Why
This issue was found in the dynamic client downloading test in Raspberry Pi.
In Raspberry Pi, for `flash-kernel`(to install dtb), some directories are binded in `Update` in chroot(dynamic client environment).
So these directories should be bind without `--make-unbindable` in initial bind(host).

### What
remove `--make-unbindable` option from `bind_mount_rw`.
Currently, this `bind_mount_rw` function is used only from the dynamic client package preparation.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [ ] test file that covers the bug case(s) is implemented.
- [x] local test is passed.

Verified that raspberry Pi update was succeeded in E2E test.

## Bug fix

### Current behavior
Fail to update Raspberry Pi in dynamic client.

### Behaivor after fix
Pass to update Raspberry Pi in dynamic client.

## Related links & ticket

<!-- List of tickets or links related to this PR -->
