### PR TITLE
refactor: otaproxy: for child ECU, just completely disable the otaproxy

### DIFF
--- a/src/otaclient/_otaproxy_ctx.py
+++ b/src/otaclient/_otaproxy_ctx.py
@@ -102,16 +102,7 @@ def otaproxy_process(
         cache_dir=local_otaproxy_cfg.BASE_DIR,
         cache_db_f=local_otaproxy_cfg.DB_FILE,
         upper_proxy=upper_proxy,
-        # NOTE(20250801): Starting from otaclient v3.9.1, we have inplace update mode with OTA resume,
-        #                   on child ECU, we don't need to rely on OTA cache to speed up OTA retry anymore.
-        # NOTE(20250801): Due to proxy_info.yaml is forced preserved across each OTA(multiple methods are used
-        #                   to ensure that, unfortunately), currently there is no way to update the proxy_info.yaml
-        #                   file on the ECU via OTA.
-        #                 For now, hardcoded to disable OTA cache on the child ECU.
-        #                 To be noticed that, otaproxy OTA cache on main ECU is still needed for streaming
-        #                   the same requests from multiple child ECUs to reduce duplicate downloads.
-        enable_cache=proxy_info.enable_local_ota_proxy_cache
-        and proxy_info.upper_ota_proxy is None,
+        enable_cache=proxy_info.should_enable_cache,
         enable_https=proxy_info.gateway_otaproxy,
         external_cache_mnt_point=external_cache_mnt_point,
         shm_metrics_writer=shm_metrics_writer,

--- a/src/otaclient/configs/_proxy_info.py
+++ b/src/otaclient/configs/_proxy_info.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """proxy_info.yaml definition and parsing logic."""
 
-# TODO(20250924): once we clear out the all the hardcoded logics of preserving
+# TODO(20250924): once we clear out all the hardcoded logics of preserving
 #                 proxy_info.yaml across OTA, we should switch to let the OTA
 #                 update the proxy_info.yaml instead of implementing the logic
 #                 in proxy_info module to hardcoded disabling the otaproxy on child ECU.

--- a/src/otaclient/configs/_proxy_info.py
+++ b/src/otaclient/configs/_proxy_info.py
@@ -13,6 +13,11 @@
 # limitations under the License.
 """proxy_info.yaml definition and parsing logic."""
 
+# TODO(20250924): once we clear out the all the hardcoded logics of preserving
+#                 proxy_info.yaml across OTA, we should switch to let the OTA
+#                 update the proxy_info.yaml instead of implementing the logic
+#                 in proxy_info module to hardcoded disabling the otaproxy on child ECU.
+
 from __future__ import annotations
 
 import logging

--- a/src/otaclient/main.py
+++ b/src/otaclient/main.py
@@ -260,7 +260,7 @@ def main() -> None:  # pragma: no cover
     # ------ setup main process ------ #
 
     _otaproxy_control_t = None
-    if proxy_info.enable_local_ota_proxy:
+    if proxy_info.should_enable_local_otaproxy:
         _otaproxy_control_t = threading.Thread(
             target=partial(
                 otaproxy_control_thread,

--- a/src/otaclient/ota_core/_main.py
+++ b/src/otaclient/ota_core/_main.py
@@ -128,7 +128,7 @@ class OTAClient:
         self._metrics = OTAMetricsData()
         self._metrics.ecu_id = self.my_ecu_id
         self._metrics.enable_local_ota_proxy_cache = (
-            proxy_info.enable_local_ota_proxy_cache
+            proxy_info.should_enable_local_otaproxy and proxy_info.should_enable_cache
         )
 
         try:

--- a/src/otaclient/ota_core/_updater.py
+++ b/src/otaclient/ota_core/_updater.py
@@ -669,7 +669,7 @@ class OTAUpdater(OTAUpdateOperator):
             )
         )
         self._metrics.finalizing_update_start_timestamp = _current_finalizing_time
-        if proxy_info.enable_local_ota_proxy:
+        if proxy_info.should_enable_local_otaproxy:
             wait_and_log(
                 check_flag=self.ecu_status_flags.any_child_ecu_in_update.is_set,
                 check_for=False,


### PR DESCRIPTION
## Introduction

Follows #614, this PR further disables the otaproxy on the child ECU, as currently our all support platforms are single layer network environment for otaclient(i.e., one main ECU, multiple child ECUs directly connected to the main ECU.). 
After #614, it is just meaningless to enable otaproxy on child ECU, and adding another layer of proxy will just decrease the overall downloading efficiency.

For easier maintenance and comprehension, instead of patching the `_otaproxy_ctx`, this PR introduces two property `should_enable_local_otaproxy` and `should_enable_local_otaproxy_cache` to implement the logic of child ECU force disabling otaproxy.