### PR TITLE
refine: create_standby: IO tuning, optimize mount options

### DIFF
--- a/src/otaclient_common/cmdhelper.py
+++ b/src/otaclient_common/cmdhelper.py
@@ -425,7 +425,7 @@ def mount_rw(
 
     When <enable_optimization> is set to True, the following extra mount options will be added:
         noatime: do not update file access time
-        commit: enlarge batch journal commits interval
+        commit=20: enlarge batch journal commits interval to 20s
         data=writeback,journal_async_commit: enable async journal commits
     See https://wiki.archlinux.org/title/Ext4, https://man.archlinux.org/man/ext4.5 for more details.
 
@@ -444,6 +444,8 @@ def mount_rw(
     # fmt: off
     mount_options = ["rw"]
     if enable_optimization:
+        # NOTE(20250829): the commit=20 is chosen by balancing the progress lost window length
+        #                 and the improvement we can get.
         mount_options.extend(["noatime","commit=20","data=writeback,journal_async_commit"])
 
     cmd = [


### PR DESCRIPTION
## Introduction

This PR introduces standby slot IO tuning with optimized mount options:
1. notime(already added in #654 ): do not update file accesstime.
2. commit=20: increase kernel journal commit interval to 20s, batching journal commits.
3. data=writeback,journal_async_commit: enable async journal commits, mitigate IO blocking.

By batching the journal commits into single write every `commit=N` second and enable async journal commit, the IO performance will be much better, IO stall will be mitigated, especially on slower device thanks to reduced number of disk writing calls.

See https://wiki.archlinux.org/title/Ext4, https://man.archlinux.org/man/ext4.5 for the IO optimization guide and mount options documentation.

Other changes:
1. active slot bind mount: enable `noatime` option also.

## Risk analysis
With the above mount options applied, only when ECU is forcely poweroff, in the last 20s window, journal commits will lost, and potential mismatch between file metadata and data blocks will occur(thanks to the ext4 journal, no filesystem corruption will occur). But otaclient can fully handle it as when OTA resume, otaclient will verify the OTA resources.

Note that, forcely poweroff is NOT the same as `systemctl stop otaclient` or using `reboot/poweroff` command, these two will gracefully umount the standby slot, all changes will be flushed and saved to the disk.