### PR TITLE
fix: resolve resource tracker warning before execve

### DIFF
--- a/src/otaclient/main.py
+++ b/src/otaclient/main.py
@@ -253,6 +253,13 @@ def main() -> None:  # pragma: no cover
                 logger.info("cleaning up resources ...")
                 if _shm:
                     del _shm
+                if ecu_status_flags:
+                    del ecu_status_flags.any_child_ecu_in_update
+                    del ecu_status_flags.any_requires_network
+                    del ecu_status_flags.all_success
+                if client_update_control_flags:
+                    del client_update_control_flags.notify_data_ready_event
+                    del client_update_control_flags.request_shutdown_event
                 if local_otaclient_op_queue:
                     del local_otaclient_op_queue
                 if local_otaclient_resp_queue:


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->
### Why
Some resource leak is detected by resource tracker before `execve`.

### What
delete resource and ensure that resource tracker doesn't output warning.
- before
```
Jun 20 15:16:55 autoware-ecu python3[448478]: [2025-06-20 15:16:55,699][INFO]-otaclient.main:main:250,on main shutdown...
Jun 20 15:16:55 autoware-ecu python3[448478]: [2025-06-20 15:16:55,711][INFO]-otaclient.main:main:253,cleaning up resources ...
Jun 20 15:16:55 autoware-ecu python3[448478]: [2025-06-20 15:16:55,711][INFO]-otaclient.main:main:271,stopping resource tracker ...
Jun 20 15:16:55 autoware-ecu python3[448505]: /usr/lib/python3.10/multiprocessing/resource_tracker.py:224: UserWarning: resource_tracker: There appear to be 31 leaked semaphore objects to clean up at shutdown
Jun 20 15:16:55 autoware-ecu python3[448505]:   warnings.warn('resource_tracker: There appear to be %d '
Jun 20 15:16:55 autoware-ecu python3[448478]: [2025-06-20 15:16:55,718][INFO]-otaclient.main:main:281,execve for dynamic client preparation ...
Jun 20 15:16:55 autoware-ecu python3[448478]: [2025-06-20 15:16:55,978][INFO]-otaclient.main:main:98,started
```

- after
```
Jun 20 15:42:26 autoware-ecu python3[645845]: [2025-06-20 15:42:26,447][INFO]-otaclient.main:main:250,on main shutdown...
Jun 20 15:42:26 autoware-ecu python3[645845]: [2025-06-20 15:42:26,456][INFO]-otaclient.main:main:253,cleaning up resources ...
Jun 20 15:42:26 autoware-ecu python3[645845]: [2025-06-20 15:42:26,457][INFO]-otaclient.main:main:271,stopping resource tracker ...
Jun 20 15:42:26 autoware-ecu python3[645845]: [2025-06-20 15:42:26,461][INFO]-otaclient.main:main:281,execve for dynamic client preparation ...
Jun 20 15:42:26 autoware-ecu python3[645845]: [2025-06-20 15:42:26,807][INFO]-otaclient.main:main:98,started
```

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [ ] test file that covers the bug case(s) is implemented.
- [x] local test is passed.

## Bug fix

### Current behavior
resource leak is occurred.

### Behaivor after fix
removed resource leak.

## Related links & ticket

<!-- List of tickets or links related to this PR -->
