### PR TITLE
chore: set default value for metrics

### DIFF
--- a/src/otaclient/metrics.py
+++ b/src/otaclient/metrics.py
@@ -19,6 +19,7 @@ import logging
 from dataclasses import asdict, dataclass
 
 from _otaclient_version import __version__
+
 from otaclient._logging import LogType
 from otaclient._types import FailureType, OTAStatus
 from otaclient.configs.cfg import ecu_info


### PR DESCRIPTION
### Why
Datadog does not support empty strings, so there is no effective way to filter for only the "success" case.

### What
Set default string for some metrics.