### PR TITLE
[3.9] feat: introduce OTA resume on inplace update mode

### DIFF
--- a/src/otaclient/create_standby/resume_ota.py
+++ b/src/otaclient/create_standby/resume_ota.py
@@ -35,7 +35,11 @@ DB_CONN_NUMS = 1  # serializing write
 
 
 class ResourceScanner:
-    """Scan and verify OTA resource folder to resume previous OTA."""
+    """Scan and verify OTA resource folder leftover by previous interrupted OTA.
+
+    NOTE that this doesn't mean resuming the previous OTA, this helper only tries to
+        re-use the OTA resources generated in previous OTA to speed up current OTA.
+    """
 
     def __init__(
         self,
@@ -97,6 +101,7 @@ class ResourceScanner:
             self._se.release()
 
     def resume_ota(self) -> None:
+        """Scan the OTA resource folder leftover by previous interrupted OTA."""
         try:
             with ThreadPoolExecutor(
                 max_workers=cfg.MAX_PROCESS_FILE_THREAD,

--- a/src/otaclient/create_standby/resume_ota.py
+++ b/src/otaclient/create_standby/resume_ota.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Try to resume previously interrupted OTA which uses inplace update mode."""
+"""Try to re-use the OTA resources from previous interrupted OTA when using inplace update mode."""
 
 from __future__ import annotations
 
@@ -27,6 +27,8 @@ from ota_metadata.legacy2.rs_table import ResourceTableORMPool
 from otaclient._status_monitor import StatusReport, UpdateProgressReport
 from otaclient.configs.cfg import cfg
 from otaclient_common import EMPTY_FILE_SHA256
+
+DB_CONN_NUMS = 1  # serializing write
 
 
 class ResourceScanner:
@@ -46,7 +48,7 @@ class ResourceScanner:
         self._ota_metadata = ota_metadata
 
         self._rst_orm_pool = ResourceTableORMPool(
-            con_factory=ota_metadata.connect_rstable, number_of_cons=3
+            con_factory=ota_metadata.connect_rstable, number_of_cons=DB_CONN_NUMS
         )
         self._se = threading.Semaphore(cfg.MAX_CONCURRENT_PROCESS_FILE_TASKS)
         self._thread_local = threading.local()

--- a/src/otaclient/create_standby/resume_ota.py
+++ b/src/otaclient/create_standby/resume_ota.py
@@ -91,7 +91,10 @@ class ResourceScanner:
             self._se.release()
 
     def resume_ota(self) -> None:
-        with ThreadPoolExecutor(max_workers=cfg.MAX_PROCESS_FILE_THREAD) as pool:
+        with ThreadPoolExecutor(
+            max_workers=cfg.MAX_PROCESS_FILE_THREAD,
+            initializer=self._thread_initializer,
+        ) as pool:
             for entry in os.scandir(self._resource_dir):
                 _fname = entry.name
                 # NOTE: in resource dir, all files except tmp files are named

--- a/src/otaclient/create_standby/resume_ota.py
+++ b/src/otaclient/create_standby/resume_ota.py
@@ -26,6 +26,7 @@ from ota_metadata.legacy2.metadata import OTAMetadata
 from ota_metadata.legacy2.rs_table import ResourceTableORMPool
 from otaclient._status_monitor import StatusReport, UpdateProgressReport
 from otaclient.configs.cfg import cfg
+from otaclient_common import EMPTY_FILE_SHA256
 
 
 class ResourceScanner:
@@ -97,6 +98,9 @@ class ResourceScanner:
         ) as pool:
             for entry in os.scandir(self._resource_dir):
                 _fname = entry.name
+                if _fname == EMPTY_FILE_SHA256:
+                    continue
+
                 # NOTE: in resource dir, all files except tmp files are named
                 #       with its sha256 digest in hex string.
                 try:

--- a/src/otaclient/create_standby/resume_ota.py
+++ b/src/otaclient/create_standby/resume_ota.py
@@ -107,6 +107,7 @@ class ResourceScanner:
                 max_workers=cfg.MAX_PROCESS_FILE_THREAD,
                 initializer=self._thread_initializer,
             ) as pool:
+                _count = 0
                 for entry in os.scandir(self._resource_dir):
                     _fname = entry.name
                     if _fname == EMPTY_FILE_SHA256:
@@ -120,10 +121,12 @@ class ResourceScanner:
                         continue
 
                     self._se.acquire()
+                    _count += 1
                     pool.submit(
                         self._process_resource_at_thread,
                         Path(entry.path),
                         expected_digest,
                     )
+            logger.info(f"totally {_count} of OTA resource files are scanned")
         except Exception as e:
             logger.warning(f"exception during scanning OTA resource dir: {e!r}")

--- a/src/otaclient/create_standby/resume_ota.py
+++ b/src/otaclient/create_standby/resume_ota.py
@@ -1,0 +1,109 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Try to resume previously interrupted OTA which uses inplace update mode."""
+
+from __future__ import annotations
+
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from hashlib import sha256
+from pathlib import Path
+from queue import Queue
+
+from ota_metadata.legacy2.metadata import OTAMetadata
+from ota_metadata.legacy2.rs_table import ResourceTableORMPool
+from otaclient._status_monitor import StatusReport, UpdateProgressReport
+from otaclient.configs.cfg import cfg
+
+
+class ResourceScanner:
+    """Scan and verify OTA resource folder to resume previous OTA."""
+
+    def __init__(
+        self,
+        *,
+        ota_metadata: OTAMetadata,
+        resource_dir: Path,
+        status_report_queue: Queue[StatusReport],
+        session_id: str,
+    ) -> None:
+        self._status_report_queue = status_report_queue
+        self.session_id = session_id
+        self._resource_dir = resource_dir
+        self._ota_metadata = ota_metadata
+
+        self._rst_orm_pool = ResourceTableORMPool(
+            con_factory=ota_metadata.connect_rstable, number_of_cons=3
+        )
+        self._se = threading.Semaphore(cfg.MAX_CONCURRENT_PROCESS_FILE_TASKS)
+        self._thread_local = threading.local()
+
+    def _thread_initializer(self):
+        self._thread_local.buffer = _buffer = bytearray(cfg.READ_CHUNK_SIZE)
+        self._thread_local.bufferview = memoryview(_buffer)
+
+    def _process_resource_at_thread(self, fpath: Path, expected_digest: bytes) -> None:
+        try:
+            hash_f, file_size = sha256(), 0
+            buffer, bufferview = (
+                self._thread_local.buffer,
+                self._thread_local.bufferview,
+            )
+            with open(fpath, "rb") as src:
+                src_fd = src.fileno()
+                os.posix_fadvise(src_fd, 0, 0, os.POSIX_FADV_NOREUSE)
+                os.posix_fadvise(src_fd, 0, 0, os.POSIX_FADV_SEQUENTIAL)
+                while read_size := src.readinto(buffer):
+                    file_size += read_size
+                    hash_f.update(bufferview[:read_size])
+                os.posix_fadvise(src_fd, 0, 0, os.POSIX_FADV_DONTNEED)
+
+            calculated_digest = hash_f.digest()
+            if (
+                calculated_digest != expected_digest
+                or self._rst_orm_pool.orm_delete_entries(digest=calculated_digest) != 1
+            ):
+                fpath.unlink(missing_ok=True)
+            else:
+                self._status_report_queue.put_nowait(
+                    StatusReport(
+                        payload=UpdateProgressReport(
+                            operation=UpdateProgressReport.Type.PREPARE_LOCAL_COPY,
+                            processed_file_num=1,
+                            processed_file_size=file_size,
+                        ),
+                        session_id=self.session_id,
+                    )
+                )
+        finally:
+            self._se.release()
+
+    def resume_ota(self) -> None:
+        with ThreadPoolExecutor(max_workers=cfg.MAX_PROCESS_FILE_THREAD) as pool:
+            for entry in os.scandir(self._resource_dir):
+                _fname = entry.name
+                # NOTE: in resource dir, all files except tmp files are named
+                #       with its sha256 digest in hex string.
+                try:
+                    expected_digest = bytes.fromhex(_fname)
+                except ValueError:
+                    continue
+
+                self._se.acquire()
+                pool.submit(
+                    self._process_resource_at_thread,
+                    Path(entry.path),
+                    expected_digest,
+                )

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -111,7 +111,7 @@ OP_CHECK_INTERVAL = 1  # second
 HOLD_REQ_HANDLING_ON_ACK_REQUEST = 16  # seconds
 WAIT_FOR_OTAPROXY_ONLINE = 3 * 60  # 3mins
 
-STANDBY_SLOT_USED_SIZE_THRESHOLD = 0.9
+STANDBY_SLOT_USED_SIZE_THRESHOLD = 0.8
 
 BASE_METADATA_FOLDER = "base"
 """On standby slot temporary OTA metadata folder(/.ota-meta), `base` folder is to

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -577,6 +577,18 @@ class _OTAUpdater:
             standby_as_ref=use_inplace_mode,
             erase_standby=not use_inplace_mode,
         )
+
+        # ------ in-update: calculate delta ------ #
+        logger.info("start to calculate and prepare delta...")
+        self._status_report_queue.put_nowait(
+            StatusReport(
+                payload=OTAUpdatePhaseChangeReport(
+                    new_update_phase=UpdatePhase.CALCULATING_DELTA,
+                    trigger_timestamp=int(time.time()),
+                ),
+                session_id=self.session_id,
+            )
+        )
         if use_inplace_mode and self._resource_dir_on_standby.is_dir():
             logger.info(
                 "OTA resource dir found on standby slot, possible an interrupted OTA. \n"
@@ -603,18 +615,6 @@ class _OTAUpdater:
             logger.error(
                 f"failed to save OTA image file_table to {self._ota_tmp_meta_on_standby=}: {e!r}"
             )
-
-        # ------ in-update: calculate delta ------ #
-        logger.info("start to calculate and prepare delta...")
-        self._status_report_queue.put_nowait(
-            StatusReport(
-                payload=OTAUpdatePhaseChangeReport(
-                    new_update_phase=UpdatePhase.CALCULATING_DELTA,
-                    trigger_timestamp=int(time.time()),
-                ),
-                session_id=self.session_id,
-            )
-        )
 
         base_meta_dir_on_standby_slot = None
         try:

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -243,9 +243,9 @@ class _OTAUpdater:
         logger.debug("process cookies_json...")
         try:
             cookies = json.loads(cookies_json)
-            assert isinstance(cookies, dict), (
-                f"invalid cookies, expecting json object: {cookies_json}"
-            )
+            assert isinstance(
+                cookies, dict
+            ), f"invalid cookies, expecting json object: {cookies_json}"
         except (JSONDecodeError, AssertionError) as e:
             _err_msg = f"cookie is invalid: {cookies_json=}"
             logger.error(_err_msg)

--- a/src/otaclient_common/_io.py
+++ b/src/otaclient_common/_io.py
@@ -190,7 +190,7 @@ def copyfile_atomic(
 def remove_file(_fpath: StrOrPath, *, ignore_error: bool = True) -> None:
     """Use proper way to remove <_fpath>."""
     _fpath = Path(_fpath)
-    if _fpath.is_dir():
+    if not _fpath.is_symlink() and _fpath.is_dir():
         return shutil.rmtree(_fpath, ignore_errors=ignore_error)
 
     try:

--- a/src/otaclient_common/_io.py
+++ b/src/otaclient_common/_io.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Common shared helper functions for IO."""
 
-
 from __future__ import annotations
 
 import hashlib
@@ -24,7 +23,6 @@ import shutil
 import sys
 from functools import partial
 from pathlib import Path
-from typing import TypeVar
 
 from otaclient_common._typing import StrOrPath
 
@@ -189,4 +187,16 @@ def copyfile_atomic(
         _tmp_file.unlink(missing_ok=True)
 
 
-_StrOrPath = TypeVar("_StrOrPath", str, Path)
+def remove_file(_fpath: StrOrPath, *, ignore_error: bool = True) -> None:
+    """Use proper way to remove <_fpath>."""
+    _fpath = Path(_fpath)
+    if not _fpath.exists():
+        return
+    if _fpath.is_dir():
+        return shutil.rmtree(_fpath, ignore_errors=ignore_error)
+
+    try:
+        _fpath.unlink(missing_ok=True)
+    except Exception:
+        if not ignore_error:
+            raise

--- a/src/otaclient_common/_io.py
+++ b/src/otaclient_common/_io.py
@@ -190,8 +190,6 @@ def copyfile_atomic(
 def remove_file(_fpath: StrOrPath, *, ignore_error: bool = True) -> None:
     """Use proper way to remove <_fpath>."""
     _fpath = Path(_fpath)
-    if not _fpath.exists():
-        return
     if _fpath.is_dir():
         return shutil.rmtree(_fpath, ignore_errors=ignore_error)
 

--- a/tests/test_otaclient/test_create_standby/conftest.py
+++ b/tests/test_otaclient/test_create_standby/conftest.py
@@ -121,7 +121,7 @@ def ab_slots_for_inplace(tmp_path: Path) -> SlotAB:
     logger.info("prepare simple a/b slots for inplace update mode ...")
     slot_a = tmp_path / "slot_a"
     slot_b = tmp_path / "slot_b"
-    logger.info(f"prepare simple a/b slots for rebuild mode: {slot_a=}, {slot_b=}")
+    logger.info(f"prepare simple a/b slots for inplace mode: {slot_a=}, {slot_b=}")
 
     slot_a.mkdir(exist_ok=True, parents=True)
     shutil.copytree(OTA_IMAGE_DATA_DIR, slot_b, symlinks=True)
@@ -137,7 +137,7 @@ def ab_slots_for_inplace(tmp_path: Path) -> SlotAB:
 
 @pytest.fixture
 def ab_slots_for_rebuild(tmp_path: Path) -> SlotAB:
-    logger.info("prepare simple a/b slots for inplace update mode ...")
+    logger.info("prepare simple a/b slots for rebuild mode ...")
     slot_a = tmp_path / "slot_a"
     slot_b = tmp_path / "slot_b"
     logger.info(f"prepare simple a/b slots for rebuild mode: {slot_a=}, {slot_b=}")

--- a/tests/test_otaclient/test_create_standby/test_resume_ota.py
+++ b/tests/test_otaclient/test_create_standby/test_resume_ota.py
@@ -1,0 +1,75 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import queue
+from pathlib import Path
+from typing import cast
+
+import pytest
+import pytest_mock
+
+from ota_metadata.legacy2.metadata import OTAMetadata
+from otaclient.create_standby.delta_gen import (
+    InPlaceDeltaWithBaseFileTable,
+)
+from otaclient.create_standby.resume_ota import ResourceScanner
+
+from .conftest import SlotAB
+
+logger = logging.getLogger(__name__)
+
+DELTA_GEN_MODULE = "otaclient.create_standby.delta_gen"
+DELTA_GEN_FULL_DISK_SCAN_BASE = f"{DELTA_GEN_MODULE}.DeltaGenFullDiskScan"
+
+
+class _MockedQue:
+    @staticmethod
+    def put_nowait(_): ...
+
+
+MockedQue = cast(queue.Queue, _MockedQue)
+
+
+@pytest.fixture(autouse=True)
+def mocked_full_disk_scan_mode(mocker: pytest_mock.MockerFixture):
+    # NOTE: to let full disk scan mode can get all the resources, only for test
+    mocker.patch(f"{DELTA_GEN_FULL_DISK_SCAN_BASE}.EXCLUDE_PATHS", {})
+    mocker.patch(f"{DELTA_GEN_MODULE}.MAX_FOLDER_DEEPTH", 2**32)
+    mocker.patch(f"{DELTA_GEN_MODULE}.MAX_FILENUM_PER_FOLDER", 2**64)
+
+
+def test_resume_ota(
+    ab_slots_for_inplace: SlotAB,
+    ota_metadata_inst: OTAMetadata,
+    resource_dir: Path,
+) -> None:
+    logger.info("process slot and generating OTA resources ...")
+    InPlaceDeltaWithBaseFileTable(
+        ota_metadata=ota_metadata_inst,
+        delta_src=ab_slots_for_inplace.slot_b,
+        copy_dst=resource_dir,
+        status_report_queue=MockedQue,
+        session_id="session_id",
+    ).process_slot(str(ota_metadata_inst._fst_db))
+
+    logger.info("scan through the generated resources ...")
+    ResourceScanner(
+        ota_metadata=ota_metadata_inst,
+        resource_dir=resource_dir,
+        status_report_queue=MockedQue,
+        session_id="session_id",
+    ).resume_ota()

--- a/tests/test_otaclient_common/test_io.py
+++ b/tests/test_otaclient_common/test_io.py
@@ -168,13 +168,16 @@ def test_copyfile_atomic(tmp_path: Path):
 def test_remove_file(tmp_path: Path):
     test_f = tmp_path / "test_f"
     test_f.touch()
+    assert test_f.is_file()
     remove_file(test_f)
     assert not test_f.is_file() and not test_f.exists()
 
     test_f.mkdir()
+    assert test_f.is_dir()
     remove_file(test_f)
     assert not test_f.is_dir() and not test_f.exists()
 
     test_f.symlink_to("abc")
+    assert test_f.is_symlink()
     remove_file(test_f)
     assert not test_f.is_symlink() and not test_f.exists()

--- a/tests/test_otaclient_common/test_io.py
+++ b/tests/test_otaclient_common/test_io.py
@@ -30,6 +30,7 @@ from otaclient_common._io import (
     cal_file_digest,
     copyfile_atomic,
     file_sha256,
+    remove_file,
     symlink_atomic,
     write_str_to_file_atomic,
 )
@@ -60,7 +61,6 @@ def test_gen_file_digest(tmp_path: Path):
 
 
 class TestWriteStrToFileAtomic:
-
     @pytest.fixture(scope="class")
     def data(self):
         data_lens = [100, 500, 1000, 9000]  # bytes
@@ -163,3 +163,18 @@ def test_copyfile_atomic(tmp_path: Path):
     copyfile_atomic(_src, _dst)
     assert file_sha256(_dst) == file_sha256(_src) == _data_hash
     assert subprocess.check_output(["cat", str(_dst)]) == _data
+
+
+def test_remove_file(tmp_path: Path):
+    test_f = tmp_path / "test_f"
+    test_f.touch()
+    remove_file(test_f)
+    assert not test_f.is_file() and not test_f.exists()
+
+    test_f.mkdir()
+    remove_file(test_f)
+    assert not test_f.is_dir() and not test_f.exists()
+
+    test_f.symlink_to("abc")
+    remove_file(test_f)
+    assert not test_f.is_symlink() and not test_f.exists()

--- a/tests/test_otaclient_common/test_io.py
+++ b/tests/test_otaclient_common/test_io.py
@@ -167,6 +167,16 @@ def test_copyfile_atomic(tmp_path: Path):
 
 def test_remove_file(tmp_path: Path):
     test_f = tmp_path / "test_f"
+    symlink_target = tmp_path / "symlink_target_dir"
+    symlink_target.mkdir()
+
+    # NOTE: we DON'T want to accidentally remove the symlink target!
+    test_f.symlink_to(symlink_target)
+    assert test_f.is_symlink()
+    remove_file(test_f)
+    assert symlink_target.is_dir()
+    assert not test_f.is_symlink() and not test_f.exists()
+
     test_f.touch()
     assert test_f.is_file()
     remove_file(test_f)
@@ -176,8 +186,3 @@ def test_remove_file(tmp_path: Path):
     assert test_f.is_dir()
     remove_file(test_f)
     assert not test_f.is_dir() and not test_f.exists()
-
-    test_f.symlink_to("abc")
-    assert test_f.is_symlink()
-    remove_file(test_f)
-    assert not test_f.is_symlink() and not test_f.exists()


### PR DESCRIPTION
## Motivation

When OTA with inplace update mode is interrupted when all OTA resources are collected and standby slot is cleaned up, for current implementation, next OTA retry will still try to use inplace mode. 
However, due to `.ota-tmp` is not full scan folder, and the standby slot has already being cleaned up, delta calculation will miss nearly all resources, resulting in large delta to be downloaded.

## Introduction

This PR introduces OTA resume when using inplace update mode.
Note that this resume doesn't mean continue the previous OTA as it, but tries with best effort to reuse the already processed delta(OTA resources) and utilize the OTA resources for current OTA.

Other changes:
1. inplace update mode with base file_table: fix issues caused by an edge case when files/dirs recorded as regular file/dir becomes symlinks.