### PR TITLE
ci: use native arm runner for squashfs release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
             runs-on: ubuntu-latest
           - platform: arm64
             base_image: ubuntu:22.04
-            runs-on: ubuntu-22.04-arm
+            runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,6 @@ jobs:
           path: dist/*.whl
 
   build_squashfs_images:
-    runs-on: ubuntu-latest
     needs: build_python_packages
     strategy:
       fail-fast: false
@@ -65,8 +64,11 @@ jobs:
         include:
           - platform: x86_64
             base_image: ubuntu:22.04
+            runs-on: ubuntu-latest
           - platform: arm64
             base_image: arm64v8/ubuntu:22.04
+            runs-on: ubuntu-latest-arm64
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - name: checkout
         uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,8 +66,8 @@ jobs:
             base_image: ubuntu:22.04
             runs-on: ubuntu-latest
           - platform: arm64
-            base_image: arm64v8/ubuntu:22.04
-            runs-on: ubuntu-latest-arm64
+            base_image: ubuntu:22.04
+            runs-on: ubuntu-22.04-arm
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: checkout


### PR DESCRIPTION
### Why
Currently, using cross platform environment(qemu) to build the squashfs for ARM. It's slow.

### What
Migrate to use native ARM runnner.

### Test
- confirmed the squashfs build was succeeded
https://github.com/tier4/ota-client/actions/runs/17290141443
    - before: 6m14s
    - after: 1m24s
- confirmed the ARM based squashfs is created
```
$ unsquashfs otaclient-arm64-v0.1.dev1.squashfs
$ cd squashfs-root/
$ find . -type f -exec file {} \; | grep ELF | awk -F',' '{print $2}' | sort | uniq -c
    812  ARM aarch64
```
