### PR TITLE
fix!: remove control for force status update

### DIFF
--- a/src/otaclient/boot_control/_grub.py
+++ b/src/otaclient/boot_control/_grub.py
@@ -426,18 +426,7 @@ class _GrubControl:
 
         # NOTE: standby slot will be prepared in an OTA, GrubControl init will not check
         #       standby slot's ota-partition folder.
-        self._grub_control_initialized = False
         self._check_active_slot_ota_partition_file()
-
-    @property
-    def initialized(self) -> bool:
-        """Indicates whether grub_control migrates itself from non-OTA booted system,
-        or recovered from a ota_partition files corrupted boot.
-
-        Normally this property should be false, if it is true, OTAStatusControl should also
-            initialize itself.
-        """
-        return self._grub_control_initialized
 
     def _check_active_slot_ota_partition_file(self):
         """Check and ensure active ota-partition files, init if needed.
@@ -514,7 +503,6 @@ class _GrubControl:
                 standby_slot=self.standby_slot
             )
             self._grub_update_on_booted_slot()
-            self._grub_control_initialized = True
 
         logger.info(f"ota-partition files for {self.active_slot} are ready")
 
@@ -765,9 +753,6 @@ class GrubController(BootControllerProtocol):
                 current_ota_status_dir=self._boot_control.active_ota_partition_folder,
                 standby_ota_status_dir=self._boot_control.standby_ota_partition_folder,
                 finalize_switching_boot=self._boot_control.finalize_update_switch_boot,
-                # NOTE(20230904): if boot control is initialized(i.e., migrate from non-ota booted system),
-                #                 force initialize the ota_status files.
-                force_initialize=self._boot_control.initialized,
             )
         except Exception as e:
             _err_msg = f"failed on start grub boot controller: {e!r}"

--- a/src/otaclient/boot_control/_ota_status_control.py
+++ b/src/otaclient/boot_control/_ota_status_control.py
@@ -50,7 +50,6 @@ class OTAStatusFilesControl:
         current_ota_status_dir: Union[str, Path],
         standby_ota_status_dir: Union[str, Path],
         finalize_switching_boot: FinalizeSwitchBootFunc,
-        force_initialize: bool = False,
     ) -> None:
         self.active_slot = active_slot
         self.standby_slot = standby_slot
@@ -58,7 +57,6 @@ class OTAStatusFilesControl:
         self.standby_ota_status_dir = Path(standby_ota_status_dir)
         self.finalize_switching_boot = finalize_switching_boot
 
-        self._force_initialize = force_initialize
         self.current_ota_status_dir.mkdir(exist_ok=True, parents=True)
         self._load_slot_in_use_file()
         self._load_status_file()
@@ -69,8 +67,6 @@ class OTAStatusFilesControl:
     def _load_status_file(self):
         """Check and/or init ota_status files for current slot."""
         _loaded_ota_status = self._load_current_status()
-        if self._force_initialize:
-            _loaded_ota_status = None
 
         # initialize ota_status files if not presented/incompleted/invalid
         if _loaded_ota_status is None:
@@ -145,8 +141,6 @@ class OTAStatusFilesControl:
 
     def _load_slot_in_use_file(self):
         _loaded_slot_in_use = self._load_current_slot_in_use()
-        if self._force_initialize:
-            _loaded_slot_in_use = None
 
         if not _loaded_slot_in_use:
             # NOTE(20230831): this can also resolve the backward compatibility issue

--- a/tests/test_otaclient/test_boot_control/test_ota_status_control.py
+++ b/tests/test_otaclient/test_boot_control/test_ota_status_control.py
@@ -70,7 +70,7 @@ class TestOTAStatusFilesControl:
 
     @pytest.mark.parametrize(
         (
-            "test_case,input_slot_a_status,input_slot_a_slot_in_use,force_initialize,"
+            "test_case,input_slot_a_status,input_slot_a_slot_in_use,"
             "output_slot_a_status,output_slot_a_slot_in_use"
         ),
         (
@@ -79,17 +79,6 @@ class TestOTAStatusFilesControl:
                 # input
                 None,
                 "",
-                False,
-                # output
-                OTAStatus.INITIALIZED,
-                SLOT_A_ID,
-            ),
-            (
-                "test_force_initialize",
-                # input
-                OTAStatus.SUCCESS,
-                SLOT_A_ID,
-                True,
                 # output
                 OTAStatus.INITIALIZED,
                 SLOT_A_ID,
@@ -99,7 +88,6 @@ class TestOTAStatusFilesControl:
                 # input
                 OTAStatus.SUCCESS,
                 SLOT_A_ID,
-                False,
                 # output
                 OTAStatus.SUCCESS,
                 SLOT_A_ID,
@@ -111,7 +99,6 @@ class TestOTAStatusFilesControl:
         test_case: str,
         input_slot_a_status: Optional[OTAStatus],
         input_slot_a_slot_in_use: str,
-        force_initialize: bool,
         output_slot_a_status: OTAStatus,
         output_slot_a_slot_in_use: str,
     ):
@@ -130,7 +117,6 @@ class TestOTAStatusFilesControl:
             current_ota_status_dir=self.slot_a_ota_status_dir,
             standby_ota_status_dir=self.slot_b_ota_status_dir,
             finalize_switching_boot=partial(self.finalize_switch_boot_func, True),
-            force_initialize=force_initialize,
         )
 
         # ------ assertion ------ #
@@ -153,7 +139,6 @@ class TestOTAStatusFilesControl:
             current_ota_status_dir=self.slot_a_ota_status_dir,
             standby_ota_status_dir=self.slot_b_ota_status_dir,
             finalize_switching_boot=partial(self.finalize_switch_boot_func, True),
-            force_initialize=False,
         )
 
         # ------ execution ------ #
@@ -177,7 +162,6 @@ class TestOTAStatusFilesControl:
             current_ota_status_dir=self.slot_a_ota_status_dir,
             standby_ota_status_dir=self.slot_b_ota_status_dir,
             finalize_switching_boot=partial(self.finalize_switch_boot_func, True),
-            force_initialize=False,
         )
 
         # ------ execution ------ #
@@ -225,7 +209,6 @@ class TestOTAStatusFilesControl:
             finalize_switching_boot=partial(
                 self.finalize_switch_boot_func, finalizing_result
             ),
-            force_initialize=False,
         )
 
         # ------ assertion ------ #
@@ -270,7 +253,6 @@ class TestOTAStatusFilesControl:
             current_ota_status_dir=self.slot_b_ota_status_dir,
             standby_ota_status_dir=self.slot_a_ota_status_dir,
             finalize_switching_boot=partial(self.finalize_switch_boot_func, True),
-            force_initialize=False,
         )
 
         # ------ assertion ------ #
@@ -304,7 +286,6 @@ class TestOTAStatusFilesControl:
             current_ota_status_dir=self.slot_a_ota_status_dir,
             standby_ota_status_dir=self.slot_b_ota_status_dir,
             finalize_switching_boot=partial(self.finalize_switch_boot_func, True),
-            force_initialize=False,
         )
 
         # ------ assertion ------ #


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->
### Why
This issues was found in the following procedure:
1. install otaclient v3.10.0-rc4
2. execute OTA from FMS Console([image](https://evaluation.dev.tier4.jp/evaluation/reports/17289704-72b9-572f-9a18-877c0115d0bf?project_id=tier4_demo))
3. restart ota service in the middle
4. `INITIALIZED` status is stored and `SUCCESS` was displayed on FMS Console

There are two issues.
1. when otaclient is interrupted in the updating, "Force Status Update for Grub" is working after rebooting.
LOG:
```
Jul 14 15:42:47 autoware-ecu otaclient[306018]: [2025-07-14 15:42:47,641][INFO]-otaclient.boot_control.selecter:get_boot_controller:79,use boot_controller for bootloader_type=<BootloaderType.GRUB: 'grub'>
Jul 14 15:42:47 autoware-ecu otaclient[306018]: [2025-07-14 15:42:47,649][INFO]-otaclient.boot_control._grub:__init__:409,self.active_slot='sda3'@/dev/sda3, self.standby_slot='sda4'@/dev/sda4
Jul 14 15:42:47 autoware-ecu otaclient[306018]: [2025-07-14 15:42:47,650][ERROR]-otaclient.boot_control._grub:_check_active_slot_ota_partition_file:477,failed to get current booted kernel and initrd.image: ValueError('failed to find booted initrd image(initrd.img-ota.standby)'), try to use active slot ota-partition files
Jul 14 15:42:47 autoware-ecu otaclient[306018]: [2025-07-14 15:42:47,650][WARNING]-otaclient.boot_control._grub:_check_active_slot_ota_partition_file:491,system is not booted with ota mechanism(not_booted_with_ota_mechanism=True, active_slot_ota_boot_files_missing=False, ota_partition_symlink_missing=False), migrating and initializing ota-partition files for sda3@/dev/sda3...
Jul 14 15:42:47 autoware-ecu otaclient[306018]: [2025-07-14 15:42:47,651][INFO]-otaclient.boot_control._grub:_prepare_kernel_initrd_links:570,finished generate ota symlinks under /boot/ota-partition.sda3
Jul 14 15:42:49 autoware-ecu otaclient[306018]: [2025-07-14 15:42:49,036][INFO]-otaclient.boot_control._grub:_grub_update_on_booted_slot:614,boot entry for vmlinuz-ota(slot=sda3): 0
Jul 14 15:42:50 autoware-ecu otaclient[306018]: [2025-07-14 15:42:50,472][INFO]-otaclient.boot_control._grub:_grub_update_on_booted_slot:646,standby rootfs: UUID=cc83f21a-6c65-4b94-bd8e-7aa9c3a08c17
Jul 14 15:42:50 autoware-ecu otaclient[306018]: [2025-07-14 15:42:50,473][INFO]-otaclient.boot_control._grub:_grub_update_on_booted_slot:666,update_grub for sda3 finished.
Jul 14 15:42:50 autoware-ecu otaclient[306018]: [2025-07-14 15:42:50,473][INFO]-otaclient.boot_control._grub:_check_active_slot_ota_partition_file:519,ota-partition files for sda3 are ready
Jul 14 15:42:50 autoware-ecu otaclient[306018]: [2025-07-14 15:42:50,482][WARNING]-otaclient.boot_control._ota_status_control:_load_current_status:202,loaded ota_status: FAILURE from /boot/ota-partition.sda3/status
Jul 14 15:42:50 autoware-ecu otaclient[306018]: [2025-07-14 15:42:50,482][WARNING]-otaclient.boot_control._ota_status_control:_load_current_status:206,successfully parsed ota_status: FAILURE
Jul 14 15:42:50 autoware-ecu otaclient[306018]: [2025-07-14 15:42:50,482][WARNING]-otaclient.boot_control._ota_status_control:_load_status_file:71,loading FAILURE
Jul 14 15:42:50 autoware-ecu otaclient[306018]: [2025-07-14 15:42:50,482][WARNING]-otaclient.boot_control._ota_status_control:_load_status_file:73,force initialize is set, resetting ota_status
Jul 14 15:42:50 autoware-ecu otaclient[306018]: [2025-07-14 15:42:50,482][WARNING]-otaclient.boot_control._ota_status_control:_load_status_file:78,ota_status files incompleted/not presented, initializing and set/store status to INITIALIZED...
```
2. When FMS receives "INITIALIZED" during OTA, it judges as SUCCESS.

### What
remove "Force Status Update" control.
This control is for "Indicates whether grub_control migrates itself from non-OTA booted system, or recovered from a ota_partition files corrupted boot".
This control cause issue, and I think we can judge it by simply checking status file existence in `_load_current_status`.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file that covers the bug case(s) is implemented.
- [x] local test is passed.

## Bug fix

### Current behavior
`SUCCESS` might be shown on FMS console even though OTA was failed.

### Behaivor after fix
`FAILURE` will be shown when OTA was interrupted.

## Related links & ticket

<!-- List of tickets or links related to this PR -->
