### PR TITLE
test: update otaproxy e2e test files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ source = [
 disable_warnings = [
     "no-data-collected",
     "module-not-measured",
+    "module-not-imported",
 ]
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,9 @@ source = [
   "ota_proxy",
   "otaclient_manifest",
 ]
+disable_warnings = [
+    "no-data-collected",
+]
 
 [tool.coverage.report]
 omit = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ source = [
 ]
 disable_warnings = [
     "no-data-collected",
+    "module-not-measured",
 ]
 
 [tool.coverage.report]

--- a/tests/test_ota_proxy/test_ota_proxy_e2e.py
+++ b/tests/test_ota_proxy/test_ota_proxy_e2e.py
@@ -338,7 +338,6 @@ class TestOTAProxyServer(ThreadpoolExecutorFixtureMixin):
                 finally:
                     shutil.rmtree(self.ota_cache_dir, ignore_errors=True)
 
-    @pytest.mark.skip
     async def test_download_file_with_special_fname(
         self, launch_ota_proxy_server: SpawnProcess
     ):

--- a/tests/test_ota_proxy/test_ota_proxy_e2e.py
+++ b/tests/test_ota_proxy/test_ota_proxy_e2e.py
@@ -168,7 +168,7 @@ def ota_downloader_process(
 
     async def main():
         sync_event.wait()
-        logger.info(f"worker#{worker_id} started")
+        _logger.info(f"worker#{worker_id} started")
         async with aiohttp.ClientSession() as session:
             await asyncio.sleep(random.randrange(100, 200) // 100)
             for count, entry in enumerate(_batch_shuffle(), start=1):


### PR DESCRIPTION
## Introduction

This PR updates and refines the otaproxy e2e test files as follow:
1. configure to output the logs from otaproxy server.
2. ota download client now is also launched from a subprocess to let each workers isolated with each other.
3. ota download client now follows otaclient's behavior, will do shuffle of the download list(shuffle 256 entries for each batch).