### PR TITLE
feat!: migrate to json logging

### DIFF
--- a/src/otaclient/configs/_cfg_configurable.py
+++ b/src/otaclient/configs/_cfg_configurable.py
@@ -45,7 +45,7 @@ class _OTAClientSettings(BaseModel):
         "ota_proxy": "INFO",
     }
     LOG_FORMAT: str = (
-        "[%(asctime)s][%(levelname)s]-%(name)s:%(funcName)s:%(lineno)d,%(message)s"
+        '{"timestamp":"%(asctime)s","level":"%(levelname)s","logger":"%(name)s","function":"%(funcName)s","line":%(lineno)d,"message":"%(message)s"}'
     )
 
     #

--- a/src/otaclient/configs/_cfg_configurable.py
+++ b/src/otaclient/configs/_cfg_configurable.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Dict, Literal
 
@@ -44,9 +45,19 @@ class _OTAClientSettings(BaseModel):
         "otaclient_common": "INFO",
         "ota_proxy": "INFO",
     }
-    LOG_FORMAT: str = (
-        '{"timestamp":"%(asctime)s","level":"%(levelname)s","logger":"%(name)s","function":"%(funcName)s","line":%(lineno)d,"message":"%(message)s"}'
-    )
+
+    @property
+    def LOG_FORMAT(self) -> str:
+        """Generate JSON log format string dynamically."""
+        log_fields = {
+            "timestamp": "%(asctime)s",
+            "level": "%(levelname)s",
+            "logger": "%(name)s",
+            "function": "%(funcName)s",
+            "line": "%(lineno)d",
+            "message": "%(message)s",
+        }
+        return json.dumps(log_fields, separators=(",", ":"))
 
     #
     # ------ downloading settings ------ #

--- a/tests/test_otaclient/test_logging.py
+++ b/tests/test_otaclient/test_logging.py
@@ -94,7 +94,6 @@ class TestLogClient:
     def mock_cfg(self, mocker: MockerFixture):
         self._cfg = _OTAClientSettings(
             LOG_LEVEL_TABLE={__name__: "INFO"},
-            LOG_FORMAT='{"timestamp":"%(asctime)s","level":"%(levelname)s","logger":"%(name)s","function":"%(funcName)s","line":%(lineno)d,"message":"%(message)s"}',
         )
         mocker.patch(f"{MODULE}.cfg", self._cfg)
 


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce.

For better understanding, adding reason/motivation of this PR are also recommended.

-->

### Why
The current log format is plain text, which is not well-suited for log management tools such as Datadog.

### What
Migrate log format to json.
In future, would like to use DATADOG for debugging, and set retention for CloudWatch log group based on the best practice. 

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file(s) that covers the change(s) is implemented.
- [x] local test is passed.
- [ ] design docs/implementation docs are prepared.

Verified E2E Tests.
- Standard Output
```
(venv) root@autoware-ecu:/opt/ota/client# sudo journalctl -u otaclient -f
Aug 06 17:05:29 autoware-ecu otaclient[31283]: {"timestamp":"2025-08-06 17:05:29,186","level":"WARNING","logger":"otaclient.grpc.api_v2.ecu_status","function":"_generate_overall_status_report","line":"204","message":"new failed ECU(s) detected: {'sub', 'autoware'}, current self._state.failed_ecus_id={'sub', 'autoware'}"}
```

- [Cloud Watch](https://ap-northeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-1#logsV2:log-groups/log-group/$252Faws$252Fgreengrass$252Fedge$252Fap-northeast-1$252F947232557913$252Ffms-prd-edge-otaclient/log-events/2025$252F08$252F06$252Ffms-prd-edge-794a25f4-48c6-4f12-be14-d6d62273b5f3-Core$252Fautoware)
<img width="983" height="187" alt="image" src="https://github.com/user-attachments/assets/7f8e1133-d8b3-454a-9210-74f1f6695a31" />

- [DATADOG](https://app.datadoghq.com/logs?query=host%3A%22%2Faws%2Fgreengrass%2Fedge%2Fap-northeast-1%2F947232557913%2Ffms-prd-edge-otaclient%22%20%40aws.awslogs.logStream%3A%2Afms-prd-edge-794a25f4-48c6-4f12-be14-d6d62273b5f3%2A&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZh94WFBgU3ryAAAABhBWmg5NFdGQkFBRERaRUp0SFVOa0RnQUIAAAAkZjE5ODdkZTctMzUwNy00OTFjLTkwMjEtN2UxMGI5ZTE3NGQxAAB6Gg&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1754457869552&to_ts=1754461469552&live=true)
<img width="885" height="756" alt="image" src="https://github.com/user-attachments/assets/7e4f1549-9c5a-49a9-be1a-ae9965597d39" />



## Documents

<!-- For feature PR, design document is required. -->

## Changes

<!-- A list of code change(s) that introduced by this PR. -->

## Behavior changes

Does this PR introduce behavior change(s)?

- [x] Yes, internal behaivor (will not impact user experience).
- [ ] Yes, external behaivor (will impact user experience).
- [ ] No.

### Previous behavior
Plane text format log.
<!-- Behaivor before the PR is introduced -->

### Behavior with this PR
Json format log.

<!-- Behavior after the PR is introduced -->

## Breaking change

Does this PR introduce breaking change?

- [x] Yes.
- [ ] No.

<!-- List the breaking change(s) -->
log format will be json

## Related links & tickets
