### PR TITLE
refinement: mount standby slot with noatime

### DIFF
--- a/src/otaclient_common/cmdhelper.py
+++ b/src/otaclient_common/cmdhelper.py
@@ -420,7 +420,7 @@ def mount_rw(
     """Mount the <target> to <mount_point> read-write.
 
     This is implemented by calling:
-        mount -o rw --make-private --make-unbindable <target> <mount_point>
+        mount -o rw,noatime --make-private --make-unbindable <target> <mount_point>
 
     NOTE: pass args = ["--make-private", "--make-unbindable"] to prevent
             mount events propagation to/from this mount point.
@@ -436,7 +436,7 @@ def mount_rw(
     # fmt: off
     cmd = [
         "mount",
-        "-o", "rw",
+        "-o", "rw,noatime",
         "--make-private",
     ]
     if set_unbindable:


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce.

For better understanding, adding reason/motivation of this PR are also recommended.
-->
### Why
In the current OTA execution, the bottleneck is I/O.

### What
mount standby slot with `noatime` option(= access time will not be updated when otaclient access it for hash calculartion in in-place mode)
In my opinion, we can omit the access time during OTA.

### Tests
Tested on local VM.
https://tier4.atlassian.net/wiki/spaces/OTA/pages/4034625624/20250826+mount+standby+slot+with+noatime
#### Environment
exact same environment(snap) based on X2 beta/v4.3, same target OTA image, in-place mode, the only difference is otaclient package.
- `ota_image_total_files_size`: 38,003,183,101 bytes
- `ota_image_total_regulars_num`: 405,252
- `delta_download_files_size`: 3,943,778,246 bytes
- `delta_download_files_num`: 4,237

#### Results
| Step                 | master (sec) | master w/ this change (sec) | diffs (sec) |
|----------------------|-------------:|-----------------------------:|------------:|
| delta_calculation    |         368  |                         345  |        -23  |

#### Logs
- [master](https://ap-northeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-1#logsV2:log-groups/log-group/$252Faws$252Fgreengrass$252Fedge$252Fap-northeast-1$252F947232557913$252Ffms-prd-edge-otaclient/log-events/2025$252F08$252F27$252Ffms-prd-edge-8cb231fd-4839-4b3b-8ae9-a19a98ba7f7e-Core$252Fautoware)

- [master w/ this change](https://ap-northeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-1#logsV2:log-groups/log-group/$252Faws$252Fgreengrass$252Fedge$252Fap-northeast-1$252F947232557913$252Ffms-prd-edge-otaclient/log-events/2025$252F08$252F28$252Ffms-prd-edge-9710865a-a68c-4cac-8f3f-885f05da25e9-Core$252Fautoware)

#### metrics
- [master](https://app.datadoghq.com/dashboard/ksx-vsy-v8k/ota?fromUser=true&refresh_mode=sliding&tpl_var_otaclient_version%5B0%5D=%2A&tpl_var_session_id%5B0%5D=1756281031-20250812043019-feat_ota_v3_10_1-d9dba4c1&from_ts=1753610966398&to_ts=1756289366398&live=true)

- [master w/ this change](https://app.datadoghq.com/dashboard/ksx-vsy-v8k/ota?fromUser=true&refresh_mode=sliding&tpl_var_otaclient_version%5B0%5D=%2A&tpl_var_session_id%5B0%5D=1756347219-20250812043019-feat_ota_v3_10_1-586a9d33&from_ts=1753670116540&to_ts=1756348516540&live=true)

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [ ] test file(s) that covers the change(s) is implemented.
- [x] local test is passed.

## Changes

<!-- A list of code change(s) that introduced by this PR. -->

## Behavior changes

Does this PR introduce behavior change(s)?

- [x] Yes, internal behaivor (will not impact user experience).
- [ ] Yes, external behaivor (will impact user experience).
- [ ] No.

### Previous behavior

<!-- Behaivor before the PR is introduced -->

When otaclient access the files in stanby-slot for hash calculation, the access date will be updated.

### Behavior with this PR

<!-- Behavior after the PR is introduced -->
When otaclient access the files in stanby-slot for hash calculation, the access date will not be updated.

## Breaking change

Does this PR introduce breaking change?

- [ ] Yes.
- [x] No.

<!-- List the breaking change(s) -->

## Related links & tickets
https://tier4.atlassian.net/browse/RT4-20109

<!-- List of tickets or links related to this PR -->
