### PR TITLE
fix(grub boot control): fix OTA boot control is unexpected initialized when OTA is interrupted/at dynamic client launching.

### DIFF
--- a/src/otaclient/boot_control/_grub.py
+++ b/src/otaclient/boot_control/_grub.py
@@ -468,6 +468,7 @@ class _GrubControl:
                 raise _GrubBootControllerError(
                     f"failed to locate booted kernel/initrd files: {kernel_fname}, {initrd_fname}"
                 )
+            self.active_ota_partition_folder.mkdir(exist_ok=True, parents=True)
 
             # NOTE: we expect the booted kernel/initrd files either to be in ota-partition folders,
             #       or directly listed under /boot folder.

--- a/src/otaclient_common/cmdhelper.py
+++ b/src/otaclient_common/cmdhelper.py
@@ -766,3 +766,16 @@ def mount_tmpfs(
         )
         if raise_exception:
             raise
+
+def get_kernel_version_via_uname() -> str | None:
+    """Get the kernel version via `uname -r`.
+
+    Returns:
+        str: The kernel version string.
+    """
+    cmd = ["uname", "-r"]
+    try:
+        return subprocess_check_output(cmd, raise_exception=True).strip()
+    except Exception as e:
+        logger.error(f"Failed to get kernel version via uname: {e!r}")
+        return


### PR DESCRIPTION
## Introduction

This PR fixes an issue of grub boot control will unexpectedly re-initializing the grub boot control files when OTA is interrupted(status should be `FAILURE`) or at dynamic otaclient launching(status should not be changed).