### PR TITLE
fix: ensure standby device umounted before choort for dynamic client

### DIFF
--- a/src/otaclient/boot_control/_grub.py
+++ b/src/otaclient/boot_control/_grub.py
@@ -879,6 +879,13 @@ class GrubController(BootControllerProtocol):
         self._ota_status_control.on_failure()
         self._mp_control.umount_all(ignore_error=True)
 
+    def prepare_active_and_standby_slots(
+        self, *, base_mount_point: Optional[Path] = None, erase_standby=False
+    ):
+        self._mp_control.prepare_standby_dev(erase_standby=erase_standby)
+        self._mp_control.mount_standby(base_mount_point=base_mount_point)
+        self._mp_control.mount_active(base_mount_point=base_mount_point)
+
     def pre_update(self, version: str, *, standby_as_ref: bool, erase_standby=False):
         try:
             logger.info("grub_boot: pre-update setup...")
@@ -886,9 +893,7 @@ class GrubController(BootControllerProtocol):
             self._ota_status_control.pre_update_current()
 
             ### mount slots ###
-            self._mp_control.prepare_standby_dev(erase_standby=erase_standby)
-            self._mp_control.mount_standby()
-            self._mp_control.mount_active()
+            self.prepare_active_and_standby_slots(erase_standby=erase_standby)
 
             ### update standby slot's ota_status files ###
             self._ota_status_control.pre_update_standby(version=version)

--- a/src/otaclient/boot_control/_jetson_cboot.py
+++ b/src/otaclient/boot_control/_jetson_cboot.py
@@ -611,6 +611,13 @@ class JetsonCBootControl(BootControllerProtocol):
     def get_standby_slot_path(self) -> Path:  # pragma: no cover
         return self._mp_control.standby_slot_mount_point
 
+    def prepare_active_and_standby_slots(
+        self, *, base_mount_point: Optional[Path] = None, erase_standby=False
+    ):
+        self._mp_control.prepare_standby_dev(erase_standby=erase_standby)
+        self._mp_control.mount_standby(base_mount_point=base_mount_point)
+        self._mp_control.mount_active(base_mount_point=base_mount_point)
+
     def pre_update(self, version: str, *, standby_as_ref: bool, erase_standby: bool):
         try:
             logger.info("jetson-cboot: pre-update ...")
@@ -626,10 +633,7 @@ class JetsonCBootControl(BootControllerProtocol):
                 self._cboot_control.set_standby_rootfs_unbootable()
 
             # prepare standby slot dev
-            self._mp_control.prepare_standby_dev(erase_standby=erase_standby)
-            # mount slots
-            self._mp_control.mount_standby()
-            self._mp_control.mount_active()
+            self.prepare_active_and_standby_slots(erase_standby=erase_standby)
 
             # update standby slot's ota_status files
             self._ota_status_control.pre_update_standby(version=version)

--- a/src/otaclient/boot_control/_jetson_cboot.py
+++ b/src/otaclient/boot_control/_jetson_cboot.py
@@ -611,12 +611,8 @@ class JetsonCBootControl(BootControllerProtocol):
     def get_standby_slot_path(self) -> Path:  # pragma: no cover
         return self._mp_control.standby_slot_mount_point
 
-    def prepare_active_and_standby_slots(
-        self, *, base_mount_point: Optional[Path] = None, erase_standby=False
-    ):
-        self._mp_control.prepare_standby_dev(erase_standby=erase_standby)
-        self._mp_control.mount_standby(base_mount_point=base_mount_point)
-        self._mp_control.mount_active(base_mount_point=base_mount_point)
+    def get_standby_slot_dev(self) -> str:  # pragma: no cover
+        return self._mp_control.standby_slot_dev
 
     def pre_update(self, version: str, *, standby_as_ref: bool, erase_standby: bool):
         try:
@@ -633,7 +629,10 @@ class JetsonCBootControl(BootControllerProtocol):
                 self._cboot_control.set_standby_rootfs_unbootable()
 
             # prepare standby slot dev
-            self.prepare_active_and_standby_slots(erase_standby=erase_standby)
+            self._mp_control.prepare_standby_dev(erase_standby=erase_standby)
+            # mount slots
+            self._mp_control.mount_standby()
+            self._mp_control.mount_active()
 
             # update standby slot's ota_status files
             self._ota_status_control.pre_update_standby(version=version)

--- a/src/otaclient/boot_control/_jetson_uefi.py
+++ b/src/otaclient/boot_control/_jetson_uefi.py
@@ -26,7 +26,7 @@ import re
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, ClassVar, Generator, Literal, NoReturn
+from typing import Any, ClassVar, Generator, Literal, NoReturn, Optional
 
 from pydantic import BaseModel
 from typing_extensions import Self
@@ -975,14 +975,19 @@ class JetsonUEFIBootControl(BootControllerProtocol):
     def get_standby_slot_path(self) -> Path:  # pragma: no cover
         return self._mp_control.standby_slot_mount_point
 
+    def prepare_active_and_standby_slots(
+        self, *, base_mount_point: Optional[Path] = None, erase_standby=False
+    ):
+        self._mp_control.prepare_standby_dev(erase_standby=erase_standby)
+        self._mp_control.mount_standby(base_mount_point=base_mount_point)
+        self._mp_control.mount_active(base_mount_point=base_mount_point)
+
     def pre_update(self, version: str, *, standby_as_ref: bool, erase_standby: bool):
         try:
             logger.info("jetson-uefi: pre-update ...")
             self._ota_status_control.pre_update_current()
 
-            self._mp_control.prepare_standby_dev(erase_standby=erase_standby)
-            self._mp_control.mount_standby()
-            self._mp_control.mount_active()
+            self.prepare_active_and_standby_slots(erase_standby=erase_standby)
 
             self._ota_status_control.pre_update_standby(version=version)
         except Exception as e:

--- a/src/otaclient/boot_control/_jetson_uefi.py
+++ b/src/otaclient/boot_control/_jetson_uefi.py
@@ -26,7 +26,7 @@ import re
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, ClassVar, Generator, Literal, NoReturn, Optional
+from typing import Any, ClassVar, Generator, Literal, NoReturn
 
 from pydantic import BaseModel
 from typing_extensions import Self
@@ -975,19 +975,17 @@ class JetsonUEFIBootControl(BootControllerProtocol):
     def get_standby_slot_path(self) -> Path:  # pragma: no cover
         return self._mp_control.standby_slot_mount_point
 
-    def prepare_active_and_standby_slots(
-        self, *, base_mount_point: Optional[Path] = None, erase_standby=False
-    ):
-        self._mp_control.prepare_standby_dev(erase_standby=erase_standby)
-        self._mp_control.mount_standby(base_mount_point=base_mount_point)
-        self._mp_control.mount_active(base_mount_point=base_mount_point)
+    def get_standby_slot_dev(self) -> str:  # pragma: no cover
+        return self._mp_control.standby_slot_dev
 
     def pre_update(self, version: str, *, standby_as_ref: bool, erase_standby: bool):
         try:
             logger.info("jetson-uefi: pre-update ...")
             self._ota_status_control.pre_update_current()
 
-            self.prepare_active_and_standby_slots(erase_standby=erase_standby)
+            self._mp_control.prepare_standby_dev(erase_standby=erase_standby)
+            self._mp_control.mount_standby()
+            self._mp_control.mount_active()
 
             self._ota_status_control.pre_update_standby(version=version)
         except Exception as e:

--- a/src/otaclient/boot_control/_rpi_boot.py
+++ b/src/otaclient/boot_control/_rpi_boot.py
@@ -21,7 +21,7 @@ import os
 import subprocess
 from pathlib import Path
 from string import Template
-from typing import Any, Generator, Literal, NoReturn, Optional
+from typing import Any, Generator, Literal, NoReturn
 
 from typing_extensions import Self
 
@@ -484,15 +484,8 @@ class RPIBootController(BootControllerProtocol):
     def get_standby_slot_path(self) -> Path:  # pragma: no cover
         return self._mp_control.standby_slot_mount_point
 
-    def prepare_active_and_standby_slots(
-        self, *, base_mount_point: Optional[Path] = None, erase_standby=False
-    ):
-        self._mp_control.prepare_standby_dev(
-            erase_standby=erase_standby,
-            fslabel=self._rpiboot_control.standby_slot,
-        )
-        self._mp_control.mount_standby(base_mount_point=base_mount_point)
-        self._mp_control.mount_active(base_mount_point=base_mount_point)
+    def get_standby_slot_dev(self) -> str:  # pragma: no cover
+        return self._mp_control.standby_slot_dev
 
     def pre_update(self, version: str, *, standby_as_ref: bool, erase_standby: bool):
         try:
@@ -501,7 +494,12 @@ class RPIBootController(BootControllerProtocol):
             self._ota_status_control.pre_update_current()
 
             ### mount slots ###
-            self.prepare_active_and_standby_slots(erase_standby=erase_standby)
+            self._mp_control.prepare_standby_dev(
+                erase_standby=erase_standby,
+                fslabel=self._rpiboot_control.standby_slot,
+            )
+            self._mp_control.mount_standby()
+            self._mp_control.mount_active()
 
             ### update standby slot's ota_status files ###
             self._ota_status_control.pre_update_standby(version=version)

--- a/src/otaclient/boot_control/_slot_mnt_helper.py
+++ b/src/otaclient/boot_control/_slot_mnt_helper.py
@@ -21,6 +21,7 @@ import logging
 import shutil
 from functools import partial
 from pathlib import Path
+from typing import Optional
 
 from otaclient.configs.cfg import cfg
 from otaclient_common import _env, cmdhelper
@@ -47,15 +48,17 @@ class SlotMountHelper:  # pragma: no cover
         self.active_slot_mount_point = Path(active_slot_mount_point)
 
         # ensure the each mount points being umounted at termination
-        # if the dynamic client is running, active slot should be mounted before chroot
-        if not _env.is_dynamic_client_running():
-            atexit.register(
-                partial(
-                    cmdhelper.ensure_umount,
-                    self.active_slot_mount_point,
-                    ignore_error=True,
-                )
+        # if the dynamic client is running, both active and standby slots should be mounted before chroot
+        if _env.is_dynamic_client_running():
+            return
+
+        atexit.register(
+            partial(
+                cmdhelper.ensure_umount,
+                self.active_slot_mount_point,
+                ignore_error=True,
             )
+        )
         atexit.register(
             partial(
                 cmdhelper.ensure_umount,
@@ -65,24 +68,34 @@ class SlotMountHelper:  # pragma: no cover
             )
         )
 
-    def mount_standby(self) -> None:
+    def mount_standby(self, base_mount_point: Optional[Path] = None) -> None:
         """Mount standby slot dev rw to <standby_slot_mount_point>.
 
         Raises:
             CalledProcessedError on the last failed attemp.
         """
         logger.debug("mount standby slot rootfs dev...")
-        cmdhelper.ensure_mointpoint(self.standby_slot_mount_point, ignore_error=True)
+
+        # if the dynamic client is running, both active and standby slots should be mounted before chroot
+        if _env.is_dynamic_client_running():
+            return
+
+        _mount_point = (
+            base_mount_point / self.standby_slot_mount_point.relative_to("/")
+            if base_mount_point
+            else self.standby_slot_mount_point
+        )
+        cmdhelper.ensure_mointpoint(_mount_point, ignore_error=True)
         cmdhelper.ensure_umount(self.standby_slot_dev, ignore_error=False)
 
         cmdhelper.ensure_mount(
             target=self.standby_slot_dev,
-            mnt_point=self.standby_slot_mount_point,
+            mnt_point=_mount_point,
             mount_func=cmdhelper.mount_rw,
             raise_exception=True,
         )
 
-    def mount_active(self) -> None:
+    def mount_active(self, base_mount_point: Optional[Path] = None) -> None:
         """Mount current active rootfs ready-only.
 
         Raises:
@@ -90,14 +103,19 @@ class SlotMountHelper:  # pragma: no cover
         """
         logger.debug("mount active slot rootfs dev...")
 
-        # if the dynamic client is running, active slot should be mounted before chroot
+        # if the dynamic client is running, both active and standby slots should be mounted before chroot
         if _env.is_dynamic_client_running():
             return
 
-        cmdhelper.ensure_mointpoint(self.active_slot_mount_point, ignore_error=True)
+        _mount_point = (
+            base_mount_point / self.active_slot_mount_point.relative_to("/")
+            if base_mount_point
+            else self.active_slot_mount_point
+        )
+        cmdhelper.ensure_mointpoint(_mount_point, ignore_error=True)
         cmdhelper.ensure_mount(
             target=self.active_rootfs,
-            mnt_point=self.active_slot_mount_point,
+            mnt_point=_mount_point,
             mount_func=cmdhelper.bind_mount_ro,
             raise_exception=True,
         )
@@ -124,6 +142,10 @@ class SlotMountHelper:  # pragma: no cover
         erase_standby: bool = False,
         fslabel: str | None = None,
     ) -> None:
+        # if the dynamic client is running, both active and standby slots should be mounted before chroot
+        if _env.is_dynamic_client_running():
+            return
+
         cmdhelper.ensure_umount(self.standby_slot_dev, ignore_error=True)
         if erase_standby:
             return cmdhelper.mkfs_ext4(self.standby_slot_dev, fslabel=fslabel)
@@ -136,11 +158,11 @@ class SlotMountHelper:  # pragma: no cover
     def umount_all(self, *, ignore_error: bool = True):
         logger.debug("unmount standby slot and active slot mount point...")
 
-        # if the dynamic client is running, active slot should be mounted before chroot
-        if not _env.is_dynamic_client_running():
-            cmdhelper.ensure_umount(
-                self.active_slot_mount_point, ignore_error=ignore_error
-            )
+        # if the dynamic client is running, both active and standby slots should be mounted before chroot
+        if _env.is_dynamic_client_running():
+            return
+
+        cmdhelper.ensure_umount(self.active_slot_mount_point, ignore_error=ignore_error)
         cmdhelper.ensure_umount(
             self.standby_slot_mount_point, ignore_error=ignore_error
         )

--- a/src/otaclient/boot_control/protocol.py
+++ b/src/otaclient/boot_control/protocol.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from pathlib import Path
-from typing import Optional, Protocol
+from typing import Protocol
 
 from otaclient._types import OTAStatus
 
@@ -38,21 +38,16 @@ class BootControllerProtocol(Protocol):
         """Get the Path points to the standby slot mount point."""
 
     @abstractmethod
+    def get_standby_slot_dev(self) -> str:
+        """Get the dev to the standby slot."""
+
+    @abstractmethod
     def load_version(self) -> str:
         """Read the version info from the current slot."""
 
     @abstractmethod
     def on_operation_failure(self) -> None:
         """Cleanup by boot_control implementation when OTA failed."""
-
-    #
-    # ------ client update ------ #
-    #
-
-    @abstractmethod
-    def prepare_active_and_standby_slots(
-        self, *, base_mount_point: Optional[Path], erase_standby: bool
-    ): ...
 
     #
     # ------ update ------ #

--- a/src/otaclient/boot_control/protocol.py
+++ b/src/otaclient/boot_control/protocol.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from pathlib import Path
-from typing import Protocol
+from typing import Optional, Protocol
 
 from otaclient._types import OTAStatus
 
@@ -44,6 +44,15 @@ class BootControllerProtocol(Protocol):
     @abstractmethod
     def on_operation_failure(self) -> None:
         """Cleanup by boot_control implementation when OTA failed."""
+
+    #
+    # ------ client update ------ #
+    #
+
+    @abstractmethod
+    def prepare_active_and_standby_slots(
+        self, *, base_mount_point: Optional[Path], erase_standby: bool
+    ): ...
 
     #
     # ------ update ------ #

--- a/src/otaclient/main.py
+++ b/src/otaclient/main.py
@@ -118,6 +118,7 @@ def main() -> None:  # pragma: no cover
                 active_root=cfg.ACTIVE_ROOT,
                 active_slot_mnt_point=cfg.ACTIVE_SLOT_MNT,
                 host_root_mnt_point=cfg.DYNAMIC_CLIENT_MNT_HOST_ROOT,
+                bootloader=ecu_info.bootloader,
             )
             client_package_prepareter.mount_client_package()
 

--- a/tests/test_otaclient/test_client_package.py
+++ b/tests/test_otaclient/test_client_package.py
@@ -24,8 +24,8 @@ from typing import Optional
 from unittest.mock import MagicMock, PropertyMock, mock_open, patch
 
 import pytest
-
 from _otaclient_version import __version__
+
 from otaclient.client_package import (
     Manifest,
     OTAClientPackageDownloader,

--- a/tests/test_otaclient/test_client_package.py
+++ b/tests/test_otaclient/test_client_package.py
@@ -24,8 +24,8 @@ from typing import Optional
 from unittest.mock import MagicMock, PropertyMock, mock_open, patch
 
 import pytest
-from _otaclient_version import __version__
 
+from _otaclient_version import __version__
 from otaclient.client_package import (
     Manifest,
     OTAClientPackageDownloader,
@@ -443,6 +443,7 @@ class TestClientPackagePrepareter:
             active_root=self.DUMMY_ACTIVE_ROOT,
             active_slot_mnt_point=self.DUMMY_ACTIVE_SLOT_MNT_POINT,
             host_root_mnt_point=self.DUMMY_HOST_ROOT_MNT_POINT,
+            bootloader=MagicMock(),
         )
 
     @patch("otaclient.client_package.cmdhelper.ensure_mointpoint")


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->
### Why
This issue was found in the dynamic client downloading test in Raspberry Pi.
In `Update`, standby slot is requested to do 1.unmount, 2.erase then 3.mount dynamically.
In Raspberry Pi, unmount and erase(`mkfs.ext4`) is failed in chroot(dynamic client) environment because the standby slot has already been mounted in host process.

### What
unmount the standby device before unshare in host system.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [ ] test file that covers the bug case(s) is implemented.
- [x] local test is passed.

The existing tests covers new function tests.
In addition, confirmed that E2E tests are passed in VM, Roscube and Raspberry Pi.

## Bug fix

### Current behavior
Fail to Update in Raspberry Pi in dynamic client

### Behaivor after fix
Pass to Update in Raspberry Pi in dynamic client

## Related links & ticket

<!-- List of tickets or links related to this PR -->
