### PR TITLE
chore: add client update debug flag

### DIFF
--- a/src/otaclient/configs/_cfg_configurable.py
+++ b/src/otaclient/configs/_cfg_configurable.py
@@ -82,7 +82,7 @@ class _OTAClientSettings(BaseModel):
     #
     # ------ debug flags ------ #
     #
-    DEBUG_ENABLE_FAILURE_TRACEBACK_IN_STATUS_RESP: bool = False
+    DEBUG_ENABLE_SKIP_CLIENT_UPDATE: bool = False
 
     #
     # ------ IO settings ------ #

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -1362,6 +1362,10 @@ class OTAClient:
         NOTE that client update API will not raise any exceptions. The failure information
             is available via status API.
         """
+        if cfg.DEBUG_ENABLE_SKIP_CLIENT_UPDATE:
+            # Skip client update in debug mode
+            return
+
         if _env.is_dynamic_client_running():
             # Duplicates client update should not be allowed.
             # TODO(airkei) [2025-06-19]: should return the dedicated error code for "client update"

--- a/tests/test_otaclient/test_configs/test_cfg_configurable.py
+++ b/tests/test_otaclient/test_configs/test_cfg_configurable.py
@@ -30,7 +30,7 @@ from otaclient.configs import ENV_PREFIX, set_configs
             r"""{"ota_metadata": "DEBUG"}""",
             {"ota_metadata": "DEBUG"},
         ),
-        ("DEBUG_ENABLE_FAILURE_TRACEBACK_IN_STATUS_RESP", "true", True),
+        ("DEBUG_ENABLE_SKIP_CLIENT_UPDATE", "true", True),
         ("DOWNLOAD_INACTIVE_TIMEOUT", "200", 200),
     ),
 )

--- a/tests/test_otaclient/test_ota_core.py
+++ b/tests/test_otaclient/test_ota_core.py
@@ -273,6 +273,27 @@ class TestOTAClient:
         self.ota_client_updater.execute.assert_called_once()
         assert self.ota_client.live_ota_status == OTAStatus.CLIENT_UPDATING
 
+    def test_client_update_debug_mode(self, mocker: pytest_mock.MockerFixture):
+        """Test client update with debug mode enabled - should skip execution."""
+        from otaclient._types import ClientUpdateRequestV2
+
+        # Mock the debug flag to enable skipping client update
+        mocker.patch(f"{OTA_CORE_MODULE}.cfg.DEBUG_ENABLE_SKIP_CLIENT_UPDATE", True)
+
+        initial_status = self.ota_client.live_ota_status
+        # --- execution --- #
+        self.ota_client.client_update(
+            request=ClientUpdateRequestV2(
+                version=self.UPDATE_FIRMWARE_VERSION,
+                url_base=self.OTA_IMAGE_URL,
+                cookies_json=self.UPDATE_COOKIES_JSON,
+                session_id="test_client_update_debug_mode",
+            )
+        )
+
+        self.ota_client_updater.execute.assert_not_called()
+        assert self.ota_client.live_ota_status == initial_status
+
     def test_client_update_interrupted(self, mocker: pytest_mock.MockerFixture):
         """Test client update with interruption."""
         from otaclient._types import ClientUpdateRequestV2


### PR DESCRIPTION
### Why
During development, we sometimes need to use a locally built otaclient instead of the one bundled in the image.

### What
- Removed the unused `DEBUG_ENABLE_FAILURE_TRACEBACK_IN_STATUS_RESP` flag.
- Added `DEBUG_ENABLE_SKIP_CLIENT_UPDATE` to allow skipping the client update process.

