### PR TITLE
feat: add request id as common ID shared between multiple ECUs

### DIFF
--- a/proto/otaclient_v2.proto
+++ b/proto/otaclient_v2.proto
@@ -86,6 +86,7 @@ message UpdateRequestEcu {
 
 message UpdateRequest {
   repeated UpdateRequestEcu ecu = 1;
+  uint64 request_id = 2; // Request id to identify the request from the client.
 }
 
 // Response
@@ -110,6 +111,7 @@ message RollbackRequestEcu {
 
 message RollbackRequest {
   repeated RollbackRequestEcu ecu = 1;
+  uint64 request_id = 2; // Request id to identify the request from the client.
 }
 
 // Response

--- a/proto/otaclient_v2.proto
+++ b/proto/otaclient_v2.proto
@@ -86,7 +86,7 @@ message UpdateRequestEcu {
 
 message UpdateRequest {
   repeated UpdateRequestEcu ecu = 1;
-  uint64 request_id = 2; // Request id to identify the request from the client.
+  string request_id = 2; // Request id to identify the request from the client.
 }
 
 // Response
@@ -111,7 +111,7 @@ message RollbackRequestEcu {
 
 message RollbackRequest {
   repeated RollbackRequestEcu ecu = 1;
-  uint64 request_id = 2; // Request id to identify the request from the client.
+  string request_id = 2; // Request id to identify the request from the client.
 }
 
 // Response

--- a/src/otaclient/_types.py
+++ b/src/otaclient/_types.py
@@ -21,7 +21,6 @@ from dataclasses import dataclass
 from typing import ClassVar, Optional
 
 from _otaclient_version import __version__
-
 from otaclient.configs.cfg import ecu_info
 from otaclient_common._typing import StrEnum
 
@@ -163,6 +162,7 @@ class IPCResponse:
 
 @dataclass
 class IPCRequest:
+    request_id: str
     session_id: str
 
 

--- a/src/otaclient/_types.py
+++ b/src/otaclient/_types.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from typing import ClassVar, Optional
 
 from _otaclient_version import __version__
+
 from otaclient.configs.cfg import ecu_info
 from otaclient_common._typing import StrEnum
 

--- a/src/otaclient/_utils.py
+++ b/src/otaclient/_utils.py
@@ -113,9 +113,24 @@ class SharedOTAClientMetricsReader(MPSharedMemoryReader[OTAMetricsSharedMemoryDa
     """Util for reading OTAMetricsSharedMemoryData from shm."""
 
 
+REQUEST_RANDOM_LEN = 4  # bytes, the corresponding hex string will be 8 chars
 SESSION_RANDOM_LEN = 4  # bytes, the corresponding hex string will be 8 chars
 
 _illegal_chars_pattern = re.compile(r'[\.\/\0<>:"\\|?*\x00-\x1F]')
+
+
+def gen_request_id(
+    *, random_bytes_num: int = REQUEST_RANDOM_LEN
+) -> str:  # pragma: no cover
+    """Generate a unique request_id for the new OTA request targeting multiple ECUs
+
+    request_id schema:
+        <unix_timestamp_in_sec_str>-<4bytes_hex>
+    """
+    _time_factor = str(int(time.time()))
+    _random_factor = os.urandom(random_bytes_num).hex()
+
+    return f"{_time_factor}-{_random_factor}"
 
 
 def gen_session_id(

--- a/src/otaclient/metrics.py
+++ b/src/otaclient/metrics.py
@@ -19,7 +19,6 @@ import logging
 from dataclasses import asdict, dataclass
 
 from _otaclient_version import __version__
-
 from otaclient._logging import LogType
 from otaclient.configs.cfg import ecu_info
 
@@ -59,6 +58,7 @@ class OTAMetricsData:
 
     # ECU and Firmware
     ecu_id: str = ecu_info.ecu_id
+    request_id: str = ""
     session_id: str = ""
     current_firmware_version: str = ""
     target_firmware_version: str = ""

--- a/src/otaclient/metrics.py
+++ b/src/otaclient/metrics.py
@@ -19,6 +19,7 @@ import logging
 from dataclasses import asdict, dataclass
 
 from _otaclient_version import __version__
+
 from otaclient._logging import LogType
 from otaclient.configs.cfg import ecu_info
 

--- a/src/otaclient/ota_core.py
+++ b/src/otaclient/ota_core.py
@@ -1302,6 +1302,7 @@ class OTAClient:
             is available via status API.
         """
         self._live_ota_status = OTAStatus.UPDATING
+        request_id = request.request_id
         new_session_id = request.session_id
         self._status_report_queue.put_nowait(
             StatusReport(
@@ -1311,9 +1312,12 @@ class OTAClient:
                 session_id=new_session_id,
             )
         )
-        logger.info(f"start new OTA update session: {new_session_id=}")
+        logger.info(
+            f"start new OTA update request:{request_id}, session: {new_session_id=}"
+        )
 
         session_wd = self._update_session_dir / new_session_id
+        self._metrics.request_id = request_id
         self._metrics.session_id = new_session_id
         try:
             logger.info("[update] entering local update...")
@@ -1367,6 +1371,7 @@ class OTAClient:
             return
 
         self._live_ota_status = OTAStatus.CLIENT_UPDATING
+        request_id = request.request_id
         new_session_id = request.session_id
         self._status_report_queue.put_nowait(
             StatusReport(
@@ -1376,7 +1381,9 @@ class OTAClient:
                 session_id=new_session_id,
             )
         )
-        logger.info(f"start new OTA client update session: {new_session_id=}")
+        logger.info(
+            f"start new OTA client update request: {request_id}, session: {new_session_id=}"
+        )
 
         session_wd = self._update_session_dir / new_session_id
         try:

--- a/src/otaclient_api/v2/_types.py
+++ b/src/otaclient_api/v2/_types.py
@@ -182,9 +182,13 @@ class RollbackRequestEcu(MessageWrapper[pb2.RollbackRequestEcu]):
 class RollbackRequest(ECUList[RollbackRequestEcu], MessageWrapper[pb2.RollbackRequest]):
     __slots__ = calculate_slots(pb2.RollbackRequest)
     ecu: RepeatedCompositeContainer[RollbackRequestEcu]
+    request_id: str
 
     def __init__(
-        self, *, ecu: _Optional[_Iterable[RollbackRequestEcu]] = ...
+        self,
+        *,
+        ecu: _Optional[_Iterable[RollbackRequestEcu]] = ...,
+        request_id: _Optional[str] = ...,
     ) -> None: ...
 
 
@@ -562,9 +566,13 @@ class UpdateRequestEcu(MessageWrapper[pb2.UpdateRequestEcu]):
 class UpdateRequest(ECUList[UpdateRequestEcu], MessageWrapper[pb2.UpdateRequest]):
     __slots__ = calculate_slots(pb2.UpdateRequest)
     ecu: RepeatedCompositeContainer[UpdateRequestEcu]
+    request_id: str
 
     def __init__(
-        self, *, ecu: _Optional[_Iterable[UpdateRequestEcu]] = ...
+        self,
+        *,
+        ecu: _Optional[_Iterable[UpdateRequestEcu]] = ...,
+        request_id: _Optional[str] = ...,
     ) -> None: ...
 
 
@@ -631,9 +639,13 @@ class ClientUpdateRequest(
 ):
     __slots__ = calculate_slots(pb2.UpdateRequest)
     ecu: RepeatedCompositeContainer[ClientUpdateRequestEcu]
+    request_id: str
 
     def __init__(
-        self, *, ecu: _Optional[_Iterable[ClientUpdateRequestEcu]] = ...
+        self,
+        *,
+        ecu: _Optional[_Iterable[ClientUpdateRequestEcu]] = ...,
+        request_id: _Optional[str] = ...,
     ) -> None: ...
 
 

--- a/src/otaclient_api/v2/otaclient_v2_pb2.py
+++ b/src/otaclient_api/v2/otaclient_v2_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import duration_pb2 as google_dot_protobuf_dot_duration__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n#otaclient_api/v2/otaclient_v2.proto\x12\x0bOtaClientV2\x1a\x1egoogle/protobuf/duration.proto\"Q\n\x10UpdateRequestEcu\x12\x0e\n\x06\x65\x63u_id\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x0b\n\x03url\x18\x03 \x01(\t\x12\x0f\n\x07\x63ookies\x18\x04 \x01(\t\";\n\rUpdateRequest\x12*\n\x03\x65\x63u\x18\x01 \x03(\x0b\x32\x1d.OtaClientV2.UpdateRequestEcu\"^\n\x11UpdateResponseEcu\x12\x0e\n\x06\x65\x63u_id\x18\x01 \x01(\t\x12(\n\x06result\x18\x02 \x01(\x0e\x32\x18.OtaClientV2.FailureType\x12\x0f\n\x07message\x18\x03 \x01(\t\"=\n\x0eUpdateResponse\x12+\n\x03\x65\x63u\x18\x01 \x03(\x0b\x32\x1e.OtaClientV2.UpdateResponseEcu\"$\n\x12RollbackRequestEcu\x12\x0e\n\x06\x65\x63u_id\x18\x01 \x01(\t\"?\n\x0fRollbackRequest\x12,\n\x03\x65\x63u\x18\x01 \x03(\x0b\x32\x1f.OtaClientV2.RollbackRequestEcu\"`\n\x13RollbackResponseEcu\x12\x0e\n\x06\x65\x63u_id\x18\x01 \x01(\t\x12(\n\x06result\x18\x02 \x01(\x0e\x32\x18.OtaClientV2.FailureType\x12\x0f\n\x07message\x18\x03 \x01(\t\"A\n\x10RollbackResponse\x12-\n\x03\x65\x63u\x18\x01 \x03(\x0b\x32 .OtaClientV2.RollbackResponseEcu\"\x0f\n\rStatusRequest\"\xf6\x04\n\x0eStatusProgress\x12/\n\x05phase\x18\x01 \x01(\x0e\x32 .OtaClientV2.StatusProgressPhase\x12\x1b\n\x13total_regular_files\x18\x02 \x01(\x04\x12\x1f\n\x17regular_files_processed\x18\x03 \x01(\x04\x12\x1c\n\x14\x66iles_processed_copy\x18\x04 \x01(\x04\x12\x1c\n\x14\x66iles_processed_link\x18\x05 \x01(\x04\x12 \n\x18\x66iles_processed_download\x18\x06 \x01(\x04\x12 \n\x18\x66ile_size_processed_copy\x18\x07 \x01(\x04\x12 \n\x18\x66ile_size_processed_link\x18\x08 \x01(\x04\x12$\n\x1c\x66ile_size_processed_download\x18\t \x01(\x04\x12\x34\n\x11\x65lapsed_time_copy\x18\n \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x34\n\x11\x65lapsed_time_link\x18\x0b \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x38\n\x15\x65lapsed_time_download\x18\x0c \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x17\n\x0f\x65rrors_download\x18\r \x01(\x04\x12\x1f\n\x17total_regular_file_size\x18\x0e \x01(\x04\x12\x35\n\x12total_elapsed_time\x18\x0f \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x16\n\x0e\x64ownload_bytes\x18\x10 \x01(\x04\"\xb3\x01\n\x06Status\x12&\n\x06status\x18\x01 \x01(\x0e\x32\x16.OtaClientV2.StatusOta\x12)\n\x07\x66\x61ilure\x18\x02 \x01(\x0e\x32\x18.OtaClientV2.FailureType\x12\x16\n\x0e\x66\x61ilure_reason\x18\x03 \x01(\t\x12\x0f\n\x07version\x18\x04 \x01(\t\x12-\n\x08progress\x18\x05 \x01(\x0b\x32\x1b.OtaClientV2.StatusProgress\"r\n\x11StatusResponseEcu\x12\x0e\n\x06\x65\x63u_id\x18\x01 \x01(\t\x12(\n\x06result\x18\x02 \x01(\x0e\x32\x18.OtaClientV2.FailureType\x12#\n\x06status\x18\x03 \x01(\x0b\x32\x13.OtaClientV2.Status\"\x8e\x01\n\x0eStatusResponse\x12/\n\x03\x65\x63u\x18\x01 \x03(\x0b\x32\x1e.OtaClientV2.StatusResponseEcuB\x02\x18\x01\x12\x19\n\x11\x61vailable_ecu_ids\x18\x02 \x03(\t\x12\x30\n\x06\x65\x63u_v2\x18\x03 \x03(\x0b\x32 .OtaClientV2.StatusResponseEcuV2\"\x87\x03\n\x13StatusResponseEcuV2\x12\x0e\n\x06\x65\x63u_id\x18\x01 \x01(\t\x12\x18\n\x10\x66irmware_version\x18\x02 \x01(\t\x12\x19\n\x11otaclient_version\x18\x03 \x01(\t\x12*\n\nota_status\x18\x0b \x01(\x0e\x32\x16.OtaClientV2.StatusOta\x12\x33\n\x0c\x66\x61ilure_type\x18\x0c \x01(\x0e\x32\x18.OtaClientV2.FailureTypeH\x00\x88\x01\x01\x12\x1b\n\x0e\x66\x61ilure_reason\x18\r \x01(\tH\x01\x88\x01\x01\x12\x1e\n\x11\x66\x61ilure_traceback\x18\x0e \x01(\tH\x02\x88\x01\x01\x12\x35\n\rupdate_status\x18\x0f \x01(\x0b\x32\x19.OtaClientV2.UpdateStatusH\x03\x88\x01\x01\x42\x0f\n\r_failure_typeB\x11\n\x0f_failure_reasonB\x14\n\x12_failure_tracebackB\x10\n\x0e_update_statusJ\x04\x08\x04\x10\x0bJ\x04\x08\x10\x10\x11\"\xdd\x05\n\x0cUpdateStatus\x12\x1f\n\x17update_firmware_version\x18\x01 \x01(\t\x12%\n\x1dtotal_files_size_uncompressed\x18\x02 \x01(\x04\x12\x17\n\x0ftotal_files_num\x18\x03 \x01(\x04\x12\x1e\n\x16update_start_timestamp\x18\x04 \x01(\x04\x12\'\n\x05phase\x18\x0b \x01(\x0e\x32\x18.OtaClientV2.UpdatePhase\x12 \n\x18total_download_files_num\x18\x0c \x01(\x04\x12!\n\x19total_download_files_size\x18\r \x01(\x04\x12\x1c\n\x14\x64ownloaded_files_num\x18\x0e \x01(\x04\x12\x18\n\x10\x64ownloaded_bytes\x18\x0f \x01(\x04\x12\x1d\n\x15\x64ownloaded_files_size\x18\x10 \x01(\x04\x12\x1a\n\x12\x64ownloading_errors\x18\x11 \x01(\x04\x12\x1e\n\x16total_remove_files_num\x18\x12 \x01(\x04\x12\x19\n\x11removed_files_num\x18\x13 \x01(\x04\x12\x1b\n\x13processed_files_num\x18\x14 \x01(\x04\x12\x1c\n\x14processed_files_size\x18\x15 \x01(\x04\x12\x35\n\x12total_elapsed_time\x18\x1f \x01(\x0b\x32\x19.google.protobuf.Duration\x12@\n\x1d\x64\x65lta_generating_elapsed_time\x18  \x01(\x0b\x32\x19.google.protobuf.Duration\x12;\n\x18\x64ownloading_elapsed_time\x18! \x01(\x0b\x32\x19.google.protobuf.Duration\x12?\n\x1cupdate_applying_elapsed_time\x18\" \x01(\x0b\x32\x19.google.protobuf.Duration*A\n\x0b\x46\x61ilureType\x12\x0e\n\nNO_FAILURE\x10\x00\x12\x0f\n\x0bRECOVERABLE\x10\x01\x12\x11\n\rUNRECOVERABLE\x10\x02*\x80\x01\n\tStatusOta\x12\x0f\n\x0bINITIALIZED\x10\x00\x12\x0b\n\x07SUCCESS\x10\x01\x12\x0b\n\x07\x46\x41ILURE\x10\x02\x12\x0c\n\x08UPDATING\x10\x03\x12\x0f\n\x0bROLLBACKING\x10\x04\x12\x14\n\x10ROLLBACK_FAILURE\x10\x05\x12\x13\n\x0f\x43LIENT_UPDATING\x10\x06*~\n\x13StatusProgressPhase\x12\x0b\n\x07INITIAL\x10\x00\x12\x0c\n\x08METADATA\x10\x01\x12\r\n\tDIRECTORY\x10\x02\x12\x0b\n\x07SYMLINK\x10\x03\x12\x0b\n\x07REGULAR\x10\x04\x12\x0e\n\nPERSISTENT\x10\x05\x12\x13\n\x0fPOST_PROCESSING\x10\x06*\xcd\x01\n\x0bUpdatePhase\x12\x10\n\x0cINITIALIZING\x10\x00\x12\x17\n\x13PROCESSING_METADATA\x10\x01\x12\x15\n\x11\x43\x41LCULATING_DELTA\x10\x02\x12\x19\n\x15\x44OWNLOADING_OTA_FILES\x10\x03\x12\x13\n\x0f\x41PPLYING_UPDATE\x10\x04\x12\x19\n\x15PROCESSING_POSTUPDATE\x10\x05\x12\x15\n\x11\x46INALIZING_UPDATE\x10\x06\x12\x1a\n\x16\x44OWNLOADING_OTA_CLIENT\x10\x07\x32\xb2\x02\n\x10OtaClientService\x12\x43\n\x06Update\x12\x1a.OtaClientV2.UpdateRequest\x1a\x1b.OtaClientV2.UpdateResponse\"\x00\x12I\n\x08Rollback\x12\x1c.OtaClientV2.RollbackRequest\x1a\x1d.OtaClientV2.RollbackResponse\"\x00\x12\x43\n\x06Status\x12\x1a.OtaClientV2.StatusRequest\x1a\x1b.OtaClientV2.StatusResponse\"\x00\x12I\n\x0c\x43lientUpdate\x12\x1a.OtaClientV2.UpdateRequest\x1a\x1b.OtaClientV2.UpdateResponse\"\x00\x42\x06\xa2\x02\x03OTAb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n#otaclient_api/v2/otaclient_v2.proto\x12\x0bOtaClientV2\x1a\x1egoogle/protobuf/duration.proto\"Q\n\x10UpdateRequestEcu\x12\x0e\n\x06\x65\x63u_id\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x0b\n\x03url\x18\x03 \x01(\t\x12\x0f\n\x07\x63ookies\x18\x04 \x01(\t\"O\n\rUpdateRequest\x12*\n\x03\x65\x63u\x18\x01 \x03(\x0b\x32\x1d.OtaClientV2.UpdateRequestEcu\x12\x12\n\nrequest_id\x18\x02 \x01(\t\"^\n\x11UpdateResponseEcu\x12\x0e\n\x06\x65\x63u_id\x18\x01 \x01(\t\x12(\n\x06result\x18\x02 \x01(\x0e\x32\x18.OtaClientV2.FailureType\x12\x0f\n\x07message\x18\x03 \x01(\t\"=\n\x0eUpdateResponse\x12+\n\x03\x65\x63u\x18\x01 \x03(\x0b\x32\x1e.OtaClientV2.UpdateResponseEcu\"$\n\x12RollbackRequestEcu\x12\x0e\n\x06\x65\x63u_id\x18\x01 \x01(\t\"S\n\x0fRollbackRequest\x12,\n\x03\x65\x63u\x18\x01 \x03(\x0b\x32\x1f.OtaClientV2.RollbackRequestEcu\x12\x12\n\nrequest_id\x18\x02 \x01(\t\"`\n\x13RollbackResponseEcu\x12\x0e\n\x06\x65\x63u_id\x18\x01 \x01(\t\x12(\n\x06result\x18\x02 \x01(\x0e\x32\x18.OtaClientV2.FailureType\x12\x0f\n\x07message\x18\x03 \x01(\t\"A\n\x10RollbackResponse\x12-\n\x03\x65\x63u\x18\x01 \x03(\x0b\x32 .OtaClientV2.RollbackResponseEcu\"\x0f\n\rStatusRequest\"\xf6\x04\n\x0eStatusProgress\x12/\n\x05phase\x18\x01 \x01(\x0e\x32 .OtaClientV2.StatusProgressPhase\x12\x1b\n\x13total_regular_files\x18\x02 \x01(\x04\x12\x1f\n\x17regular_files_processed\x18\x03 \x01(\x04\x12\x1c\n\x14\x66iles_processed_copy\x18\x04 \x01(\x04\x12\x1c\n\x14\x66iles_processed_link\x18\x05 \x01(\x04\x12 \n\x18\x66iles_processed_download\x18\x06 \x01(\x04\x12 \n\x18\x66ile_size_processed_copy\x18\x07 \x01(\x04\x12 \n\x18\x66ile_size_processed_link\x18\x08 \x01(\x04\x12$\n\x1c\x66ile_size_processed_download\x18\t \x01(\x04\x12\x34\n\x11\x65lapsed_time_copy\x18\n \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x34\n\x11\x65lapsed_time_link\x18\x0b \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x38\n\x15\x65lapsed_time_download\x18\x0c \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x17\n\x0f\x65rrors_download\x18\r \x01(\x04\x12\x1f\n\x17total_regular_file_size\x18\x0e \x01(\x04\x12\x35\n\x12total_elapsed_time\x18\x0f \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x16\n\x0e\x64ownload_bytes\x18\x10 \x01(\x04\"\xb3\x01\n\x06Status\x12&\n\x06status\x18\x01 \x01(\x0e\x32\x16.OtaClientV2.StatusOta\x12)\n\x07\x66\x61ilure\x18\x02 \x01(\x0e\x32\x18.OtaClientV2.FailureType\x12\x16\n\x0e\x66\x61ilure_reason\x18\x03 \x01(\t\x12\x0f\n\x07version\x18\x04 \x01(\t\x12-\n\x08progress\x18\x05 \x01(\x0b\x32\x1b.OtaClientV2.StatusProgress\"r\n\x11StatusResponseEcu\x12\x0e\n\x06\x65\x63u_id\x18\x01 \x01(\t\x12(\n\x06result\x18\x02 \x01(\x0e\x32\x18.OtaClientV2.FailureType\x12#\n\x06status\x18\x03 \x01(\x0b\x32\x13.OtaClientV2.Status\"\x8e\x01\n\x0eStatusResponse\x12/\n\x03\x65\x63u\x18\x01 \x03(\x0b\x32\x1e.OtaClientV2.StatusResponseEcuB\x02\x18\x01\x12\x19\n\x11\x61vailable_ecu_ids\x18\x02 \x03(\t\x12\x30\n\x06\x65\x63u_v2\x18\x03 \x03(\x0b\x32 .OtaClientV2.StatusResponseEcuV2\"\x87\x03\n\x13StatusResponseEcuV2\x12\x0e\n\x06\x65\x63u_id\x18\x01 \x01(\t\x12\x18\n\x10\x66irmware_version\x18\x02 \x01(\t\x12\x19\n\x11otaclient_version\x18\x03 \x01(\t\x12*\n\nota_status\x18\x0b \x01(\x0e\x32\x16.OtaClientV2.StatusOta\x12\x33\n\x0c\x66\x61ilure_type\x18\x0c \x01(\x0e\x32\x18.OtaClientV2.FailureTypeH\x00\x88\x01\x01\x12\x1b\n\x0e\x66\x61ilure_reason\x18\r \x01(\tH\x01\x88\x01\x01\x12\x1e\n\x11\x66\x61ilure_traceback\x18\x0e \x01(\tH\x02\x88\x01\x01\x12\x35\n\rupdate_status\x18\x0f \x01(\x0b\x32\x19.OtaClientV2.UpdateStatusH\x03\x88\x01\x01\x42\x0f\n\r_failure_typeB\x11\n\x0f_failure_reasonB\x14\n\x12_failure_tracebackB\x10\n\x0e_update_statusJ\x04\x08\x04\x10\x0bJ\x04\x08\x10\x10\x11\"\xdd\x05\n\x0cUpdateStatus\x12\x1f\n\x17update_firmware_version\x18\x01 \x01(\t\x12%\n\x1dtotal_files_size_uncompressed\x18\x02 \x01(\x04\x12\x17\n\x0ftotal_files_num\x18\x03 \x01(\x04\x12\x1e\n\x16update_start_timestamp\x18\x04 \x01(\x04\x12\'\n\x05phase\x18\x0b \x01(\x0e\x32\x18.OtaClientV2.UpdatePhase\x12 \n\x18total_download_files_num\x18\x0c \x01(\x04\x12!\n\x19total_download_files_size\x18\r \x01(\x04\x12\x1c\n\x14\x64ownloaded_files_num\x18\x0e \x01(\x04\x12\x18\n\x10\x64ownloaded_bytes\x18\x0f \x01(\x04\x12\x1d\n\x15\x64ownloaded_files_size\x18\x10 \x01(\x04\x12\x1a\n\x12\x64ownloading_errors\x18\x11 \x01(\x04\x12\x1e\n\x16total_remove_files_num\x18\x12 \x01(\x04\x12\x19\n\x11removed_files_num\x18\x13 \x01(\x04\x12\x1b\n\x13processed_files_num\x18\x14 \x01(\x04\x12\x1c\n\x14processed_files_size\x18\x15 \x01(\x04\x12\x35\n\x12total_elapsed_time\x18\x1f \x01(\x0b\x32\x19.google.protobuf.Duration\x12@\n\x1d\x64\x65lta_generating_elapsed_time\x18  \x01(\x0b\x32\x19.google.protobuf.Duration\x12;\n\x18\x64ownloading_elapsed_time\x18! \x01(\x0b\x32\x19.google.protobuf.Duration\x12?\n\x1cupdate_applying_elapsed_time\x18\" \x01(\x0b\x32\x19.google.protobuf.Duration*A\n\x0b\x46\x61ilureType\x12\x0e\n\nNO_FAILURE\x10\x00\x12\x0f\n\x0bRECOVERABLE\x10\x01\x12\x11\n\rUNRECOVERABLE\x10\x02*\x80\x01\n\tStatusOta\x12\x0f\n\x0bINITIALIZED\x10\x00\x12\x0b\n\x07SUCCESS\x10\x01\x12\x0b\n\x07\x46\x41ILURE\x10\x02\x12\x0c\n\x08UPDATING\x10\x03\x12\x0f\n\x0bROLLBACKING\x10\x04\x12\x14\n\x10ROLLBACK_FAILURE\x10\x05\x12\x13\n\x0f\x43LIENT_UPDATING\x10\x06*~\n\x13StatusProgressPhase\x12\x0b\n\x07INITIAL\x10\x00\x12\x0c\n\x08METADATA\x10\x01\x12\r\n\tDIRECTORY\x10\x02\x12\x0b\n\x07SYMLINK\x10\x03\x12\x0b\n\x07REGULAR\x10\x04\x12\x0e\n\nPERSISTENT\x10\x05\x12\x13\n\x0fPOST_PROCESSING\x10\x06*\xcd\x01\n\x0bUpdatePhase\x12\x10\n\x0cINITIALIZING\x10\x00\x12\x17\n\x13PROCESSING_METADATA\x10\x01\x12\x15\n\x11\x43\x41LCULATING_DELTA\x10\x02\x12\x19\n\x15\x44OWNLOADING_OTA_FILES\x10\x03\x12\x13\n\x0f\x41PPLYING_UPDATE\x10\x04\x12\x19\n\x15PROCESSING_POSTUPDATE\x10\x05\x12\x15\n\x11\x46INALIZING_UPDATE\x10\x06\x12\x1a\n\x16\x44OWNLOADING_OTA_CLIENT\x10\x07\x32\xb2\x02\n\x10OtaClientService\x12\x43\n\x06Update\x12\x1a.OtaClientV2.UpdateRequest\x1a\x1b.OtaClientV2.UpdateResponse\"\x00\x12I\n\x08Rollback\x12\x1c.OtaClientV2.RollbackRequest\x1a\x1d.OtaClientV2.RollbackResponse\"\x00\x12\x43\n\x06Status\x12\x1a.OtaClientV2.StatusRequest\x1a\x1b.OtaClientV2.StatusResponse\"\x00\x12I\n\x0c\x43lientUpdate\x12\x1a.OtaClientV2.UpdateRequest\x1a\x1b.OtaClientV2.UpdateResponse\"\x00\x42\x06\xa2\x02\x03OTAb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -25,44 +25,44 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   DESCRIPTOR._serialized_options = b'\242\002\003OTA'
   _STATUSRESPONSE.fields_by_name['ecu']._options = None
   _STATUSRESPONSE.fields_by_name['ecu']._serialized_options = b'\030\001'
-  _globals['_FAILURETYPE']._serialized_start=2878
-  _globals['_FAILURETYPE']._serialized_end=2943
-  _globals['_STATUSOTA']._serialized_start=2946
-  _globals['_STATUSOTA']._serialized_end=3074
-  _globals['_STATUSPROGRESSPHASE']._serialized_start=3076
-  _globals['_STATUSPROGRESSPHASE']._serialized_end=3202
-  _globals['_UPDATEPHASE']._serialized_start=3205
-  _globals['_UPDATEPHASE']._serialized_end=3410
+  _globals['_FAILURETYPE']._serialized_start=2918
+  _globals['_FAILURETYPE']._serialized_end=2983
+  _globals['_STATUSOTA']._serialized_start=2986
+  _globals['_STATUSOTA']._serialized_end=3114
+  _globals['_STATUSPROGRESSPHASE']._serialized_start=3116
+  _globals['_STATUSPROGRESSPHASE']._serialized_end=3242
+  _globals['_UPDATEPHASE']._serialized_start=3245
+  _globals['_UPDATEPHASE']._serialized_end=3450
   _globals['_UPDATEREQUESTECU']._serialized_start=84
   _globals['_UPDATEREQUESTECU']._serialized_end=165
   _globals['_UPDATEREQUEST']._serialized_start=167
-  _globals['_UPDATEREQUEST']._serialized_end=226
-  _globals['_UPDATERESPONSEECU']._serialized_start=228
-  _globals['_UPDATERESPONSEECU']._serialized_end=322
-  _globals['_UPDATERESPONSE']._serialized_start=324
-  _globals['_UPDATERESPONSE']._serialized_end=385
-  _globals['_ROLLBACKREQUESTECU']._serialized_start=387
-  _globals['_ROLLBACKREQUESTECU']._serialized_end=423
-  _globals['_ROLLBACKREQUEST']._serialized_start=425
-  _globals['_ROLLBACKREQUEST']._serialized_end=488
-  _globals['_ROLLBACKRESPONSEECU']._serialized_start=490
-  _globals['_ROLLBACKRESPONSEECU']._serialized_end=586
-  _globals['_ROLLBACKRESPONSE']._serialized_start=588
-  _globals['_ROLLBACKRESPONSE']._serialized_end=653
-  _globals['_STATUSREQUEST']._serialized_start=655
-  _globals['_STATUSREQUEST']._serialized_end=670
-  _globals['_STATUSPROGRESS']._serialized_start=673
-  _globals['_STATUSPROGRESS']._serialized_end=1303
-  _globals['_STATUS']._serialized_start=1306
-  _globals['_STATUS']._serialized_end=1485
-  _globals['_STATUSRESPONSEECU']._serialized_start=1487
-  _globals['_STATUSRESPONSEECU']._serialized_end=1601
-  _globals['_STATUSRESPONSE']._serialized_start=1604
-  _globals['_STATUSRESPONSE']._serialized_end=1746
-  _globals['_STATUSRESPONSEECUV2']._serialized_start=1749
-  _globals['_STATUSRESPONSEECUV2']._serialized_end=2140
-  _globals['_UPDATESTATUS']._serialized_start=2143
-  _globals['_UPDATESTATUS']._serialized_end=2876
-  _globals['_OTACLIENTSERVICE']._serialized_start=3413
-  _globals['_OTACLIENTSERVICE']._serialized_end=3719
+  _globals['_UPDATEREQUEST']._serialized_end=246
+  _globals['_UPDATERESPONSEECU']._serialized_start=248
+  _globals['_UPDATERESPONSEECU']._serialized_end=342
+  _globals['_UPDATERESPONSE']._serialized_start=344
+  _globals['_UPDATERESPONSE']._serialized_end=405
+  _globals['_ROLLBACKREQUESTECU']._serialized_start=407
+  _globals['_ROLLBACKREQUESTECU']._serialized_end=443
+  _globals['_ROLLBACKREQUEST']._serialized_start=445
+  _globals['_ROLLBACKREQUEST']._serialized_end=528
+  _globals['_ROLLBACKRESPONSEECU']._serialized_start=530
+  _globals['_ROLLBACKRESPONSEECU']._serialized_end=626
+  _globals['_ROLLBACKRESPONSE']._serialized_start=628
+  _globals['_ROLLBACKRESPONSE']._serialized_end=693
+  _globals['_STATUSREQUEST']._serialized_start=695
+  _globals['_STATUSREQUEST']._serialized_end=710
+  _globals['_STATUSPROGRESS']._serialized_start=713
+  _globals['_STATUSPROGRESS']._serialized_end=1343
+  _globals['_STATUS']._serialized_start=1346
+  _globals['_STATUS']._serialized_end=1525
+  _globals['_STATUSRESPONSEECU']._serialized_start=1527
+  _globals['_STATUSRESPONSEECU']._serialized_end=1641
+  _globals['_STATUSRESPONSE']._serialized_start=1644
+  _globals['_STATUSRESPONSE']._serialized_end=1786
+  _globals['_STATUSRESPONSEECUV2']._serialized_start=1789
+  _globals['_STATUSRESPONSEECUV2']._serialized_end=2180
+  _globals['_UPDATESTATUS']._serialized_start=2183
+  _globals['_UPDATESTATUS']._serialized_end=2916
+  _globals['_OTACLIENTSERVICE']._serialized_start=3453
+  _globals['_OTACLIENTSERVICE']._serialized_end=3759
 # @@protoc_insertion_point(module_scope)

--- a/tests/test_otaclient/test_grpc/test_api_v2/test_servicer.py
+++ b/tests/test_otaclient/test_grpc/test_api_v2/test_servicer.py
@@ -130,6 +130,7 @@ class TestOTAClientAPIServicer:
             version="1.0.0",
             url_base="http://example.com",
             cookies_json="{}",
+            request_id="test-request-id",
             session_id="test-session-id",
         )
 
@@ -162,6 +163,7 @@ class TestOTAClientAPIServicer:
             version="1.0.0",
             url_base="http://example.com",
             cookies_json="{}",
+            request_id="test-request-id",
             session_id="test-session-id",
         )
 

--- a/tests/test_otaclient/test_ota_core.py
+++ b/tests/test_otaclient/test_ota_core.py
@@ -218,6 +218,7 @@ class TestOTAClient:
                 version=self.UPDATE_FIRMWARE_VERSION,
                 url_base=self.OTA_IMAGE_URL,
                 cookies_json=self.UPDATE_COOKIES_JSON,
+                request_id="test-request-id",
                 session_id="test_update_normal_finished",
             )
         )
@@ -244,6 +245,7 @@ class TestOTAClient:
                 version=self.UPDATE_FIRMWARE_VERSION,
                 url_base=self.OTA_IMAGE_URL,
                 cookies_json=self.UPDATE_COOKIES_JSON,
+                request_id="test-request-id",
                 session_id="test_updaste_interrupted",
             )
         )
@@ -265,6 +267,7 @@ class TestOTAClient:
                 version=self.UPDATE_FIRMWARE_VERSION,
                 url_base=self.OTA_IMAGE_URL,
                 cookies_json=self.UPDATE_COOKIES_JSON,
+                request_id="test-request-id",
                 session_id="test_client_update_normal_finished",
             )
         )
@@ -292,6 +295,7 @@ class TestOTAClient:
                 version=self.UPDATE_FIRMWARE_VERSION,
                 url_base=self.OTA_IMAGE_URL,
                 cookies_json=self.UPDATE_COOKIES_JSON,
+                request_id="test-request-id",
                 session_id="test_client_update_interrupted",
             )
         )


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce.

For better understanding, adding reason/motivation of this PR are also recommended.

-->
### Why
Currently, when OTA is requested from WebAuto, there is no common ID shared between multiple ECUs.
- session id: this ID is different between OTA execution in each ECU

### What
Add request id as common ID shared between multiple ECUs. Then pass it to metrics to visualize the metrics against a single Request from Web Auto Agent.
- format: `<unix_timestamp_in_sec_str>-<4bytes_hex>`
- use case
    - from Web Auto Agent to main ECU: `request_id` is None
    - from main ECU to other ECUs: use `request_id` generated in main ECU

> [!NOTE]
> This request ID is used only for request. Not used for response so far.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file(s) that covers the change(s) is implemented.
- [x] local test is passed.
- [ ] design docs/implementation docs are prepared.

Tested in multiple ECUs environment, then verified that the same request id is used between multiple ECUs.

## Documents

<!-- For feature PR, design document is required. -->

## Changes

<!-- A list of code change(s) that introduced by this PR. -->

## Behavior changes

Does this PR introduce behavior change(s)?

- [ ] Yes, internal behaivor (will not impact user experience).
- [ ] Yes, external behaivor (will impact user experience).
- [x] No.

### Previous behavior

<!-- Behaivor before the PR is introduced -->

### Behavior with this PR

<!-- Behavior after the PR is introduced -->

## Breaking change

Does this PR introduce breaking change?

- [ ] Yes.
- [x] No.

<!-- List the breaking change(s) -->

## Related links & tickets
