### PR TITLE
[3.9] feat: mount tmpfs as OTA update session workdir

### DIFF
--- a/src/otaclient/_utils.py
+++ b/src/otaclient/_utils.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import itertools
 import logging
 import os
+import re
 import sys
 import time
 import traceback
@@ -86,6 +87,8 @@ class SharedOTAClientStatusReader(MPSharedStatusReader[OTAClientStatus]):
 
 SESSION_RANDOM_LEN = 4  # bytes, the corresponding hex string will be 8 chars
 
+_illegal_chars_pattern = re.compile(r'[\/\0<>:"\\|?*\x00-\x1F]')
+
 
 def gen_session_id(
     update_version: str, *, random_bytes_num: int = SESSION_RANDOM_LEN
@@ -95,7 +98,8 @@ def gen_session_id(
     token schema:
         <update_version>-<unix_timestamp_in_sec_str>-<4bytes_hex>
     """
+    sanitized_version_str = _illegal_chars_pattern.sub("_", update_version)
     _time_factor = str(int(time.time()))
     _random_factor = os.urandom(random_bytes_num).hex()
 
-    return f"{update_version}-{_time_factor}-{_random_factor}"
+    return f"{sanitized_version_str}-{_time_factor}-{_random_factor}"

--- a/src/otaclient/_utils.py
+++ b/src/otaclient/_utils.py
@@ -87,7 +87,7 @@ class SharedOTAClientStatusReader(MPSharedStatusReader[OTAClientStatus]):
 
 SESSION_RANDOM_LEN = 4  # bytes, the corresponding hex string will be 8 chars
 
-_illegal_chars_pattern = re.compile(r'[\/\0<>:"\\|?*\x00-\x1F]')
+_illegal_chars_pattern = re.compile(r'[\.\/\0<>:"\\|?*\x00-\x1F]')
 
 
 def gen_session_id(
@@ -102,4 +102,4 @@ def gen_session_id(
     _time_factor = str(int(time.time()))
     _random_factor = os.urandom(random_bytes_num).hex()
 
-    return f"{sanitized_version_str}-{_time_factor}-{_random_factor}"
+    return f"{_time_factor}-{sanitized_version_str}-{_random_factor}"

--- a/src/otaclient/_utils.py
+++ b/src/otaclient/_utils.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Common shared utils, only used by otaclient package."""
 
-
 from __future__ import annotations
 
 import itertools
@@ -70,15 +69,6 @@ def check_other_otaclient(pid_fpath: StrOrPath) -> None:  # pragma: no cover
         logger.warning(f"dangling otaclient lock file({pid=}) detected, cleanup")
         pid_fpath.unlink(missing_ok=True)
     write_str_to_file_atomic(pid_fpath, f"{os.getpid()}")
-
-
-def create_otaclient_rundir(run_dir: StrOrPath = "/run/otaclient") -> None:
-    """Create the otaclient runtime working dir.
-
-    TODO: make a helper class for managing otaclient runtime dir.
-    """
-    run_dir = Path(run_dir)
-    run_dir.mkdir(exist_ok=True, parents=True)
 
 
 def get_traceback(exc: Exception, *, splitter: str = "\n") -> str:  # pragma: no cover

--- a/src/otaclient/configs/_cfg_configurable.py
+++ b/src/otaclient/configs/_cfg_configurable.py
@@ -30,6 +30,9 @@ LOG_LEVEL_LITERAL = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
 
 class _OTAClientSettings(BaseModel):
+    # ------ OTA session setting ------ #
+    SESSION_WD_TMPFS_SIZE_IN_MB: int = 700  # MB
+
     #
     # ------ logging settings ------ #
     #

--- a/src/otaclient/configs/_cfg_consts.py
+++ b/src/otaclient/configs/_cfg_consts.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """otaclient internal uses consts, should not be changed from external."""
 
-
 from __future__ import annotations
 
 from otaclient_common import replace_root
@@ -29,7 +28,6 @@ class CreateStandbyMechanism(StrEnum):
 
 
 class Consts:
-
     CANONICAL_ROOT = CANONICAL_ROOT
 
     @property
@@ -43,7 +41,7 @@ class Consts:
     OTACLIENT_PID_FILE = "/run/otaclient.pid"
 
     # runtime folder for holding ota related files
-    RUNTIME_OTA_SESSION = "/run/otaclient/ota"
+    RUNTIME_OTA_SESSION = "/run/otaclient/update-session"
 
     MOUNT_SPACE = "/run/otaclient/mnt"
     ACTIVE_SLOT_MNT = "/run/otaclient/mnt/active_slot"

--- a/src/otaclient/main.py
+++ b/src/otaclient/main.py
@@ -30,6 +30,8 @@ from functools import partial
 from otaclient import __version__
 from otaclient._types import MultipleECUStatusFlags
 from otaclient._utils import SharedOTAClientStatusReader, SharedOTAClientStatusWriter
+from otaclient.configs.cfg import cfg
+from otaclient_common.cmdhelper import ensure_umount
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +69,12 @@ def _on_shutdown(sys_exit: bool = False) -> None:  # pragma: no cover
         _shm = None
 
     if sys_exit:
+        logger.warning(
+            "otaclient will exit now, unconditionally umount all mount points ..."
+        )
+        ensure_umount(cfg.RUNTIME_OTA_SESSION, ignore_error=True, max_retry=2)
+        ensure_umount(cfg.ACTIVE_SLOT_MNT, ignore_error=True, max_retry=2)
+        ensure_umount(cfg.STANDBY_SLOT_MNT, ignore_error=True, max_retry=2)
         sys.exit(1)
 
 

--- a/src/otaclient/main.py
+++ b/src/otaclient/main.py
@@ -69,13 +69,15 @@ def _on_shutdown(sys_exit: bool = False) -> None:  # pragma: no cover
         _shm = None
 
     if sys_exit:
-        logger.warning(
-            "otaclient will exit now, unconditionally umount all mount points ..."
-        )
-        ensure_umount(cfg.RUNTIME_OTA_SESSION, ignore_error=True, max_retry=2)
-        ensure_umount(cfg.ACTIVE_SLOT_MNT, ignore_error=True, max_retry=2)
-        ensure_umount(cfg.STANDBY_SLOT_MNT, ignore_error=True, max_retry=2)
-        sys.exit(1)
+        try:
+            logger.warning(
+                "otaclient will exit now, unconditionally umount all mount points ..."
+            )
+            ensure_umount(cfg.RUNTIME_OTA_SESSION, ignore_error=True, max_retry=2)
+            ensure_umount(cfg.ACTIVE_SLOT_MNT, ignore_error=True, max_retry=2)
+            ensure_umount(cfg.STANDBY_SLOT_MNT, ignore_error=True, max_retry=2)
+        finally:
+            sys.exit(1)
 
 
 def _signal_handler(signal_value, _) -> None:  # pragma: no cover

--- a/src/otaclient/main.py
+++ b/src/otaclient/main.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Entrypoint of otaclient."""
 
-
 from __future__ import annotations
 
 import atexit
@@ -80,7 +79,7 @@ def _signal_handler(signal_value, _) -> None:  # pragma: no cover
 def main() -> None:  # pragma: no cover
     from otaclient._logging import configure_logging
     from otaclient._otaproxy_ctx import otaproxy_control_thread
-    from otaclient._utils import check_other_otaclient, create_otaclient_rundir
+    from otaclient._utils import check_other_otaclient
     from otaclient.configs.cfg import cfg, ecu_info, proxy_info
     from otaclient.grpc.api_v2.main import grpc_server_process
     from otaclient.ota_core import ota_core_process
@@ -94,7 +93,6 @@ def main() -> None:  # pragma: no cover
     logger.info(f"proxy_info.yaml: \n{proxy_info}")
 
     check_other_otaclient(cfg.OTACLIENT_PID_FILE)
-    create_otaclient_rundir(cfg.RUN_DIR)
 
     #
     # ------ start each processes ------ #

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -845,6 +845,8 @@ class OTAClient:
         self._runtime_dir = _runtime_dir = Path(cfg.RUN_DIR)
         _runtime_dir.mkdir(exist_ok=True, parents=True)
         self._update_session_dir = _update_session_dir = Path(cfg.RUNTIME_OTA_SESSION)
+
+        ensure_umount(_update_session_dir, ignore_error=True)
         _update_session_dir.mkdir(exist_ok=True, parents=True)
 
         # NOTE: for each otaclient instance lifecycle, only one tmpfs will be mounted.

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -68,7 +68,11 @@ from otaclient._types import (
     UpdatePhase,
     UpdateRequestV2,
 )
-from otaclient._utils import SharedOTAClientStatusWriter, get_traceback, wait_and_log
+from otaclient._utils import (
+    SharedOTAClientStatusWriter,
+    get_traceback,
+    wait_and_log,
+)
 from otaclient.boot_control import BootControllerProtocol, get_boot_controller
 from otaclient.configs.cfg import cfg, ecu_info, proxy_info
 from otaclient.create_standby import (
@@ -81,6 +85,7 @@ from otaclient.create_standby import (
 )
 from otaclient.create_standby.delta_gen import DeltaGenParams
 from otaclient_common import EMPTY_FILE_SHA256, human_readable_size, replace_root
+from otaclient_common.cmdhelper import ensure_umount, mount_tmpfs
 from otaclient_common.common import ensure_otaproxy_start
 from otaclient_common.downloader import (
     Downloader,
@@ -177,6 +182,7 @@ class _OTAUpdater:
         version: str,
         raw_url_base: str,
         cookies_json: str,
+        session_wd: Path,
         ca_chains_store: CAChainStore,
         upper_otaproxy: str | None = None,
         boot_controller: BootControllerProtocol,
@@ -188,6 +194,11 @@ class _OTAUpdater:
         self.update_start_timestamp = int(time.time())
         self.session_id = session_id
         self._status_report_queue = status_report_queue
+
+        # ------ mount session wd as a tmpfs ------ #
+        self._session_workdir = session_wd
+        session_wd.mkdir(exist_ok=True, parents=True)
+        mount_tmpfs(session_wd, cfg.SESSION_WD_TMPFS_SIZE_IN_MB)
 
         # ------ init updater implementation ------ #
         self.ecu_status_flags = ecu_status_flags
@@ -228,19 +239,13 @@ class _OTAUpdater:
             )
         )
 
-        # TODO: use a tmpfs mount with 320MB in size for session workdir
-        self._session_workdir = session_wd = (
-            Path(cfg.RUN_DIR) / f"update_session-{session_id}"
-        )
-        session_wd.mkdir(exist_ok=True, parents=True)
-
         # ------ parse cookies ------ #
         logger.debug("process cookies_json...")
         try:
             cookies = json.loads(cookies_json)
-            assert isinstance(
-                cookies, dict
-            ), f"invalid cookies, expecting json object: {cookies_json}"
+            assert isinstance(cookies, dict), (
+                f"invalid cookies, expecting json object: {cookies_json}"
+            )
         except (JSONDecodeError, AssertionError) as e:
             _err_msg = f"cookie is invalid: {cookies_json=}"
             logger.error(_err_msg)
@@ -803,6 +808,7 @@ class _OTAUpdater:
             self._boot_controller.on_operation_failure()
             raise ota_errors.ApplyOTAUpdateFailed(_err_msg, module=__name__) from e
         finally:
+            ensure_umount(self._session_workdir, ignore_error=True)
             shutil.rmtree(self._session_workdir, ignore_errors=True)
 
 
@@ -837,6 +843,10 @@ class OTAClient:
         self._live_ota_status = OTAStatus.INITIALIZED
         self.started = False
 
+        self._runtime_dir = _runtime_dir = Path(cfg.RUN_DIR)
+        _runtime_dir.mkdir(exist_ok=True, parents=True)
+        self._update_session_dir = _update_session_dir = Path(cfg.RUNTIME_OTA_SESSION)
+        _update_session_dir.mkdir(exist_ok=True, parents=True)
         try:
             _boot_controller_type = get_boot_controller(ecu_info.bootloader)
         except Exception as e:
@@ -945,6 +955,7 @@ class OTAClient:
         )
         logger.info(f"start new OTA update session: {new_session_id=}")
 
+        session_wd = self._update_session_dir / f"update_session-{new_session_id}"
         try:
             logger.info("[update] entering local update...")
             if not self.ca_chains_store:
@@ -957,6 +968,7 @@ class OTAClient:
                 version=request.version,
                 raw_url_base=request.url_base,
                 cookies_json=request.cookies_json,
+                session_wd=session_wd,
                 ca_chains_store=self.ca_chains_store,
                 boot_controller=self.boot_controller,
                 ecu_status_flags=self.ecu_status_flags,

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -956,7 +956,7 @@ class OTAClient:
         )
         logger.info(f"start new OTA update session: {new_session_id=}")
 
-        session_wd = self._update_session_dir / f"update_session-{new_session_id}"
+        session_wd = self._update_session_dir / new_session_id
         try:
             logger.info("[update] entering local update...")
             if not self.ca_chains_store:
@@ -985,6 +985,8 @@ class OTAClient:
                 failure_reason=e.get_failure_reason(),
                 failure_type=e.failure_type,
             )
+        finally:
+            shutil.rmtree(session_wd, ignore_errors=True)
 
     def rollback(self, request: RollbackRequestV2) -> None:
         self._live_ota_status = OTAStatus.ROLLBACKING

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -851,12 +851,19 @@ class OTAClient:
         #       If otaclient exits on successful OTA, no need to umount it manually as we will reboot soon.
         ensure_umount(_update_session_dir, ignore_error=True)
         _update_session_dir.mkdir(exist_ok=True, parents=True)
-        ensure_mount(
-            "tmpfs",
-            _update_session_dir,
-            mount_func=partial(mount_tmpfs, size_in_mb=cfg.SESSION_WD_TMPFS_SIZE_IN_MB),
-            raise_exception=False,
-        )
+        try:
+            ensure_mount(
+                "tmpfs",
+                _update_session_dir,
+                mount_func=partial(
+                    mount_tmpfs, size_in_mb=cfg.SESSION_WD_TMPFS_SIZE_IN_MB
+                ),
+                raise_exception=True,
+            )
+        except Exception as e:
+            logger.warning(f"failed to mount tmpfs for OTA runtime use: {e!r}")
+            logger.warning("will directly use /run tmpfs for OTA runtime!")
+
         try:
             _boot_controller_type = get_boot_controller(ecu_info.bootloader)
         except Exception as e:

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -242,9 +242,9 @@ class _OTAUpdater:
         logger.debug("process cookies_json...")
         try:
             cookies = json.loads(cookies_json)
-            assert isinstance(cookies, dict), (
-                f"invalid cookies, expecting json object: {cookies_json}"
-            )
+            assert isinstance(
+                cookies, dict
+            ), f"invalid cookies, expecting json object: {cookies_json}"
         except (JSONDecodeError, AssertionError) as e:
             _err_msg = f"cookie is invalid: {cookies_json=}"
             logger.error(_err_msg)

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -242,9 +242,9 @@ class _OTAUpdater:
         logger.debug("process cookies_json...")
         try:
             cookies = json.loads(cookies_json)
-            assert isinstance(
-                cookies, dict
-            ), f"invalid cookies, expecting json object: {cookies_json}"
+            assert isinstance(cookies, dict), (
+                f"invalid cookies, expecting json object: {cookies_json}"
+            )
         except (JSONDecodeError, AssertionError) as e:
             _err_msg = f"cookie is invalid: {cookies_json=}"
             logger.error(_err_msg)
@@ -846,6 +846,10 @@ class OTAClient:
         _runtime_dir.mkdir(exist_ok=True, parents=True)
         self._update_session_dir = _update_session_dir = Path(cfg.RUNTIME_OTA_SESSION)
         _update_session_dir.mkdir(exist_ok=True, parents=True)
+
+        # NOTE: for each otaclient instance lifecycle, only one tmpfs will be mounted.
+        #       If otaclient terminates by signal, umounting will be handled by _on_shutdown.
+        #       If otaclient exits on successful OTA, no need to umount it manually as we will reboot soon.
         mount_tmpfs(_update_session_dir, cfg.SESSION_WD_TMPFS_SIZE_IN_MB)
 
         try:

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -198,7 +198,6 @@ class _OTAUpdater:
         # ------ mount session wd as a tmpfs ------ #
         self._session_workdir = session_wd
         session_wd.mkdir(exist_ok=True, parents=True)
-        mount_tmpfs(session_wd, cfg.SESSION_WD_TMPFS_SIZE_IN_MB)
 
         # ------ init updater implementation ------ #
         self.ecu_status_flags = ecu_status_flags
@@ -847,6 +846,8 @@ class OTAClient:
         _runtime_dir.mkdir(exist_ok=True, parents=True)
         self._update_session_dir = _update_session_dir = Path(cfg.RUNTIME_OTA_SESSION)
         _update_session_dir.mkdir(exist_ok=True, parents=True)
+        mount_tmpfs(_update_session_dir, cfg.SESSION_WD_TMPFS_SIZE_IN_MB)
+
         try:
             _boot_controller_type = get_boot_controller(ecu_info.bootloader)
         except Exception as e:

--- a/src/otaclient_common/cmdhelper.py
+++ b/src/otaclient_common/cmdhelper.py
@@ -21,6 +21,7 @@ When underlying subprocess call failed and <raise_exception> is True,
 from __future__ import annotations
 
 import logging
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -588,3 +589,17 @@ def ensure_mointpoint(
                 f"But still use {mnt_point} and override the previous mount"
             )
         )
+
+
+def mount_tmpfs(mnt_point: StrOrPath, size_in_mb: int) -> None:
+    # fmt: off
+    cmd = [
+        "mount", "-t", "tmpfs",
+        "-o", f"size={size_in_mb}M", "tmpfs", str(mnt_point)
+    ]
+    # fmt: on
+    try:
+        subprocess_call(cmd, raise_exception=True)
+    except subprocess.CalledProcessError as e:
+        logger.error(f"failed to mount tmpfs with {size_in_mb}MB at {mnt_point}: {e!r}")
+        raise

--- a/src/otaclient_common/cmdhelper.py
+++ b/src/otaclient_common/cmdhelper.py
@@ -26,7 +26,7 @@ import sys
 import time
 from pathlib import Path
 from subprocess import CalledProcessError
-from typing import Literal, NoReturn, Protocol
+from typing import Any, Literal, NoReturn, Protocol
 
 from otaclient_common._typing import StrOrPath
 from otaclient_common.common import subprocess_call, subprocess_check_output
@@ -591,15 +591,24 @@ def ensure_mointpoint(
         )
 
 
-def mount_tmpfs(mnt_point: StrOrPath, size_in_mb: int) -> None:  # pragma: no cover
+def mount_tmpfs(
+    target: Any,
+    mount_point: StrOrPath,
+    *,
+    size_in_mb: int,
+    raise_exception: bool = True,
+) -> None:  # pragma: no cover
     # fmt: off
     cmd = [
         "mount", "-t", "tmpfs",
-        "-o", f"size={size_in_mb}M", "tmpfs", str(mnt_point)
+        "-o", f"size={size_in_mb}M", "tmpfs", str(mount_point)
     ]
     # fmt: on
     try:
         subprocess_call(cmd, raise_exception=True)
     except subprocess.CalledProcessError as e:
-        logger.error(f"failed to mount tmpfs with {size_in_mb}MB at {mnt_point}: {e!r}")
-        raise
+        logger.error(
+            f"failed to mount tmpfs with {size_in_mb}MB at {mount_point}: {e!r}"
+        )
+        if raise_exception:
+            raise

--- a/src/otaclient_common/cmdhelper.py
+++ b/src/otaclient_common/cmdhelper.py
@@ -591,7 +591,7 @@ def ensure_mointpoint(
         )
 
 
-def mount_tmpfs(mnt_point: StrOrPath, size_in_mb: int) -> None:
+def mount_tmpfs(mnt_point: StrOrPath, size_in_mb: int) -> None:  # pragma: no cover
     # fmt: off
     cmd = [
         "mount", "-t", "tmpfs",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -295,8 +295,8 @@ def ota_status_collector(
 
 
 @pytest.fixture(autouse=True)
-def mock_mount_tmpfs(mocker: pytest_mock.MockerFixture) -> None:
-    mocker.patch("otaclient.ota_core.mount_tmpfs")
+def mock_ensure_mount(mocker: pytest_mock.MockerFixture) -> None:
+    mocker.patch("otaclient.ota_core.ensure_mount")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -297,3 +297,8 @@ def ota_status_collector(
 @pytest.fixture(autouse=True)
 def mock_mount_tmpfs(mocker: pytest_mock.MockerFixture) -> None:
     mocker.patch("otaclient.ota_core.mount_tmpfs")
+
+
+@pytest.fixture(autouse=True)
+def mock_ensure_umount(mocker: pytest_mock.MockerFixture) -> None:
+    mocker.patch("otaclient.ota_core.ensure_umount")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -292,3 +292,8 @@ def ota_status_collector(
     finally:
         _report_queue.put_nowait(TERMINATE_SENTINEL)
         _collector_thread.join()
+
+
+@pytest.fixture(autouse=True)
+def mock_mount_tmpfs(mocker: pytest_mock.MockerFixture) -> None:
+    mocker.patch("otaclient.ota_core.mount_tmpfs")


### PR DESCRIPTION
## Motivation

> [!NOTE]
> tmpfs is thin-provision, the size of tmpfs is the maximum allowed memory used for this mount, the actual memory usage depending on the size sum of all files currently in the tmpfs mount. 

Currently, otaclient uses `/run/otaclient` as runtime dir for holding files used during OTA(OTA image metadata, etc.).
`/run` dir is system scope shared tmpfs, typically it will have maximum size of 10% of actual memory(i.e., for a system with 8G memory, it will have 800MB tmpfs mount at `/run`).

To avoid using too much space of system scope shared `/run`, this PR introduces to use dedicated tmpfs only OTA update.

## Introduction

This PR implements mounting a maximum 700MB tmpfs as OTA session workdir(at `/run/otaclient/update-session`) before actually starting to handle accepted OTA request, storing OTA image metadata used during OTA update, including file_table database, etc.

Also, this PR fixes an issue of slot mount points cannot be umount if otaclient is terminated by signals. Now after ota_core exits, main daemon process will unconditionally call `ensure_umount` on active/standby slots mount points and OTA update session tmpfs mountpoint. 