### PR TITLE
refactor!: otaproxy: for multiple ECUs environment, disable OTA cache for child ECUs

### DIFF
--- a/src/otaclient/_otaproxy_ctx.py
+++ b/src/otaclient/_otaproxy_ctx.py
@@ -104,7 +104,7 @@ def otaproxy_process(
         upper_proxy=upper_proxy,
         # NOTE(20250801): Starting from otaclient v3.9.1, we have inplace update mode with OTA resume,
         #                   on child ECU, we don't need rely on OTA cache to speed up the OTA retry anymore.
-        # NOTE(20250801): Due to proxy_info.yaml is forced preserved accross each OTA,
+        # NOTE(20250801): Due to proxy_info.yaml is forced preserved across each OTA,
         #                   (multiple methods are used to ensure that, unfortunately),
         #                   currently there is no way to update the proxy_info.yaml file on
         #                   the ECU via OTA.

--- a/src/otaclient/_otaproxy_ctx.py
+++ b/src/otaclient/_otaproxy_ctx.py
@@ -103,11 +103,10 @@ def otaproxy_process(
         cache_db_f=local_otaproxy_cfg.DB_FILE,
         upper_proxy=upper_proxy,
         # NOTE(20250801): Starting from otaclient v3.9.1, we have inplace update mode with OTA resume,
-        #                   on child ECU, we don't need rely on OTA cache to speed up the OTA retry anymore.
-        # NOTE(20250801): Due to proxy_info.yaml is forced preserved across each OTA,
-        #                   (multiple methods are used to ensure that, unfortunately),
-        #                   currently there is no way to update the proxy_info.yaml file on
-        #                   the ECU via OTA.
+        #                   on child ECU, we don't need to rely on OTA cache to speed up OTA retry anymore.
+        # NOTE(20250801): Due to proxy_info.yaml is forced preserved across each OTA(multiple methods are used
+        #                   to ensure that, unfortunately), currently there is no way to update the proxy_info.yaml
+        #                   file on the ECU via OTA.
         #                 For now, hardcoded to disable OTA cache on the child ECU.
         #                 To be noticed that, otaproxy OTA cache on main ECU is still needed for streaming
         #                   the same requests from multiple child ECUs to reduce duplicate downloads.

--- a/src/otaclient/_otaproxy_ctx.py
+++ b/src/otaclient/_otaproxy_ctx.py
@@ -16,7 +16,6 @@
 The API exposed by this module is meant to be controlled by otaproxy managing thread only.
 """
 
-
 from __future__ import annotations
 
 import atexit
@@ -103,7 +102,17 @@ def otaproxy_process(
         cache_dir=local_otaproxy_cfg.BASE_DIR,
         cache_db_f=local_otaproxy_cfg.DB_FILE,
         upper_proxy=upper_proxy,
-        enable_cache=proxy_info.enable_local_ota_proxy_cache,
+        # NOTE(20250801): Starting from otaclient v3.9.1, we have inplace update mode with OTA resume,
+        #                   on child ECU, we don't need rely on OTA cache to speed up the OTA retry anymore.
+        # NOTE(20250801): Due to proxy_info.yaml is forced preserved accross each OTA,
+        #                   (multiple methods are used to ensure that, unfortunately),
+        #                   currently there is no way to update the proxy_info.yaml file on
+        #                   the ECU via OTA.
+        #                 For now, hardcoded to disable OTA cache on the child ECU.
+        #                 To be noticed that, otaproxy OTA cache on main ECU is still needed for streaming
+        #                   the same requests from multiple child ECUs to reduce duplicate downloads.
+        enable_cache=proxy_info.enable_local_ota_proxy_cache
+        and proxy_info.upper_ota_proxy is None,
         enable_https=proxy_info.gateway_otaproxy,
         external_cache_mnt_point=external_cache_mnt_point,
         shm_metrics_writer=shm_metrics_writer,


### PR DESCRIPTION
## Introduction

This PR disables the otaproxy cache on child ECU(child ECU is ECU that has `upper_ota_proxy` configured) in multiple ECUs environment, no matter how `enable_local_ota_proxy_cache` is configured.

The motivation is, starting from otaclient v3.9.1, we have OTA resume feature(requires inplace mode), so for child ECU, we don't need rely on OTA cache to speed up the OTA retry anymore.

However, due to proxy_info.yaml is forced preserved across each OTA(unfortunately this is ensured by multiple methods from multiple area), updating proxy_info.yaml via OTA is currently impossible, so this PR comes up.