### PR TITLE
chore: add metrics log

### DIFF
--- a/src/otaclient/metrics.py
+++ b/src/otaclient/metrics.py
@@ -19,6 +19,7 @@ import logging
 from dataclasses import asdict, dataclass
 
 from _otaclient_version import __version__
+
 from otaclient._logging import LogType
 from otaclient.configs.cfg import ecu_info
 

--- a/tests/test_otaclient/test_metrics.py
+++ b/tests/test_otaclient/test_metrics.py
@@ -19,6 +19,7 @@ import json
 from unittest.mock import patch
 
 from _otaclient_version import __version__
+
 from otaclient import metrics
 from otaclient._logging import LogType
 from otaclient.configs.cfg import ecu_info


### PR DESCRIPTION
### Why
Currently, metrics for sub ECUs is not published into CloudWatch because we can't update `persistents.txt` and add gRPC endpoint. For Main ECU, the default endpoint in code is available and can publish metrics.

### What
This PR introduces a temporary workaround that enables metrics to be uploaded via an HTTP endpoint.
Note that these metrics will not be sent to the `otaclient-metrics` log group, but instead will be uploaded to the `otaclient` log group alongside other logs.