### PR TITLE
fix!: remove rollback API support

### DIFF
--- a/src/otaclient/grpc/api_v2/servicer.py
+++ b/src/otaclient/grpc/api_v2/servicer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """OTA Service API v2 implementation."""
 
-
 from __future__ import annotations
 
 import asyncio
@@ -73,14 +72,6 @@ class OTAClientAPIServicer:
         """Thread worker for dispatching a local update."""
         return self._dispatch_local_request(request, api_types.UpdateResponseEcu)
 
-    def _local_rollback(
-        self, rollback_request: RollbackRequestV2
-    ) -> api_types.RollbackResponseEcu:
-        """Thread worker for dispatching a local rollback."""
-        return self._dispatch_local_request(
-            rollback_request, api_types.RollbackResponseEcu
-        )
-
     def _local_client_update(
         self, request: ClientUpdateRequestV2
     ) -> api_types.ClientUpdateResponseEcu:
@@ -125,9 +116,9 @@ class OTAClientAPIServicer:
         try:
             _req_response = self._resp_queue.get(timeout=WAIT_FOR_LOCAL_ECU_ACK_TIMEOUT)
             assert isinstance(_req_response, IPCResponse), "unexpected msg"
-            assert (
-                _req_response.session_id == request.session_id
-            ), "mismatched session_id"
+            assert _req_response.session_id == request.session_id, (
+                "mismatched session_id"
+            )
 
             if _req_response.res == IPCResEnum.ACCEPT:
                 return response_type(
@@ -381,14 +372,17 @@ class OTAClientAPIServicer:
     async def rollback(
         self, request: api_types.RollbackRequest
     ) -> api_types.RollbackResponse:
-        return await self._handle_request(
-            request=request,
-            local_handler=self._local_rollback,
-            request_cls=RollbackRequestV2,
-            remote_call=OTAClientCall.rollback_call,
-            response_type=api_types.RollbackResponse,
-            update_acked_ecus=None,
-        )
+        # NOTE(20250818): remove rollback API handler support
+        _res = []
+        for _ecu_req in request.ecu:
+            _res.append(
+                api_types.RollbackResponseEcu(
+                    ecu_id=_ecu_req.ecu_id,
+                    result=api_types.FailureType.RECOVERABLE,
+                    message="rollback API support is removed",
+                ),
+            )
+        return api_types.RollbackResponse(ecu=_res)
 
     async def client_update(
         self, request: api_types.ClientUpdateRequest

--- a/src/otaclient/grpc/api_v2/servicer.py
+++ b/src/otaclient/grpc/api_v2/servicer.py
@@ -116,9 +116,9 @@ class OTAClientAPIServicer:
         try:
             _req_response = self._resp_queue.get(timeout=WAIT_FOR_LOCAL_ECU_ACK_TIMEOUT)
             assert isinstance(_req_response, IPCResponse), "unexpected msg"
-            assert _req_response.session_id == request.session_id, (
-                "mismatched session_id"
-            )
+            assert (
+                _req_response.session_id == request.session_id
+            ), "mismatched session_id"
 
             if _req_response.res == IPCResEnum.ACCEPT:
                 return response_type(

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -233,9 +233,9 @@ class _OTAUpdateOperator:
         logger.debug("process cookies_json...")
         try:
             cookies = json.loads(cookies_json)
-            assert isinstance(cookies, dict), (
-                f"invalid cookies, expecting json object: {cookies_json}"
-            )
+            assert isinstance(
+                cookies, dict
+            ), f"invalid cookies, expecting json object: {cookies_json}"
         except (JSONDecodeError, AssertionError) as e:
             _err_msg = f"cookie is invalid: {cookies_json=}"
             logger.error(_err_msg)

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -68,7 +68,6 @@ from otaclient._types import (
     IPCResponse,
     MultipleECUStatusFlags,
     OTAStatus,
-    RollbackRequestV2,
     UpdatePhase,
     UpdateRequestV2,
 )
@@ -234,9 +233,9 @@ class _OTAUpdateOperator:
         logger.debug("process cookies_json...")
         try:
             cookies = json.loads(cookies_json)
-            assert isinstance(
-                cookies, dict
-            ), f"invalid cookies, expecting json object: {cookies_json}"
+            assert isinstance(cookies, dict), (
+                f"invalid cookies, expecting json object: {cookies_json}"
+            )
         except (JSONDecodeError, AssertionError) as e:
             _err_msg = f"cookie is invalid: {cookies_json=}"
             logger.error(_err_msg)
@@ -1420,31 +1419,6 @@ class OTAClient:
         finally:
             shutil.rmtree(session_wd, ignore_errors=True)
 
-    def rollback(self, request: RollbackRequestV2) -> None:
-        self._live_ota_status = OTAStatus.ROLLBACKING
-        new_session_id = request.session_id
-        self._status_report_queue.put_nowait(
-            StatusReport(
-                payload=OTAStatusChangeReport(
-                    new_ota_status=OTAStatus.ROLLBACKING,
-                ),
-                session_id=new_session_id,
-            )
-        )
-
-        logger.info(f"start new OTA rollback session: {new_session_id=}")
-        try:
-            logger.info("[rollback] entering...")
-            self._live_ota_status = OTAStatus.ROLLBACKING
-            _OTARollbacker(boot_controller=self.boot_controller).execute()
-        except ota_errors.OTAError as e:
-            self._on_failure(
-                e,
-                ota_status=OTAStatus.FAILURE,
-                failure_reason=e.get_failure_reason(),
-                failure_type=e.failure_type,
-            )
-
     def main(
         self,
         *,
@@ -1510,26 +1484,6 @@ class OTAClient:
                 _allow_request_after = (
                     _now + HOLD_REQ_HANDLING_ON_ACK_CLIENT_UPDATE_REQUEST
                 )
-
-            elif (
-                isinstance(request, RollbackRequestV2)
-                and self._live_ota_status == OTAStatus.SUCCESS
-            ):
-                _rollback_thread = threading.Thread(
-                    target=self.rollback,
-                    args=[request],
-                    daemon=True,
-                    name="ota_rollback_executor",
-                )
-                _rollback_thread.start()
-
-                resp_queue.put_nowait(
-                    IPCResponse(
-                        res=IPCResEnum.ACCEPT,
-                        session_id=request.session_id,
-                    )
-                )
-                _allow_request_after = _now + HOLD_REQ_HANDLING_ON_ACK_REQUEST
             else:
                 _err_msg = f"request is invalid: {request=}, {self._live_ota_status=}"
                 logger.error(_err_msg)

--- a/tests/test_otaclient/test_grpc/test_api_v2/test_servicer.py
+++ b/tests/test_otaclient/test_grpc/test_api_v2/test_servicer.py
@@ -395,6 +395,7 @@ class TestOTAClientAPIServicer:
 
     @pytest.mark.asyncio
     async def test_rollback_local_ecu(self, mocker: MockerFixture):
+        """Ensure that rollback is not triggerred."""
         # Arrange
         rollback_request = api_types.RollbackRequest()
         rollback_request.add_ecu(
@@ -426,12 +427,13 @@ class TestOTAClientAPIServicer:
         expected_response.add_ecu(
             api_types.RollbackResponseEcu(
                 ecu_id="autoware",
-                result=api_types.FailureType.NO_FAILURE,
+                result=api_types.FailureType.RECOVERABLE,
+                message="rollback API support is removed",
             )
         )
 
         compare_message(result, expected_response)
-        self.op_queue.put_nowait.assert_called_once()
+        self.op_queue.put_nowait.assert_not_called()
         self.ecu_status_storage.on_ecus_accept_update_request.assert_not_called()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Introduction

The rollback API is not used, while exposes a potential DoS vulnerability that can be utilized by attackers that has local network access to the otaclient grpc server listen address due to the request is not signed and verified.

This PR removes the actual rollback grpc API handler, replaced with a dummy handler that responds with failure `RECOVERABLE` and message `rollback support is removed`, indicating rollback API is invalid. 

TODO: redesign the rollback API to support request signing, or completely remove this API from the API definition.