### PR TITLE
fix: otaproxy cannot commit cache to db when the cache entry already exists

### DIFF
--- a/src/ota_proxy/cache_streaming.py
+++ b/src/ota_proxy/cache_streaming.py
@@ -38,7 +38,6 @@ from otaclient_common.common import get_backoff
 from .config import config as cfg
 from .db import CacheMeta
 from .errors import (
-    CacheCommitFailed,
     CacheProviderNotReady,
     CacheStreamingFailed,
     CacheStreamingInterrupt,
@@ -163,6 +162,39 @@ class CacheTracker:
         self._bytes_written = 0
         self._acall_soon = asyncio.get_event_loop().call_soon_threadsafe
 
+    def _finalize_cache(self) -> None:
+        """Finalize the caching, commit the cache entry to db.
+
+        At this point, the cache entry is already downloaded and complete.
+
+        NOTE(20250731): when otaproxy starts with previous cache files existed,
+                            there is chance that the `save_path` might already exist,
+                            while not committed to the database.
+                        Still commit the cache, if that file is broken, let otaclient
+                            reports it with OTA cache file protocol in next OTA download request.
+        NOTE(20250731): not considering the case that /ota-cache folder is tampered
+                            or poluted intentionally, assume that all files are normal files.
+                        If `save_dst` exists and is not a regular file, we just give up caching this file.
+        """
+        if not self.cache_meta:
+            return
+
+        if self.save_path.is_symlink():
+            self.save_path.unlink()
+        if self.save_path.exists():
+            if not self.save_path.is_file():
+                burst_suppressed_logger.warning(
+                    f"potential poluted /ota-cache folder, {self.save_path} exists but not a file!"
+                )
+                return
+        else:
+            os.link(self.fpath, self.save_path)
+
+        try:
+            self._commit_cache_cb(self.cache_meta)
+        except Exception as e:
+            burst_suppressed_logger.warning(f"failed to commit cache to db: {e}")
+
     # exposed API
 
     def gen_deadline_checker(self):
@@ -207,21 +239,8 @@ class CacheTracker:
             tracker_events.set_writer_finished()
             cache_meta.cache_size = self._bytes_written
 
-            try:
-                if not tracker_events.writer_failed:
-                    # NOTE(20250731): when otaproxy starts with previous cache files existed,
-                    #                 the `save_path` might already exist.
-                    #                 If that file is broken, let otaclient reports it with
-                    #                 OTA cache file protocol in next OTA download request.
-                    # NOTE(20250831): not considering the case that /ota-cache folder is tampered
-                    #                 or poluted intentionally, assume that all files are normal files.
-                    if not self.save_path.exists():
-                        os.link(self.fpath, self.save_path)
-                    self._commit_cache_cb(cache_meta)
-            except Exception as e:
-                raise CacheCommitFailed(
-                    f"failed to commit cache to db, or finalize cache file: {e!r}"
-                ) from e
+            if not tracker_events.writer_failed:
+                self._finalize_cache()
         except Exception as e:
             tracker_events.set_writer_failed()
             burst_suppressed_logger.error(f"caching {cache_meta} failed: {e!r}")
@@ -248,14 +267,7 @@ class CacheTracker:
                 os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
             tracker_events.set_writer_finished()
             cache_meta.cache_size = self._bytes_written = len(data)
-            try:
-                if not self.save_path.exists():
-                    os.link(self.fpath, self.save_path)
-                self._commit_cache_cb(cache_meta)
-            except Exception as e:
-                raise CacheCommitFailed(
-                    f"failed to commit cache to db, or finalize cache file: {e!r}"
-                ) from e
+            self._finalize_cache()
         except Exception as e:
             tracker_events.set_writer_failed()
             burst_suppressed_logger.error(f"caching {cache_meta} failed: {e!r}")

--- a/src/ota_proxy/errors.py
+++ b/src/ota_proxy/errors.py
@@ -13,6 +13,9 @@ class StorageReachHardLimit(BaseOTACacheError): ...
 class CacheStreamingInterrupt(BaseOTACacheError): ...
 
 
+class CacheCommitFailed(BaseOTACacheError): ...
+
+
 class ReaderPoolBusy(Exception):
     """Raised when read worker thread pool is busy."""
 

--- a/src/ota_proxy/errors.py
+++ b/src/ota_proxy/errors.py
@@ -13,9 +13,6 @@ class StorageReachHardLimit(BaseOTACacheError): ...
 class CacheStreamingInterrupt(BaseOTACacheError): ...
 
 
-class CacheCommitFailed(BaseOTACacheError): ...
-
-
 class ReaderPoolBusy(Exception):
     """Raised when read worker thread pool is busy."""
 

--- a/src/ota_proxy/ota_cache.py
+++ b/src/ota_proxy/ota_cache.py
@@ -564,7 +564,7 @@ class OTACache:
         # NOTE: register the tracker before open the remote fd!
         tracker = CacheTracker(
             cache_identifier=cache_identifier,
-            base_dir=self._base_dir,
+            base_dir=Path(self._base_dir),
             commit_cache_cb=self._commit_cache_callback,
             below_hard_limit_event=self._storage_below_hard_limit_event,
         )

--- a/tests/test_ota_proxy/test_cache_streaming.py
+++ b/tests/test_ota_proxy/test_cache_streaming.py
@@ -91,7 +91,7 @@ class TestOngoingCachingRegister:
         # NOTE: register the tracker before open the remote fd!
         _tracker = CacheTracker(
             cache_identifier=self.URL,
-            base_dir=self.base_dir,
+            base_dir=Path(self.base_dir),
             commit_cache_cb=None,  # type: ignore
             below_hard_limit_event=None,  # type: ignore
         )
@@ -111,7 +111,7 @@ class TestOngoingCachingRegister:
         await self.register_finish.acquire()
 
         # simulate waiting for writer finished downloading
-        await _tracker.fpath.touch()
+        _tracker.fpath.touch()
         await self.writer_done_event.wait()
 
         # finished


### PR DESCRIPTION
## Introduction

This PR fixes an issue of OTA cache commit will fail when the cache file is already presented. Now otaproxy will check whether the cache file to save already exists or not, if that is a file, skip overriding the file.

This kind of thing happens when previous OTA is interrupted, and there is a chance the cache file is saved but the cache entry is not committed to the database.  