### PR TITLE
feat!: use HTTP host for gRPC endpoint

### DIFF
--- a/src/otaclient/_logging.py
+++ b/src/otaclient/_logging.py
@@ -223,27 +223,6 @@ class _LogTeeHandler(logging.Handler):
         atexit.register(_thread_exit)
 
 
-def get_grpc_endpoint(
-    logging_server: AnyHttpUrl, logging_server_grpc: AnyHttpUrl | None
-) -> AnyHttpUrl | None:
-    """Get the gRPC endpoint from proxy_info."""
-
-    # TODO: Currently, we cannot update /boot/ota/proxy_info.yaml because it is not included in the OTA image.
-    # As a workaround, we use the HTTP host with the gRPC port for gRPC communication,
-    # since their hosts are essentially the same.
-    # In the future, once we can update proxy_info.yaml, we should switch to using the dedicated gRPC endpoint in proxy_info.yaml.
-    if logging_server_grpc is None:
-        return None
-
-    port = urlparse(str(logging_server_grpc).rstrip("/")).port
-
-    parsed_http = urlparse(str(logging_server))
-    scheme = parsed_http.scheme
-    host = parsed_http.hostname
-
-    return AnyHttpUrl(f"{scheme}://{host}:{port}")
-
-
 def configure_logging() -> None:
     """Configure logging with http/gRPC handler."""
     # ------ suppress logging from non-first-party modules ------ #
@@ -256,9 +235,16 @@ def configure_logging() -> None:
     # ------ configure each sub loggers and attach ota logging handler ------ #
     log_upload_handler = None
     if logging_upload_endpoint := proxy_info.logging_server:
-        logging_upload_grpc_endpoint = get_grpc_endpoint(
-            proxy_info.logging_server, proxy_info.logging_server_grpc
-        )
+
+        # TODO: Currently, we cannot update /boot/ota/proxy_info.yaml because it is not included in the OTA image.
+        # As a workaround, we use the HTTP host with the gRPC port for gRPC communication,
+        # since their hosts are essentially the same.
+        # In the future, once we can update proxy_info.yaml, we should switch to using the dedicated gRPC endpoint in proxy_info.yaml.
+        _parsed_http = urlparse(str(logging_upload_endpoint))
+        _scheme = _parsed_http.scheme
+        _host = _parsed_http.hostname
+        _port = urlparse(str(proxy_info.logging_server_grpc).rstrip("/")).port
+        logging_upload_grpc_endpoint = AnyHttpUrl(f"{_scheme}://{_host}:{_port}")
 
         log_upload_handler = _LogTeeHandler()
         fmt = logging.Formatter(fmt=cfg.LOG_FORMAT)

--- a/tests/test_otaclient/test_logging.py
+++ b/tests/test_otaclient/test_logging.py
@@ -213,3 +213,29 @@ class TestLogClient:
             assert _response.message == log_message
         else:
             pytest.fail(f"Unexpected log type: {_response.log_type}")
+
+    @pytest.mark.parametrize(
+        "logging_server, logging_server_grpc, expected_url",
+        [
+            (
+                AnyHttpUrl("http://127.0.0.1:8083"),
+                AnyHttpUrl("http://127.0.0.2:8084"),
+                AnyHttpUrl("http://127.0.0.1:8084"),
+            ),
+            (
+                AnyHttpUrl("https://127.0.0.1:8083"),
+                AnyHttpUrl("http://127.0.0.2:8084"),
+                AnyHttpUrl("https://127.0.0.1:8084"),
+            ),
+            (
+                AnyHttpUrl("http://127.0.0.1:8083"),
+                None,
+                None,
+            ),
+        ],
+    )
+    def test_get_grpc_endpoint(self, logging_server, logging_server_grpc, expected_url):
+        from otaclient._logging import get_grpc_endpoint
+
+        endpoint = get_grpc_endpoint(logging_server, logging_server_grpc)
+        assert endpoint == expected_url

--- a/tests/test_otaclient/test_logging.py
+++ b/tests/test_otaclient/test_logging.py
@@ -81,7 +81,7 @@ class DummyLogServerService(log_v1_grpc.OTAClientIoTLoggingServiceServicer):
 
 class TestLogClient:
     OTA_CLIENT_LOGGING_SERVER = "http://127.0.0.1:8083"
-    OTA_CLIENT_LOGGING_SERVER_GRPC = "http://127.0.0.1:8084"
+    OTA_CLIENT_LOGGING_SERVER_GRPC = "http://192.168.0.1:8084"
     ECU_ID = "testclient"
 
     @pytest.fixture(autouse=True)
@@ -120,7 +120,7 @@ class TestLogClient:
             servicer=DummyLogServerService(self.test_queue, self.data_ready),
             server=server,
         )
-        parsed_url = urlparse(TestLogClient.OTA_CLIENT_LOGGING_SERVER_GRPC)
+        parsed_url = urlparse("http://127.0.0.1:8084")
         server.add_insecure_port(parsed_url.netloc)
         try:
             await server.start()
@@ -214,28 +214,15 @@ class TestLogClient:
         else:
             pytest.fail(f"Unexpected log type: {_response.log_type}")
 
-    @pytest.mark.parametrize(
-        "logging_server, logging_server_grpc, expected_url",
-        [
-            (
-                AnyHttpUrl("http://127.0.0.1:8083"),
-                AnyHttpUrl("http://127.0.0.2:8084"),
-                AnyHttpUrl("http://127.0.0.1:8084"),
-            ),
-            (
-                AnyHttpUrl("https://127.0.0.1:8083"),
-                AnyHttpUrl("http://127.0.0.2:8084"),
-                AnyHttpUrl("https://127.0.0.1:8084"),
-            ),
-            (
-                AnyHttpUrl("http://127.0.0.1:8083"),
-                None,
-                None,
-            ),
-        ],
-    )
-    def test_get_grpc_endpoint(self, logging_server, logging_server_grpc, expected_url):
-        from otaclient._logging import get_grpc_endpoint
+    def test_configure_logging(self, mocker: MockerFixture):
+        mock_start_upload_thread = mocker.patch.object(
+            _logging._LogTeeHandler, "start_upload_thread"
+        )
 
-        endpoint = get_grpc_endpoint(logging_server, logging_server_grpc)
-        assert endpoint == expected_url
+        configure_logging()
+
+        mock_start_upload_thread.assert_called_once_with(
+            logging_upload_endpoint=self._proxy_info.logging_server,
+            logging_upload_grpc_endpoint=AnyHttpUrl("http://127.0.0.1:8084"),
+            ecu_id=self._ecu_info.ecu_id,
+        )

--- a/tests/test_otaclient/test_logging.py
+++ b/tests/test_otaclient/test_logging.py
@@ -103,7 +103,7 @@ class TestLogClient:
         self._ecu_info = ECUInfo(ecu_id=TestLogClient.ECU_ID)
         mocker.patch(f"{MODULE}.ecu_info", self._ecu_info)
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def mock_proxy_info(self, mocker: MockerFixture):
         self._proxy_info = ProxyInfo(
             logging_server=AnyHttpUrl(TestLogClient.OTA_CLIENT_LOGGING_SERVER),
@@ -167,7 +167,6 @@ class TestLogClient:
     )
     async def test_grpc_logging(
         self,
-        mock_proxy_info,
         launch_grpc_server,
         restore_logging,
         log_message,
@@ -215,7 +214,7 @@ class TestLogClient:
         else:
             pytest.fail(f"Unexpected log type: {_response.log_type}")
 
-    def test_configure_logging(self, mock_proxy_info, mocker: MockerFixture):
+    def test_configure_logging(self, restore_logging, mocker: MockerFixture):
         mock_start_upload_thread = mocker.patch.object(
             _logging._LogTeeHandler, "start_upload_thread"
         )

--- a/tests/test_otaclient/test_logging.py
+++ b/tests/test_otaclient/test_logging.py
@@ -103,7 +103,7 @@ class TestLogClient:
         self._ecu_info = ECUInfo(ecu_id=TestLogClient.ECU_ID)
         mocker.patch(f"{MODULE}.ecu_info", self._ecu_info)
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture
     def mock_proxy_info(self, mocker: MockerFixture):
         self._proxy_info = ProxyInfo(
             logging_server=AnyHttpUrl(TestLogClient.OTA_CLIENT_LOGGING_SERVER),
@@ -167,6 +167,7 @@ class TestLogClient:
     )
     async def test_grpc_logging(
         self,
+        mock_proxy_info,
         launch_grpc_server,
         restore_logging,
         log_message,
@@ -214,7 +215,7 @@ class TestLogClient:
         else:
             pytest.fail(f"Unexpected log type: {_response.log_type}")
 
-    def test_configure_logging(self, mocker: MockerFixture):
+    def test_configure_logging(self, mock_proxy_info, mocker: MockerFixture):
         mock_start_upload_thread = mocker.patch.object(
             _logging._LogTeeHandler, "start_upload_thread"
         )


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce.

For better understanding, adding reason/motivation of this PR are also recommended.

-->
### Why
Currently, we cannot update `/boot/ota/proxy_info.yaml` because it is not included in the OTA image.
If `proxy_info.yaml` doesn't contain gRPC endpoint, sub-ECUs can't publish the metrics to main ECU.

### What
Use HTTP host with default gRPC port(8084) for gRPC communication as workaround, since their hosts are essentially the same.
In the future, once we can update proxy_info.yaml, we should switch to using the dedicated gRPC endpoint in proxy_info.yaml.


## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file(s) that covers the change(s) is implemented.
- [x] local test is passed.
- [ ] design docs/implementation docs are prepared.

## Documents

<!-- For feature PR, design document is required. -->

## Changes

<!-- A list of code change(s) that introduced by this PR. -->

## Behavior changes

Does this PR introduce behavior change(s)?

- [ ] Yes, internal behaivor (will not impact user experience).
- [x] Yes, external behaivor (will impact user experience).
- [ ] No.

### Previous behavior

<!-- Behaivor before the PR is introduced -->
sub ECUs use HTTP for logging and can't publish metrics to CloudWatch

### Behavior with this PR

<!-- Behavior after the PR is introduced -->
sub ECUs use gRPC for logging adn publish metrics to CloudWatch.

## Breaking change

Does this PR introduce breaking change?

- [x] Yes.
- [ ] No.

<!-- List the breaking change(s) -->

## Related links & tickets
