### PR TITLE
chore: add system uptime debug message

### DIFF
--- a/src/otaclient/main.py
+++ b/src/otaclient/main.py
@@ -130,8 +130,7 @@ def main() -> None:  # pragma: no cover
     )
     # Log system uptime (time since OS boot)
     try:
-        with open("/proc/uptime", "r") as f:
-            uptime_seconds = float(f.read().split()[0])
+        uptime_seconds = time.clock_gettime(time.CLOCK_BOOTTIME)
         uptime_hours = uptime_seconds // 3600
         uptime_minutes = (uptime_seconds % 3600) // 60
         uptime_secs = uptime_seconds % 60

--- a/src/otaclient/main.py
+++ b/src/otaclient/main.py
@@ -128,6 +128,18 @@ def main() -> None:  # pragma: no cover
     logger.info(
         f"env.running_downloaded_dynamic_ota_client: {os.getenv(cfg.RUNNING_DOWNLOADED_DYNAMIC_OTA_CLIENT)}"
     )
+    # Log system uptime (time since OS boot)
+    try:
+        with open("/proc/uptime", "r") as f:
+            uptime_seconds = float(f.read().split()[0])
+        uptime_hours = uptime_seconds // 3600
+        uptime_minutes = (uptime_seconds % 3600) // 60
+        uptime_secs = uptime_seconds % 60
+        logger.info(
+            f"system uptime: {uptime_hours:.0f}h {uptime_minutes:.0f}m {uptime_secs:.1f}s ({uptime_seconds:.1f}s total)"
+        )
+    except Exception as e:
+        logger.warning(f"failed to read system uptime: {e}")
 
     if _env.is_dynamic_client_preparing():
         logger.info("preparing downloaded dynamic ota client ...")


### PR DESCRIPTION
### Why
Sometimes it takes time to wake up otaclient after rebooting

### What
Add system uptime for logging message.
NOTE: so far, we don't add this to metrics because it is not a part of Update metrics.

### Test
example message:
```
system uptime: 0h 1m 59.0s (119.0s total)
```