### PR TITLE
fix: fix dynamic client exit after metrics publish 

### DIFF
--- a/src/otaclient/ota_core/_main.py
+++ b/src/otaclient/ota_core/_main.py
@@ -72,6 +72,7 @@ OP_CHECK_INTERVAL = 1  # second
 HOLD_REQ_HANDLING_ON_ACK_REQUEST = 16  # seconds
 HOLD_REQ_HANDLING_ON_ACK_CLIENT_UPDATE_REQUEST = 4  # seconds
 WAIT_FOR_OTAPROXY_ONLINE = 3 * 60  # 3mins
+WAIT_BEFORE_DYNAMIC_CLIENT_EXIT = 6  # seconds
 
 
 class OTAClient:
@@ -231,6 +232,7 @@ class OTAClient:
             # dynamic client is not running, no need to exit
             return
 
+        time.sleep(WAIT_BEFORE_DYNAMIC_CLIENT_EXIT)
         logger.info("exit from dynamic client...")
         self._client_update_control_flags.request_shutdown_event.set()
 

--- a/src/otaclient/ota_core/_main.py
+++ b/src/otaclient/ota_core/_main.py
@@ -301,7 +301,6 @@ class OTAClient:
                 failure_reason=e.get_failure_reason(),
                 failure_type=e.failure_type,
             )
-            self._exit_from_dynamic_client()
         finally:
             shutil.rmtree(session_wd, ignore_errors=True)
             try:
@@ -311,6 +310,8 @@ class OTAClient:
             except Exception as e:
                 logger.error(f"failed to merge metrics: {e!r}")
             self._metrics.publish()
+
+            self._exit_from_dynamic_client()
 
     def client_update(self, request: ClientUpdateRequestV2) -> None:
         """

--- a/tests/test_otaclient/test_ota_core.py
+++ b/tests/test_otaclient/test_ota_core.py
@@ -271,8 +271,8 @@ class TestOTAClient:
         self.ota_updater.execute.assert_called_once()
         assert self.ota_client.live_ota_status == OTAStatus.FAILURE
 
-        mock_exit_from_dynamic_client.assert_called_once()
         mock_publish.assert_called_once()
+        mock_exit_from_dynamic_client.assert_called_once()
 
     def test_client_update_normal_finished(self):
         """Test client update with normal completion."""


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce. -->
### Why
This issue was found in code check.
In a dynamic client environment, if an update fails, the following issues may occur depending on task scheduling. This is because `_exit_from_dynamic_client` requests the main process to exit (restarting the otaclient service):
  - session_wd may not be deleted
  - metrics may not be published

### What
execute `_exit_from_dynamic_client` after file deleting, metrics publishing and wait for 6 seconds

### Test
confirmed the behavior in E2E test.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file that covers the bug case(s) is implemented.
- [x] local test is passed.

## Bug fix

### Current behavior

### Behaivor after fix

## Related links & ticket

<!-- List of tickets or links related to this PR -->
