### PR TITLE
[3.10] fix: update_slot doesn't raise exception on process_regular_files failed(#612)

### DIFF
--- a/src/otaclient/create_standby/update_slot.py
+++ b/src/otaclient/create_standby/update_slot.py
@@ -247,5 +247,8 @@ class UpdateStandbySlot:
         self._process_non_regular_files()
         self._process_regular_file_entries()
 
+        if self._interrupted.is_set():
+            raise UpdateStandbySlotFailed("failure during regular files processing!")
+
         # finally, cleanup the resource dir
         shutil.rmtree(self._resource_dir, ignore_errors=True)


### PR DESCRIPTION
backport 90c4e465389fc1adfbd5754315870f4286dc9e96 from https://github.com/tier4/ota-client/pull/612