### PR TITLE
[backport v3.9] chore: support pre-release identification in squashfs filename

### DIFF
--- a/.github/actions/generate_manifest/generate_manifest.py
+++ b/.github/actions/generate_manifest/generate_manifest.py
@@ -57,12 +57,17 @@ def generate_manifest(input_dir: str):
             file_type = "squashfs" if file.endswith(".squashfs") else "patch"
             if file_type == "squashfs":
                 # squashfs file name format: otaclient-${architecture}-v${version}.squashfs
-                match = re.search(r"v(\d+\.\d+(?:\.\d+)?)", file)
+                # Supports pre-release versions like: v0.1.dev1, v3.10.0rc1, etc.
+                match = re.search(r"v(\d+\.\d+(?:\.\d+)?(?:\.[a-zA-Z0-9]+)?)", file)
                 _base_version = None
                 version = match.group(1) if match else "unknown"
             else:
                 # patch file name format: otaclient-${architecture}_v${BASE_VERSION}-v${VERSION}.patch
-                match = re.search(r"v(\d+\.\d+(?:\.\d+)?)-v(\d+\.\d+(?:\.\d+)?)", file)
+                # Supports pre-release versions in both base and target versions
+                match = re.search(
+                    r"v(\d+\.\d+(?:\.\d+)?(?:\.[a-zA-Z0-9]+)?)-v(\d+\.\d+(?:\.\d+)?(?:\.[a-zA-Z0-9]+)?)",
+                    file,
+                )
                 _base_version = match.group(1) if match else "unknown"
                 version = match.group(2) if match else "unknown"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,8 @@ jobs:
         id: set_env
         run: |
           OTACLIENT_WHL=$(basename $(ls dist/otaclient-*.whl))
-          OTACLIENT_VERSION=$(hatch version | sed -E 's/([0-9]+\.[0-9]+(\.[0-9]+)?).*/\1/')
+          # Remove everything after '+' to clean Git metadata
+          OTACLIENT_VERSION=$(hatch version | cut -d'+' -f1)
           echo OTACLIENT_WHL=${OTACLIENT_WHL} >> $GITHUB_OUTPUT
           echo OTACLIENT_VERSION=${OTACLIENT_VERSION} >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
The backport of https://github.com/tier4/ota-client/pull/573
### Why
squashfs filename doesn't include pre-release identification like `dev1`, `rc1`.

### What
support to include pre-release identification into squashfs filename and version in `manifest.json`

### Test
trigger test Release CI and verified.
https://github.com/tier4/ota-client/actions/runs/15777102055
- filename
  - `otaclient-x86_64-v0.1.dev1.squashfs`
  -  `otaclient-arm64-v0.1.dev1.squashfs`
- manifest.json
```
{
    "schema_version": "1",
    "date": "2025-06-20T10:46:23.526347Z",
    "packages": [
        {
            "filename": "otaclient-x86_64-v0.1.dev1.squashfs",
            "version": "0.1.dev1",
            "type": "squashfs",
            "architecture": "x86_64",
            "size": 71049216,
            "checksum": "sha256:327fb2190a4829d888253c88f536dfe13a0d8fec33eac76b8bae14e35da2d7b4"
        },
        {
            "filename": "otaclient-arm64-v0.1.dev1.squashfs",
            "version": "0.1.dev1",
            "type": "squashfs",
            "architecture": "arm64",
            "size": 67743744,
            "checksum": "sha256:0e9ef22d14be6dbfbb112745fc2a6b4792ce21993bc60f9f675fbded72a8337e"
        }
    ]
}
```