### PR TITLE
dep: update protobuf version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "multidict<7.0,>=4.5",
   "msgpack>=1,<1.2",
   "otaclient_iot_logging_server_pb2 @ https://github.com/tier4/otaclient-iot-logging-server/releases/download/v1.3.0/otaclient_iot_logging_server_pb2-1.0.0-py3-none-any.whl#sha256:e5a2e6474a8b6f5656679877a5df40891e6a65c29830a31faed3d47d9973be60",
-  "protobuf>=4.21.12,<6.32",
+  "protobuf>=4.25.8,<6.32",
   "pydantic<3,>=2.10",
   "pydantic-settings<3,>=2.3",
   "pyyaml<7,>=6.0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1648,7 +1648,7 @@ requires-dist = [
     { name = "msgpack", specifier = ">=1,<1.2" },
     { name = "multidict", specifier = ">=4.5,<7.0" },
     { name = "otaclient-iot-logging-server-pb2", url = "https://github.com/tier4/otaclient-iot-logging-server/releases/download/v1.3.0/otaclient_iot_logging_server_pb2-1.0.0-py3-none-any.whl" },
-    { name = "protobuf", specifier = ">=4.21.12,<6.32" },
+    { name = "protobuf", specifier = ">=4.25.8,<6.32" },
     { name = "pydantic", specifier = ">=2.10,<3" },
     { name = "pydantic-settings", specifier = ">=2.3,<3" },
     { name = "pyyaml", specifier = ">=6.0.1,<7" },


### PR DESCRIPTION
### Why
https://tier4.atlassian.net/browse/RT4-17728
https://security.snyk.io/vuln/SNYK-PYTHON-PROTOBUF-10364902

Sync requests to update protobuf to 4.25.8 or higher.

### What
set minimum version as 4.25.8

### Test
- Fixed version to 4.25.8 in test build, then verified the actual behavior in VM and Roscube.
- Confirmed that there is no breaking changes in Python between 4.21.12 and 4.25.8 in change log.