### PR TITLE
fix: publish metrics after exceptions handling

### DIFF
--- a/src/otaclient/metrics.py
+++ b/src/otaclient/metrics.py
@@ -19,7 +19,6 @@ import logging
 from dataclasses import asdict, dataclass
 
 from _otaclient_version import __version__
-
 from otaclient._logging import LogType
 from otaclient.configs.cfg import ecu_info
 
@@ -118,5 +117,8 @@ class OTAMetricsData:
             # metrics data has already been published.
             return
 
-        logger.info(json.dumps(asdict(self)), extra={"log_type": LogType.METRICS})
-        self._already_published = True
+        try:
+            logger.info(json.dumps(asdict(self)), extra={"log_type": LogType.METRICS})
+            self._already_published = True
+        except Exception as e:
+            logger.error(f"Failed to publish metrics: {e}")

--- a/src/otaclient/metrics.py
+++ b/src/otaclient/metrics.py
@@ -19,7 +19,6 @@ import logging
 from dataclasses import asdict, dataclass
 
 from _otaclient_version import __version__
-
 from otaclient._logging import LogType
 from otaclient.configs.cfg import ecu_info
 
@@ -67,7 +66,7 @@ class OTAMetricsData:
     # Status
     failure_type: str = ""
     failure_reason: str = ""
-    failed_at_phase: str = ""
+    failed_status: str = ""
 
     # Mode
     use_inplace_mode: bool = False

--- a/src/otaclient/metrics.py
+++ b/src/otaclient/metrics.py
@@ -19,6 +19,7 @@ import logging
 from dataclasses import asdict, dataclass
 
 from _otaclient_version import __version__
+
 from otaclient._logging import LogType
 from otaclient.configs.cfg import ecu_info
 

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -1336,6 +1336,7 @@ class OTAClient:
             )
             self._exit_from_dynamic_client()
         finally:
+            shutil.rmtree(session_wd, ignore_errors=True)
             try:
                 if self._shm_metrics_reader:
                     _shm_metrics = self._shm_metrics_reader.sync_msg()
@@ -1343,7 +1344,6 @@ class OTAClient:
             except Exception as e:
                 logger.error(f"failed to merge metrics: {e!r}")
             self._metrics.publish()
-            shutil.rmtree(session_wd, ignore_errors=True)
 
     def client_update(self, request: ClientUpdateRequestV2) -> None:
         """

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -1258,7 +1258,7 @@ class OTAClient:
             )
             self._metrics.failure_type = failure_type
             self._metrics.failure_reason = failure_reason
-            self._metrics.failed_at_phase = ota_status
+            self._metrics.failed_status = ota_status
         finally:
             del exc  # prevent ref cycle
 


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->

### Why
Currently, metrics is published before exception handling. As a result, any error information is not contained in the metrics.

### What
Publish metrics after exception handling in `Update` method.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file that covers the bug case(s) is implemented.
- [x] local test is passed.

Verified the actual behavior and failure information is stored in metrics.
```
Jul 30 15:09:03 autoware-ecu python3[120866]: [2025-07-30 15:09:03,558][INFO]-otaclient.metrics:publish:122,{"initializing_start_timestamp": 1753855717, "processing_metadata_start_timestamp": 1753855719, "delta_calculation_start_timestamp": 0, "download_start_timestamp": 0, "apply_update_start_timestamp": 0, "post_update_start_timestamp": 0, "finalizing_update_start_timestamp": 0, "ecu_id": "autoware", "session_id": "1753855717-20250717101703-test_beta-v4_3-lin-e6200e35", "current_firmware_version": "20250425-v3.0.4-release", "target_firmware_version": "20250717101703-test/beta-v4.3-lin", "otaclient_version": "3.10.1.dev2+g87306dca.d20250730", "failure_type": "UNRECOVERABLE", "failure_reason": "E312: unrecoverable OTA error, please contact technical support: failed to calculate and/or prepare update delta", "failed_status": "FAILURE", "use_inplace_mode": true, "ota_image_total_files_size": 37563450338, "ota_image_total_regulars_num": 396130, "ota_image_total_directories_num": 0, "ota_image_total_symlinks_num": 0, "delta_download_files_num": 0, "delta_download_files_size": 0, "downloaded_bytes": 0, "downloaded_errors": 0, "enable_local_ota_proxy_cache": false, "cache_total_requests": 5, "cache_external_hits": 0, "cache_local_hits": 0}
```
- "failure_type": "UNRECOVERABLE"
- "failure_reason": "E312: unrecoverable OTA error, please contact technical support: failed to calculate and/or prepare update delta",
- "failed_status": "FAILURE"

## Bug fix

### Current behavior
Metrics never contains error/success status.

### Behaivor after fix
Metrics contains error/success status.

## Related links & ticket

<!-- List of tickets or links related to this PR -->
