### PR TITLE
refine: otaproxy io tunning, enlarge r/w backlog length, do not manual sync

### DIFF
--- a/src/ota_proxy/cache_streaming.py
+++ b/src/ota_proxy/cache_streaming.py
@@ -212,7 +212,6 @@ class CacheTracker:
                 # first create the file
                 f.write(b"")
                 f.flush()
-                os.fsync(fd)
 
                 self.cache_meta = cache_meta
                 weakref.finalize(self, _unlink_no_error, self.fpath)
@@ -229,7 +228,6 @@ class CacheTracker:
                         self._bytes_written += len(data)
                 finally:
                     f.flush()
-                    os.fsync(fd)
                     os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
 
             # NOTE(20240805): mark the writer succeeded in advance to release the
@@ -262,7 +260,6 @@ class CacheTracker:
                 self.cache_meta = cache_meta
                 f.write(data)
                 f.flush()
-                os.fsync(fd)
                 weakref.finalize(self, _unlink_no_error, self.fpath)
                 os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
             tracker_events.set_writer_finished()

--- a/src/ota_proxy/config.py
+++ b/src/ota_proxy/config.py
@@ -24,13 +24,11 @@ class Config:
     WRITE_CHUNK_SIZE = 2 * 1024 * 1024  # 2MiB
     LOCAL_READ_SIZE = 2 * 1024 * 1024  # 2MiB
 
-    # adjust from 8 ~ 16 threads
-    CACHE_WRITE_WORKERS_NUM = max(8, min(16, (os.cpu_count() or 1) + 4))
-    # adjust from 16 ~ 32 threads
-    CACHE_READ_WORKERS_NUM = max(16, min(32, (os.cpu_count() or 1) + 4))
+    CACHE_WRITE_WORKERS_NUM = max(16, min(16, (os.cpu_count() or 1) + 4))
+    CACHE_READ_WORKERS_NUM = max(32, min(32, (os.cpu_count() or 1) + 4))
 
-    MAX_PENDING_WRITE = CACHE_WRITE_WORKERS_NUM * 10
-    MAX_PENDING_READ = CACHE_READ_WORKERS_NUM * 10
+    MAX_PENDING_WRITE = 384
+    MAX_PENDING_READ = 512
 
     # ------ storage quota ------ #
     DISK_USE_LIMIT_SOFT_P = 70  # in p%

--- a/src/ota_proxy/config.py
+++ b/src/ota_proxy/config.py
@@ -24,8 +24,8 @@ class Config:
     WRITE_CHUNK_SIZE = 2 * 1024 * 1024  # 2MiB
     LOCAL_READ_SIZE = 2 * 1024 * 1024  # 2MiB
 
-    CACHE_WRITE_WORKERS_NUM = max(16, min(16, (os.cpu_count() or 1) + 4))
-    CACHE_READ_WORKERS_NUM = max(32, min(32, (os.cpu_count() or 1) + 4))
+    CACHE_WRITE_WORKERS_NUM = max(8, min(16, (os.cpu_count() or 1) + 4))
+    CACHE_READ_WORKERS_NUM = max(16, min(32, (os.cpu_count() or 1) + 4))
 
     MAX_PENDING_WRITE = 384
     MAX_PENDING_READ = 512


### PR DESCRIPTION
## Introduction

This PR introduces some tunning to the otaproxy:
1. enlarge maximum r/w backlog length(r: -> 512, w: -> 384).
2. do not do manual sync when writing cache, just flush is enough.

The background is, when doing local otaproxy test with multiple clients, I found that the backlog setting is to conservative, causing many cache writes being dropped, but actually the system can handle much more than the current settings. With the settings configured by this PR, the cache write dropping is resolved while the system disk IO can still handle the requests.
Also, inspired by #658 , there is also no need to do manual fsync.