### PR TITLE
[3.10] refinement: set status as SUCCESS instead of restarting in ClientUpdate

### DIFF
--- a/.github/actions/generate_manifest/generate_manifest.py
+++ b/.github/actions/generate_manifest/generate_manifest.py
@@ -58,14 +58,16 @@ def generate_manifest(input_dir: str):
             if file_type == "squashfs":
                 # squashfs file name format: otaclient-${architecture}-v${version}.squashfs
                 # Supports pre-release versions like: v0.1.dev1, v3.10.0rc1, etc.
-                match = re.search(r"v(\d+\.\d+(?:\.\d+)?(?:\.[a-zA-Z0-9]+)?)", file)
+                match = re.search(
+                    r"v(\d+\.\d+(?:\.\d+)?(?:\.[a-zA-Z0-9]+)?)\.squashfs", file
+                )
                 _base_version = None
                 version = match.group(1) if match else "unknown"
             else:
                 # patch file name format: otaclient-${architecture}_v${BASE_VERSION}-v${VERSION}.patch
                 # Supports pre-release versions in both base and target versions
                 match = re.search(
-                    r"v(\d+\.\d+(?:\.\d+)?(?:\.[a-zA-Z0-9]+)?)-v(\d+\.\d+(?:\.\d+)?(?:\.[a-zA-Z0-9]+)?)",
+                    r"v(\d+\.\d+(?:\.\d+)?(?:\.[a-zA-Z0-9]+)?)-v(\d+\.\d+(?:\.\d+)?(?:\.[a-zA-Z0-9]+)?)\.patch",
                     file,
                 )
                 _base_version = match.group(1) if match else "unknown"

--- a/src/otaclient/errors.py
+++ b/src/otaclient/errors.py
@@ -41,6 +41,8 @@ class OTAErrorCode(int, Enum):
     E_INVALID_STATUS_FOR_OTAROLLBACK = 202
     E_OTA_IMAGE_INVALID = 203
     E_UPDATE_REQUEST_COOKIE_INVALID = 204
+    E_CLIENT_UPDATE_SAME_VERSIONS = 205
+    E_CLIENT_UPDATE_FAILED = 206
 
     #
     # ------ unrecoverable errors ------
@@ -167,6 +169,18 @@ class OTAImageInvalid(OTAErrorRecoverable):
 class UpdateRequestCookieInvalid(OTAErrorRecoverable):
     failure_errcode: OTAErrorCode = OTAErrorCode.E_UPDATE_REQUEST_COOKIE_INVALID
     failure_description: str = "failed to complete OTA as cookie is invalid"
+
+
+class ClientUpdateSameVersions(OTAErrorRecoverable):
+    failure_errcode: OTAErrorCode = OTAErrorCode.E_CLIENT_UPDATE_SAME_VERSIONS
+    failure_description: str = "client package version is the same, skip client update"
+
+
+class ClientUpdateFailed(OTAErrorRecoverable):
+    failure_errcode: OTAErrorCode = OTAErrorCode.E_CLIENT_UPDATE_FAILED
+    failure_description: str = (
+        "failed to update client package, please check the log for more details"
+    )
 
 
 #


### PR DESCRIPTION
backport d3f9255253d31aa1b3e7b502ecd6f46fab49320b from https://github.com/tier4/ota-client/pull/624