### PR TITLE
refine: use inplace update mode when active_slot's OTA resource dir presented

### DIFF
--- a/src/otaclient/create_standby/utils.py
+++ b/src/otaclient/create_standby/utils.py
@@ -83,7 +83,7 @@ def _check_fs_used_size_reach_threshold(
 
 
 def can_use_in_place_mode(
-    dev: StrOrPath, mnt_point: StrOrPath, threshold_in_bytes: int
+    dev: StrOrPath, mnt_point: StrOrPath, threshold_in_bytes: int | None = None
 ) -> bool:  # pragma: no cover
     """
     Check whether target standby slot device is ready for in-place update mode.
@@ -95,4 +95,6 @@ def can_use_in_place_mode(
     """
     if not (_check_if_ext4(dev) and _check_if_fs_healthy(dev)):
         return False
-    return _check_fs_used_size_reach_threshold(dev, mnt_point, threshold_in_bytes)
+    if threshold_in_bytes is not None:
+        return _check_fs_used_size_reach_threshold(dev, mnt_point, threshold_in_bytes)
+    return True

--- a/src/otaclient/ota_core/_updater.py
+++ b/src/otaclient/ota_core/_updater.py
@@ -211,6 +211,10 @@ class OTAUpdater(OTAUpdateOperator):
     def _pre_update(self):
         """Prepare the standby slot and optimize the file_table."""
         logger.info("enter local OTA update...")
+
+        # NOTE(20250905): if ota_resources dir on active slot presented,
+        #                 no need to use rebuild mode.
+        _ota_resources_dir_presented = self._resource_dir_on_active.is_dir()
         with TemporaryDirectory() as _tmp_dir:
             self._can_use_in_place_mode = use_inplace_mode = can_use_in_place_mode(
                 dev=self._boot_controller.standby_slot_dev,
@@ -218,7 +222,7 @@ class OTAUpdater(OTAUpdateOperator):
                 threshold_in_bytes=int(
                     self._ota_metadata.total_regulars_size
                     * STANDBY_SLOT_USED_SIZE_THRESHOLD
-                ),
+                ) if not _ota_resources_dir_presented else None,
             )
         logger.info(
             f"check if we can use in-place mode to update standby slot: {use_inplace_mode}"


### PR DESCRIPTION
## Introduction

Previously, to prevent too large delta, when standby slot's disk usage is smaller than 80% of the OTA image's system image size, rebuild mode will be used(see #595). 
But since #640 , (OTA resources dir )delta calculation result is preserved for speeding up OTA, when OTA resources dir presented at active slot, we can use it with inplace mode instead of using rebuild mode.

This PR introduces the refinement, the condition of using inplace mode is updated, if active slot's OTA resources dir is available, the disk usage check will be bypassed. 