### PR TITLE
chore: bump aiohttp minimum version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dynamic = [
 ]
 dependencies = [
   "anyio>=4.5.1,<5",
-  "aiohttp>=3.10.11,<3.13",
+  "aiohttp>=3.12.14,<3.13",
   "cryptography==45.0.5",
   "grpcio==1.70.0",
   "multidict<7.0,>=4.5",


### PR DESCRIPTION
### Why
https://tier4.atlassian.net/browse/RT4-18639
https://security.snyk.io/vuln/SNYK-PYTHON-AIOHTTP-10742466

### What
Bump aiohttp minimum version to 3.12.14