### PR TITLE
refinement: introduce adaptive chown/chmod

### DIFF
--- a/src/ota_metadata/file_table/utils.py
+++ b/src/ota_metadata/file_table/utils.py
@@ -94,6 +94,47 @@ class DirTypedDict(TypedDict):
 #
 
 
+def _apply_permissions(path: StrOrPath, *, uid: int, gid: int, mode: int) -> None:
+    """Apply permissions only if they differ from current ones to reduce I/O load."""
+    path = Path(path)
+
+    try:
+        # Get current stat info
+        current_stat = path.lstat()
+
+        uid_changed = current_stat.st_uid != uid
+        gid_changed = current_stat.st_gid != gid
+        mode_changed = current_stat.st_mode != mode
+
+        # If ownership needs to change, we must apply chmod after chown
+        # because chown clears setuid/setgid bits on files
+        if uid_changed or gid_changed:
+            os.chown(path, uid=uid, gid=gid)
+            os.chmod(path, mode=mode)
+        elif mode_changed:
+            os.chmod(path, mode=mode)
+    except OSError:
+        os.chown(path, uid=uid, gid=gid)
+        os.chmod(path, mode=mode)
+
+
+def _apply_symlink_permissions(path: StrOrPath, *, uid: int, gid: int) -> None:
+    """Apply only chown for symlinks to reduce I/O load."""
+    path = Path(path)
+
+    try:
+        # Get current stat info for symlink
+        current_stat = path.lstat()
+
+        # Only apply chown if needed
+        if current_stat.st_uid != uid or current_stat.st_gid != gid:
+            os.chown(path, uid=uid, gid=gid, follow_symlinks=False)
+        # NOTE: changing mode of symlink is not needed and ineffective, and on some platform
+        #   changing mode of symlink will even result in exception raised.
+    except OSError:
+        os.chown(path, uid=uid, gid=gid, follow_symlinks=False)
+
+
 def fpath_on_target(_canonical_path: StrOrPath, target_mnt: StrOrPath) -> Path:
     """Return the fpath of self joined to <target_mnt>."""
     _canonical_path = Path(_canonical_path)
@@ -105,8 +146,9 @@ def prepare_dir(entry: DirTypedDict, *, target_mnt: StrOrPath) -> None:
     _target_on_mnt = fpath_on_target(entry["path"], target_mnt=target_mnt)
     try:
         _target_on_mnt.mkdir(exist_ok=True, parents=True)
-        os.chown(_target_on_mnt, uid=entry["uid"], gid=entry["gid"])
-        os.chmod(_target_on_mnt, mode=entry["mode"])
+        _apply_permissions(
+            _target_on_mnt, uid=entry["uid"], gid=entry["gid"], mode=entry["mode"]
+        )
     except Exception as e:
         burst_suppressed_logger.exception(f"failed on preparing {entry!r}: {e!r}")
         raise
@@ -128,14 +170,11 @@ def prepare_non_regular(
 
             # NOTE(20241213): chown will reset the sticky bit of the file!!!
             #   Remember to always put chown before chmod !!!
-            os.chown(
+            _apply_symlink_permissions(
                 _target_on_mnt,
                 uid=entry["uid"],
                 gid=entry["gid"],
-                follow_symlinks=False,
             )
-            # NOTE: changing mode of symlink is not needed and uneffective, and on some platform
-            #   changing mode of symlink will even result in exception raised.
             return
 
         # NOTE: legacy OTA image doesn't support char dev, so not process char device
@@ -156,8 +195,7 @@ def prepare_regular_copy(
         if not (_uid == 0 and _gid == 0):
             # NOTE: if owner is changed, the sticky bit will be reset.
             #       Remember to always put chown before chmod !!!
-            os.chown(_target_on_mnt, uid=_uid, gid=_gid)
-            os.chmod(_target_on_mnt, mode=_mode)
+            _apply_permissions(_target_on_mnt, uid=_uid, gid=_gid, mode=_mode)
 
         # NOTE: old OTA image doesn't suppport xattrs
         # if _xattr := entry["xattrs"]:
@@ -184,8 +222,7 @@ def prepare_regular_inlined(
         if not (_uid == 0 and _gid == 0):
             # NOTE: if owner is changed, the sticky bit will be reset.
             #       Remember to always put chown before chmod !!!
-            os.chown(_target_on_mnt, uid=_uid, gid=_gid)
-            os.chmod(_target_on_mnt, mode=_mode)
+            _apply_permissions(_target_on_mnt, uid=_uid, gid=_gid, mode=_mode)
 
         # NOTE: old OTA image doesn't suppport xattrs
         # if _xattr := entry["xattrs"]:
@@ -208,8 +245,9 @@ def prepare_regular_hardlink(
         # NOTE: os.link will make dst a hardlink to src.
         os.link(_rs, _target_on_mnt)
         if not hardlink_skip_apply_permission:
-            os.chown(_target_on_mnt, uid=entry["uid"], gid=entry["gid"])
-            os.chmod(_target_on_mnt, mode=entry["mode"])
+            _apply_permissions(
+                _target_on_mnt, uid=entry["uid"], gid=entry["gid"], mode=entry["mode"]
+            )
 
             # NOTE: old OTA image doesn't suppport xattrs
             # if _xattr := entry["xattrs"]:
@@ -226,8 +264,9 @@ def prepare_regular_move(
     try:
         _target_on_mnt = fpath_on_target(entry["path"], target_mnt=target_mnt)
         os.replace(str(_rs), _target_on_mnt)
-        os.chown(_target_on_mnt, uid=entry["uid"], gid=entry["gid"])
-        os.chmod(_target_on_mnt, mode=entry["mode"])
+        _apply_permissions(
+            _target_on_mnt, uid=entry["uid"], gid=entry["gid"], mode=entry["mode"]
+        )
 
         # NOTE: old OTA image doesn't suppport xattrs
         # if _xattr := entry["xattrs"]:

--- a/tests/test_ota_metadata/test_utils.py
+++ b/tests/test_ota_metadata/test_utils.py
@@ -1,0 +1,88 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from ota_metadata.file_table.utils import (
+    _apply_permissions,
+    _apply_symlink_permissions,
+)
+
+
+class TestApplyPermissions:
+    """Integration tests for permission functions with real files."""
+
+    @pytest.mark.skipif(
+        os.getuid() != 0, reason="Need root privileges for ownership changes"
+    )
+    def test_apply_permissions_real_file_as_root(self, tmp_path: Path):
+        """Integration test for _apply_permissions with real file operations (requires root)."""
+        test_file = tmp_path / "test_file.txt"
+        test_file.touch()
+
+        # Test changing to a different user/group and mode
+        uid, gid, mode = 1000, 1000, 0o755
+        _apply_permissions(test_file, uid=uid, gid=gid, mode=mode)
+
+        # Verify the changes
+        stat_result = test_file.lstat()
+        assert stat_result.st_uid == uid
+        assert stat_result.st_gid == gid
+        # Use stat.S_IMODE to get only the permission bits
+        assert stat.S_IMODE(stat_result.st_mode) == stat.S_IMODE(mode)
+
+    @pytest.mark.skipif(
+        os.getuid() != 0, reason="Need root privileges for ownership changes"
+    )
+    def test_apply_symlink_permissions_real_symlink_as_root(self, tmp_path: Path):
+        """Integration test for _apply_symlink_permissions with real symlink operations (requires root)."""
+        target_file = tmp_path / "target.txt"
+        target_file.touch()
+        symlink_file = tmp_path / "symlink.txt"
+        symlink_file.symlink_to(target_file)
+
+        # Test changing symlink ownership
+        uid, gid = 1000, 1000
+        _apply_symlink_permissions(symlink_file, uid=uid, gid=gid)
+
+        # Verify the changes (use lstat to get symlink stats, not target stats)
+        stat_result = symlink_file.lstat()
+        assert stat_result.st_uid == uid
+        assert stat_result.st_gid == gid
+
+    def test_apply_permissions_mode_only_non_root(self, tmp_path: Path):
+        """Integration test for _apply_permissions mode changes (works without root)."""
+        test_file = tmp_path / "test_file.txt"
+        test_file.touch()
+
+        # Get current ownership
+        current_stat = test_file.lstat()
+        uid, gid = current_stat.st_uid, current_stat.st_gid
+
+        # Only change mode
+        new_mode = 0o755
+        _apply_permissions(test_file, uid=uid, gid=gid, mode=new_mode)
+
+        # Verify mode change
+        stat_result = test_file.lstat()
+        # Use stat.S_IMODE to get only the permission bits
+        assert stat.S_IMODE(stat_result.st_mode) == stat.S_IMODE(new_mode)
+        assert stat_result.st_uid == uid  # ownership unchanged
+        assert stat_result.st_gid == gid  # ownership unchanged


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce.

For better understanding, adding reason/motivation of this PR are also recommended.
-->
### Why
In the current OTA execution, the bottleneck is I/O.

### What
Introduce Adaptive `os.chown()` / `os.chmod()` execution: for apply stage
Execute `os.chown()` and `os.chmod()` only when necessary. `lstat` is lightweight compared with these system calls, so we will call `lstat` for all of files for checking.


### Tests
Tested on local VM.
https://tier4.atlassian.net/wiki/spaces/OTA/pages/4024402383/20250825+reduce+I+O+load+PR
#### Environment
exact same environment(snap) based on X2 beta/v4.3, same target OTA image, in-place mode, the only difference is otaclient package.
- `ota_image_total_files_size`: 38,003,183,101 bytes
- `ota_image_total_regulars_num`: 405,252
- `delta_download_files_size`: 3,943,778,246 bytes
- `delta_download_files_num`: 4,237

#### Results
| Steps | master(sec) |  master w/ this change(sec) | diffs(sec)
|----------|---------------|---------------------------|----------
| apply_update| 323 | 302 | -21 |

#### Logs
- [master](https://ap-northeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-1#logsV2:log-groups/log-group/$252Faws$252Fgreengrass$252Fedge$252Fap-northeast-1$252F947232557913$252Ffms-prd-edge-otaclient/log-events/2025$252F08$252F27$252Ffms-prd-edge-8cb231fd-4839-4b3b-8ae9-a19a98ba7f7e-Core$252Fautoware)

- [master w/ this change](https://ap-northeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-1#logsV2:log-groups/log-group/$252Faws$252Fgreengrass$252Fedge$252Fap-northeast-1$252F947232557913$252Ffms-prd-edge-otaclient/log-events/2025$252F08$252F27$252Ffms-prd-edge-44535e5f-62a3-4217-bd57-8c92ee85c62f-Core$252Fautoware)

#### metrics
- [master](https://app.datadoghq.com/dashboard/ksx-vsy-v8k/ota?fromUser=true&refresh_mode=sliding&tpl_var_otaclient_version%5B0%5D=%2A&tpl_var_session_id%5B0%5D=1756281031-20250812043019-feat_ota_v3_10_1-d9dba4c1&from_ts=1753610966398&to_ts=1756289366398&live=true)

- [master w/ this change](https://app.datadoghq.com/dashboard/ksx-vsy-v8k/ota?fromUser=true&refresh_mode=sliding&tpl_var_otaclient_version%5B0%5D=%2A&tpl_var_session_id%5B0%5D=1756279237-20250812043019-feat_ota_v3_10_1-f4f85f2e&from_ts=1753610966398&to_ts=1756289366398&live=true)

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file(s) that covers the change(s) is implemented.
- [x] local test is passed.

## Changes

<!-- A list of code change(s) that introduced by this PR. -->

## Behavior changes

Does this PR introduce behavior change(s)?

- [ ] Yes, internal behaivor (will not impact user experience).
- [ ] Yes, external behaivor (will impact user experience).
- [x] No.

### Previous behavior

<!-- Behaivor before the PR is introduced -->

### Behavior with this PR

<!-- Behavior after the PR is introduced -->

## Breaking change

Does this PR introduce breaking change?

- [ ] Yes.
- [x] No.

<!-- List the breaking change(s) -->

## Related links & tickets
https://tier4.atlassian.net/browse/RT4-20109

<!-- List of tickets or links related to this PR -->
