### PR TITLE
refinement: use os.sync instead of fsync

### DIFF
--- a/src/ota_metadata/legacy/_parser.py
+++ b/src/ota_metadata/legacy/_parser.py
@@ -43,6 +43,7 @@ import atexit
 import base64
 import json
 import logging
+import os
 import re
 import shutil
 import time
@@ -756,6 +757,9 @@ class OTAMetadata:
             except TasksEnsureFailed as e:
                 logger.error(f"faild to finish download all ota metadata files: {e!r}")
                 raise
+
+        # Sync all downloaded metadata files to disk
+        os.sync()
 
     # APIs
 

--- a/src/otaclient/create_standby/delta_gen.py
+++ b/src/otaclient/create_standby/delta_gen.py
@@ -188,7 +188,6 @@ class ProcessFileHelper(Generic[T]):
                 dst.write(self._hash_bufferview[:read_size])
 
             dst.flush()
-            os.fsync(dst_fd)
 
             # NOTE(20250616): hint kernel to drop the file cache pages.
             os.posix_fadvise(src_fd, 0, 0, os.POSIX_FADV_DONTNEED)
@@ -330,6 +329,9 @@ class DeltaGenFullDiskScan(_DeltaGeneratorBase):
         finally:
             self._ft_reg_orm_pool.orm_pool_shutdown()
             self._ft_dir_orm.orm_con.close()
+
+        # Sync all filesystem writes to disk after processing all files
+        os.sync()
 
 
 class InPlaceDeltaGenFullDiskScan(DeltaGenFullDiskScan):
@@ -619,6 +621,9 @@ class DeltaWithBaseFileTable(_DeltaGeneratorBase):
         finally:
             self._ft_reg_orm_pool.orm_pool_shutdown()
             self._ft_dir_orm.orm_con.close()
+
+        # Sync all filesystem writes to disk after processing all files
+        os.sync()
 
 
 class InPlaceDeltaWithBaseFileTable(DeltaWithBaseFileTable):

--- a/src/otaclient/create_standby/update_slot.py
+++ b/src/otaclient/create_standby/update_slot.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import threading
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -257,3 +258,6 @@ class UpdateStandbySlot:
 
         if self._interrupted.is_set():
             raise UpdateStandbySlotFailed("failure during regular files processing!")
+
+        # Sync all file operations to disk after slot update completion
+        os.sync()

--- a/src/otaclient/ota_core/_updater.py
+++ b/src/otaclient/ota_core/_updater.py
@@ -195,6 +195,9 @@ class OTAUpdater(OTAUpdateOperator):
             self._downloader_pool.shutdown()
             resource_meta.shutdown()
 
+        # Sync all downloaded files to disk after download completion
+        os.sync()
+
     def _execute_update(self):
         """Implementation of OTA updating."""
         logger.info(f"execute local update({ecu_info.ecu_id=}): {self.update_version=}")

--- a/src/otaclient_common/downloader.py
+++ b/src/otaclient_common/downloader.py
@@ -438,7 +438,6 @@ class Downloader:
                     traffic_on_wire += _read_size
 
             dst_fp.flush()
-            os.fsync(dst_fd)
             os.posix_fadvise(dst_fd, 0, 0, os.POSIX_FADV_DONTNEED)
 
         if size and size != downloaded_file_size:

--- a/src/otaclient_common/linux.py
+++ b/src/otaclient_common/linux.py
@@ -242,7 +242,6 @@ def copyfile_nocache(src: StrOrPath, dst: StrOrPath) -> None:
                 if _fastcopy_sendfile:
                     _fastcopy_sendfile(fsrc, fdst)
                     fdst.flush()
-                    os.fsync(dst_fd)
                     return
             except OSError:
                 raise
@@ -253,7 +252,6 @@ def copyfile_nocache(src: StrOrPath, dst: StrOrPath) -> None:
 
             _copyfileobj(fsrc, fdst)
             fdst.flush()
-            os.fsync(dst_fd)
         finally:
             os.posix_fadvise(src_fd, 0, 0, os.POSIX_FADV_DONTNEED)
             os.posix_fadvise(dst_fd, 0, 0, os.POSIX_FADV_DONTNEED)


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce.

For better understanding, adding reason/motivation of this PR are also recommended.
-->
### Why
In the current OTA execution, the bottleneck is I/O.

### What
Introduce the use of `os.sync` instead of calling `fsync` on each file individually. After this change, both `os.sync` and `fsync` will be used selectively, depending on the feature.
As long as ext4 is used with `barrier=1`, the filesystem will not be broken.

#### Usage
- `os.sync` applies to:
    - Delta calculation
    - Download (metadata and target files)
    - Applying updates
- `fsync` applies to:
    - Atomic file operations
    - Cache control

### Tests
Tested on local VM.
https://tier4.atlassian.net/wiki/spaces/OTA/pages/4031807558/20250826+use+os.sync+instead+of+fsync
#### Environment
exact same environment(snap) based on X2 beta/v4.3, same target OTA image, in-place mode, the only difference is otaclient package.
- `ota_image_total_files_size`: 38,003,183,101 bytes
- `ota_image_total_regulars_num`: 405,252
- `delta_download_files_size`: 3,943,778,246 bytes
- `delta_download_files_num`: 4,237

#### Results
| Step                 | master (sec) | master w/ this change (sec) | diffs (sec) |
|----------------------|-------------:|-----------------------------:|------------:|
| processing_metadata  |          29  |                          25  |         -4  |
| delta_calculation    |         368  |                         340  |        -28  |
| download             |          99  |                          56  |        -43  |
| apply_update         |         323  |                          85  |       -238  |
| post_update          |           9  |                          10  |         +1  |

#### Logs
- [master](https://ap-northeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-1#logsV2:log-groups/log-group/$252Faws$252Fgreengrass$252Fedge$252Fap-northeast-1$252F947232557913$252Ffms-prd-edge-otaclient/log-events/2025$252F08$252F27$252Ffms-prd-edge-8cb231fd-4839-4b3b-8ae9-a19a98ba7f7e-Core$252Fautoware)

- [master w/ this change](https://ap-northeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-1#logsV2:log-groups/log-group/$252Faws$252Fgreengrass$252Fedge$252Fap-northeast-1$252F947232557913$252Ffms-prd-edge-otaclient/log-events/2025$252F08$252F28$252Ffms-prd-edge-9e078e00-4f87-459c-9ca9-4258e0943b37-Core$252Fautoware)

#### metrics
- [master](https://app.datadoghq.com/dashboard/ksx-vsy-v8k/ota?fromUser=true&refresh_mode=sliding&tpl_var_otaclient_version%5B0%5D=%2A&tpl_var_session_id%5B0%5D=1756281031-20250812043019-feat_ota_v3_10_1-d9dba4c1&from_ts=1753610966398&to_ts=1756289366398&live=true)

- [master w/ this change](https://app.datadoghq.com/dashboard/ksx-vsy-v8k/ota?fromUser=true&overlay=changes&overlayQuery=service%3Aci%20auto%3Atrue&refresh_mode=sliding&tpl_var_otaclient_version%5B0%5D=%2A&tpl_var_session_id%5B0%5D=1756339316-20250812043019-feat_ota_v3_10_1-d3e930ec&from_ts=1753662908367&to_ts=1756341308367&live=true)

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [ ] test file(s) that covers the change(s) is implemented.
- [x] local test is passed.

## Changes

<!-- A list of code change(s) that introduced by this PR. -->

## Behavior changes

Does this PR introduce behavior change(s)?

- [x] Yes, internal behaivor (will not impact user experience).
- [ ] Yes, external behaivor (will impact user experience).
- [ ] No.

### Previous behavior

<!-- Behaivor before the PR is introduced -->

When the process is killed during each step, only single file might be lost before writing to disk. 
Then need to operate the file again when OTA is re-triggered.

### Behavior with this PR

<!-- Behavior after the PR is introduced -->
When the process is killed during each step, some files might be lost before writing to disk. 
Then need to operate these files again when OTA is re-triggered.

## Breaking change

Does this PR introduce breaking change?

- [ ] Yes.
- [x] No.

<!-- List the breaking change(s) -->

## Related links & tickets
https://tier4.atlassian.net/browse/RT4-20109

<!-- List of tickets or links related to this PR -->
