### PR TITLE
[3.9] fix: replace_root and TopDownCommonShortestPath: DO NOT resolve input paths

### DIFF
--- a/src/otaclient/create_standby/utils.py
+++ b/src/otaclient/create_standby/utils.py
@@ -39,7 +39,6 @@ class TopDownCommonShortestPath:
         self._store: set[Path] = set()
 
     def add_path(self, _path: Path):
-        _path = Path(_path).resolve()
         for _parent in _path.parents:
             # this path is covered by a shorter common prefix
             if _parent in self._store:

--- a/src/otaclient_common/__init__.py
+++ b/src/otaclient_common/__init__.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Common shared libs for otaclient."""
 
-
 from __future__ import annotations
 
 import os
@@ -59,11 +58,7 @@ def replace_root(
     For example, if path="/abc", old_root="/", new_root="/new_root",
     then we will have "/new_root/abc".
     """
-    # normalize all the input args
-    path = os.path.normpath(path)
-    old_root = os.path.normpath(old_root)
-    new_root = os.path.normpath(new_root)
-
+    old_root, new_root = str(old_root), str(new_root)
     if not (old_root.startswith("/") and new_root.startswith("/")):
         raise ValueError(f"{old_root=} and/or {new_root=} is not valid root")
     if os.path.commonpath([path, old_root]) != old_root:


### PR DESCRIPTION
## Introduction

This PR fixes a bug caused by `replace_root` and `TopDownCommonShortestPath` try to resolve the input paths. 

This will introduce side effect when input path is somehow not an actual dir, but a symlink, on the active slot.
The path will be resolved by looking at current rootfs filesystem, which is unexpected if the input path should be relative to standby slot during delta calculation.

Also, paths resolve is not needed in the first place, so the change here doesn't break the current behavior.