### PR TITLE
[3.10] feat: add cdn cache hit ratio into metrics (#610)

### DIFF
--- a/src/otaclient/metrics.py
+++ b/src/otaclient/metrics.py
@@ -34,6 +34,7 @@ class OTAMetricsSharedMemoryData:
 
     # Cache
     cache_total_requests: int = 0
+    cache_cdn_hits: int = 0
     cache_external_hits: int = 0
     cache_local_hits: int = 0
 
@@ -87,6 +88,7 @@ class OTAMetricsData:
 
     # Cache metrics
     cache_total_requests: int = 0
+    cache_cdn_hits: int = 0
     cache_external_hits: int = 0
     cache_local_hits: int = 0
 

--- a/tests/test_otaclient/test_metrics.py
+++ b/tests/test_otaclient/test_metrics.py
@@ -45,6 +45,7 @@ class TestOTAMetricsData:
         # Create mock shared memory data
         shm_metrics = metrics.OTAMetricsSharedMemoryData()
         shm_metrics.cache_total_requests = 100
+        shm_metrics.cache_cdn_hits = 20
         shm_metrics.cache_external_hits = 50
         shm_metrics.cache_local_hits = 30
 
@@ -53,6 +54,7 @@ class TestOTAMetricsData:
 
         # Verify the data was merged
         assert ota_metrics.cache_total_requests == 100
+        assert ota_metrics.cache_cdn_hits == 20
         assert ota_metrics.cache_external_hits == 50
         assert ota_metrics.cache_local_hits == 30
 


### PR DESCRIPTION
backport 41a632a9f54ee10bfc9a6e05238e2a28bf5add62 from https://github.com/tier4/ota-client/pull/610