### PR TITLE
fix: restart otaclient when client update is failed

### DIFF
--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -1208,9 +1208,9 @@ class OTAClient:
             ).execute()
         except ota_errors.OTAError:
             # TODO(airkei) [2025-06-19]: should return the dedicated error code for "client update"
-            self._exit_from_dynamic_client()
+            self._client_update_control_flags.request_shutdown_event.set()
         except Exception:
-            self._exit_from_dynamic_client()
+            self._client_update_control_flags.request_shutdown_event.set()
 
     def rollback(self, request: RollbackRequestV2) -> None:
         self._live_ota_status = OTAStatus.ROLLBACKING

--- a/tests/test_otaclient/test_ota_core.py
+++ b/tests/test_otaclient/test_ota_core.py
@@ -268,15 +268,14 @@ class TestOTAClient:
         """Test client update with interruption."""
         from otaclient._types import ClientUpdateRequestV2
 
-        mock_exit_from_dynamic_client = mocker.patch.object(
-            self.ota_client, "_exit_from_dynamic_client"
-        )
-
         # inject exception
         _error = OTAErrorRecoverable(
             "client update interrupted by test as expected", module=__name__
         )
         self.ota_client_updater.execute.side_effect = _error
+        self.ota_client._client_update_control_flags.request_shutdown_event.set = (
+            mocker.MagicMock()
+        )
 
         # --- execution --- #
         self.ota_client.client_update(
@@ -291,8 +290,8 @@ class TestOTAClient:
         # --- assertion on interrupted client update --- #
         self.ota_client_updater.execute.assert_called_once()
 
-        # Verify that _exit_from_dynamic_client was called
-        mock_exit_from_dynamic_client.assert_called_once()
+        # Verify that request_shutdown_event was set
+        self.ota_client._client_update_control_flags.request_shutdown_event.set.assert_called_once()
 
 
 class TestOTAClientUpdater:


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->

### Why
This issue was found in pre-QA tests of WebAutoAgent.
When otaclient met errors in `ClientUpdate`, the expected behavior is to restart the process.
Currently, when there is an error, restart doesn't happen.

### What
restart when client update is failed.


## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file that covers the bug case(s) is implemented.
- [x] local test is passed.

Verified the actual behavior in E2E tests.

## Bug fix

### Current behavior
otaclient doesn't restart when `ClientUpdate` is failed.

### Behaivor after fix
restart otaclient when `ClientUpdate` is failed.

## Related links & ticket

<!-- List of tickets or links related to this PR -->
