### PR TITLE
refine: ThreadPoolExecutorWithRetry: now TaskEnsureFailed records the last exception raised from the pool on interruption

### DIFF
--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -228,7 +228,7 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
                 try:  # raise exc to upper caller
                     raise _wrapped_exc
                 finally:
-                    del _wrapped_exc # break circular ref
+                    del _wrapped_exc  # break circular ref
 
             try:
                 done_fut = self._fut_queue.get_nowait()

--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -214,9 +214,9 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
                         "execution interrupted due to thread pool shutdown"
                     )
 
+                # NOTE: still raise TaskEnsureFailed to upper,
+                #       let choose to upper dig into the TaskEnsureFailed or not.
                 try:  # raise exc to upper caller
-                    if _last_exc.cause:
-                        raise _last_exc.cause
                     raise _last_exc
                 finally:
                     del _last_exc

--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -211,18 +211,18 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
                         self._fut_queue.get_nowait()
 
                 try:
-                    _last_exc = self._exc_deque.pop()
+                    _wrapped_exc = self._exc_deque.pop()
                 except Exception:
-                    _last_exc = TasksEnsureFailed(
+                    _wrapped_exc = TasksEnsureFailed(
                         "execution interrupted due to thread pool shutdown"
                     )
 
                 # NOTE: still raise TaskEnsureFailed to upper,
                 #       let choose to upper dig into the TaskEnsureFailed or not.
                 try:  # raise exc to upper caller
-                    raise _last_exc
+                    raise _wrapped_exc
                 finally:
-                    del _last_exc
+                    del _wrapped_exc
 
             try:
                 done_fut = self._fut_queue.get_nowait()

--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -50,6 +50,12 @@ class TasksEnsureFailed(Exception):
     def cause(self) -> BaseException | None:
         return self.__cause__
 
+    def __repr__(self) -> str:
+        _base = super().__repr__()
+        return f"{_base}, caused by {self.cause!r}"
+
+    __str__ = __repr__
+
 
 class _TaskSubmitFailedAfterPoolShutdown(Exception): ...
 

--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -228,7 +228,7 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
                 try:  # raise exc to upper caller
                     raise _wrapped_exc
                 finally:
-                    del _wrapped_exc
+                    del _wrapped_exc # break circular ref
 
             try:
                 done_fut = self._fut_queue.get_nowait()

--- a/src/otaclient_common/retry_task_map.py
+++ b/src/otaclient_common/retry_task_map.py
@@ -21,7 +21,7 @@ import itertools
 import logging
 import threading
 import time
-from collections import OrderedDict
+from collections import OrderedDict, deque
 from concurrent.futures import Future, ThreadPoolExecutor
 from functools import partial
 from queue import Empty, SimpleQueue
@@ -40,9 +40,21 @@ logger = logging.getLogger(__name__)
 class TasksEnsureFailed(Exception):
     """Exception for tasks ensuring failed."""
 
+    @classmethod
+    def caused_by(cls, *args, cause: BaseException):
+        _new = cls(*args)
+        _new.__cause__ = cause
+        return _new
+
+    @property
+    def cause(self) -> BaseException | None:
+        return self.__cause__
+
+
+class WatchdogFailed(TasksEnsureFailed): ...
+
 
 class _RetryOnEntryTracker:
-
     def __init__(self, max_entries: int) -> None:
         self._max_entries = max_entries
         self._register: OrderedDict[int, int] = OrderedDict()
@@ -59,7 +71,6 @@ class _RetryOnEntryTracker:
 
 
 class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
-
     def __init__(
         self,
         max_concurrent: int,
@@ -95,6 +106,7 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
         self._total_retry_counter = itertools.count(start=1)
         self._concurrent_semaphore = threading.Semaphore(max_concurrent)
         self._fut_queue: SimpleQueue[Future[Any]] = SimpleQueue()
+        self._exc_deque: deque[TasksEnsureFailed] = deque(maxlen=1)
 
         self._watchdog_check_interval = watchdog_check_interval
         self._rtm_watchdog_funcs: list[Callable[[], Any]] = []
@@ -103,7 +115,6 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
         if callable(watchdog_func):
             self._rtm_watchdog_funcs.append(watchdog_func)
 
-        self._failure_msg = ""
         super().__init__(
             max_workers=max_workers,
             thread_name_prefix=thread_name_prefix,
@@ -125,7 +136,9 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
                 for _func in _checker_funcs:
                     _func()
             except Exception as e:
-                self._rtm_shutdown(f"watchdog failed: {e!r}")
+                _err_msg = f"watchdog failed: {e!r}"
+                self._exc_deque.append(WatchdogFailed.caused_by(_err_msg, cause=e))
+                self._rtm_shutdown(_err_msg)
 
     def _task_done_cb_at_thread(
         self, fut: Future[Any], /, *, item: T, func: Callable[[T], Any]
@@ -136,7 +149,8 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
         self._fut_queue.put_nowait(fut)
 
         # release semaphore only on success
-        if not fut.exception():
+        _exc = fut.exception()
+        if not _exc:
             self._concurrent_semaphore.release()
             return
 
@@ -149,7 +163,8 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
             self._max_total_retry is not None
             and _total_retry_count > self._max_total_retry
         ):
-            _err_msg = f"{_total_retry_count=} exceeds {self._max_total_retry=}, abort"
+            _err_msg = f"{_total_retry_count=} exceeds {self._max_total_retry=}, abort! last exc: {_exc}"
+            self._exc_deque.append(TasksEnsureFailed.caused_by(_err_msg, cause=_exc))
             return self._rtm_shutdown(_err_msg)
 
         # check continues retry on the same entry
@@ -157,9 +172,8 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
         if (
             _max_entry_retry := self._max_retry_on_entry
         ) is not None and _retry_on_entry > _max_entry_retry:
-            _err_msg = (
-                f"{_retry_on_entry=} on {item=} exceed {_max_entry_retry=}, abort"
-            )
+            _err_msg = f"{_retry_on_entry=} on {item=} exceed {_max_entry_retry=}, abort! last exc: {_exc}"
+            self._exc_deque.append(TasksEnsureFailed.caused_by(_err_msg, cause=_exc))
             return self._rtm_shutdown(_err_msg)
 
         # finally, retry to re-schedule the failed workitem
@@ -192,7 +206,20 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
                 with contextlib.suppress(Empty):
                     while True:  # drain the _fut_queue
                         self._fut_queue.get_nowait()
-                raise TasksEnsureFailed(self._failure_msg)  # raise exc to upper caller
+
+                try:
+                    _last_exc = self._exc_deque.pop()
+                except Exception:
+                    _last_exc = TasksEnsureFailed(
+                        "execution interrupted due to thread pool shutdown"
+                    )
+
+                try:  # raise exc to upper caller
+                    if _last_exc.cause:
+                        raise _last_exc.cause
+                    raise _last_exc
+                finally:
+                    del _last_exc
 
             try:
                 done_fut = self._fut_queue.get_nowait()
@@ -206,22 +233,22 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
         """
         Called by task_done_cb or dispatcher to shutdown threadpool on failure.
         """
-        if self._rtm_lower_pool_shutdown:
-            return  # no need to shutdown again
-
         # NOTE: only one shutdown is allowed
         if self._rtm_shutdown_lock.acquire(blocking=False):
             try:
+                if self._rtm_lower_pool_shutdown:
+                    return  # no need to shutdown again
+
                 _err_msg = f"shutdown executor and drain workitem queue: {msg}"
                 logger.warning(_err_msg)
-                self._failure_msg = _err_msg
 
                 # wait MUST be False to prevent deadlock when calling _on_shutdown from worker
                 self.shutdown(wait=False)
-                # drain the worker queues
                 with contextlib.suppress(Empty):
-                    while True:
+                    while True:  # drain the worker queues
                         self._work_queue.get_nowait()
+                # remember to add one sentinel back to the work_queue
+                self._work_queue.put_nowait(None)  # type: ignore
             finally:
                 self._rtm_shutdown_lock.release()
 
@@ -235,7 +262,7 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
         with self._rtm_start_lock:
             if self._rtm_started or self._rtm_lower_pool_shutdown:
                 try:
-                    raise ValueError(
+                    raise TasksEnsureFailed(
                         "ensure_tasks cannot be started more than once or lower pool has already shutdown"
                     )
                 finally:  # do not hold refs to input params
@@ -257,6 +284,7 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
                     )
             except Exception as e:
                 _err_msg = f"tasks dispatcher failed: {e!r}, abort"
+                self._exc_deque.append(TasksEnsureFailed.caused_by(_err_msg, cause=e))
                 self._rtm_shutdown(_err_msg)
                 return
 
@@ -285,7 +313,6 @@ class _ThreadPoolExecutorWithRetry(ThreadPoolExecutor):
 if TYPE_CHECKING:
 
     class ThreadPoolExecutorWithRetry:
-
         def __init__(
             self,
             max_concurrent: int,

--- a/tests/test_otaclient_common/test_retry_task_map.py
+++ b/tests/test_otaclient_common/test_retry_task_map.py
@@ -46,7 +46,7 @@ class _RetryTaskMapTestErr(Exception):
 def _thread_initializer(msg: str) -> None:
     """For testing thread worker initializer."""
     thread_native_id = threading.get_native_id()
-    logger.info(f"thread worker #{thread_native_id} initialized: {msg}")
+    logger.info(f"thread worker(pid: {thread_native_id}) initialized: {msg}")
 
 
 class ThreadSafeTracker:

--- a/tests/test_otaclient_common/test_retry_task_map.py
+++ b/tests/test_otaclient_common/test_retry_task_map.py
@@ -151,6 +151,8 @@ class TestRetryTaskMap:
                 ):
                     ...
 
+            _cause = exc_info.value.cause
+            assert type(_cause) is _RetryTaskMapTestErr
             logger.info(
                 f"interrupted as expected by {exc_info=}, caused by {exc_info.value.cause}"
             )
@@ -178,6 +180,8 @@ class TestRetryTaskMap:
                 ):
                     ...
 
+            _cause = exc_info.value.cause
+            assert type(_cause) is _RetryTaskMapTestErr
             logger.info(
                 f"interrupted as expected by {exc_info=}, caused by {exc_info.value.cause}"
             )

--- a/tests/test_otaclient_common/test_retry_task_map.py
+++ b/tests/test_otaclient_common/test_retry_task_map.py
@@ -124,9 +124,7 @@ class TestRetryTaskMap:
 
             _cause = exc_info.value.cause
             assert type(_cause) is ValueError
-            logger.info(
-                f"interrupted as expected by {exc_info=}, caused by {exc_info.value.cause}"
-            )
+            logger.info(f"interrupted as expected by {exc_info=}, caused by {_cause!r}")
 
         total_failure_count = next(self._total_failure_counter) - 1
         logger.info(f"{total_failure_count=}")
@@ -153,9 +151,7 @@ class TestRetryTaskMap:
 
             _cause = exc_info.value.cause
             assert type(_cause) is _RetryTaskMapTestErr
-            logger.info(
-                f"interrupted as expected by {exc_info=}, caused by {exc_info.value.cause}"
-            )
+            logger.info(f"interrupted as expected by {exc_info=}, caused by {_cause!r}")
 
         total_failure_count = next(self._total_failure_counter) - 1
         logger.info(f"{total_failure_count=}")
@@ -182,9 +178,7 @@ class TestRetryTaskMap:
 
             _cause = exc_info.value.cause
             assert type(_cause) is _RetryTaskMapTestErr
-            logger.info(
-                f"interrupted as expected by {exc_info=}, caused by {exc_info.value.cause}"
-            )
+            logger.info(f"interrupted as expected by {exc_info=}, caused by {_cause!r}")
 
         assert any(
             _per_entry_failure >= MAX_RETRY_ON_ENTRY


### PR DESCRIPTION
## Introduction

This PR refines the ThreadPoolExecutorWithRetry by improving exception handling to capture and propagate the last exception raised from worker threads that triggers the interruption. The TasksEnsureFailed exception is enhanced to hold the root cause exception, providing better debugging information when tasks fail.
Caller of the ThreadPoolExecutorWithRetry now can retrieve the exception object from the TaskEnsureFailed, and use the original exception for further processing(like re-raising the original exception rather than TaskEnsureFailed).