### PR TITLE
[3.10] fix: otaproxy cannot commit cache to db when the cache entry already exists(#613)

### DIFF
--- a/src/ota_proxy/ota_cache.py
+++ b/src/ota_proxy/ota_cache.py
@@ -564,7 +564,7 @@ class OTACache:
         # NOTE: register the tracker before open the remote fd!
         tracker = CacheTracker(
             cache_identifier=cache_identifier,
-            base_dir=self._base_dir,
+            base_dir=Path(self._base_dir),
             commit_cache_cb=self._commit_cache_callback,
             below_hard_limit_event=self._storage_below_hard_limit_event,
         )

--- a/tests/test_ota_proxy/test_cache_streaming.py
+++ b/tests/test_ota_proxy/test_cache_streaming.py
@@ -91,7 +91,7 @@ class TestOngoingCachingRegister:
         # NOTE: register the tracker before open the remote fd!
         _tracker = CacheTracker(
             cache_identifier=self.URL,
-            base_dir=self.base_dir,
+            base_dir=Path(self.base_dir),
             commit_cache_cb=None,  # type: ignore
             below_hard_limit_event=None,  # type: ignore
         )
@@ -111,7 +111,7 @@ class TestOngoingCachingRegister:
         await self.register_finish.acquire()
 
         # simulate waiting for writer finished downloading
-        await _tracker.fpath.touch()
+        _tracker.fpath.touch()
         await self.writer_done_event.wait()
 
         # finished


### PR DESCRIPTION
backport ba91b32d6205c682b548b8acfa12b2ca1640391c from https://github.com/tier4/ota-client/pull/613