### PR TITLE
[3.11]  backport #680: ci(test): test container image: add support for OTA image v1, refactoring compose files

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,55 +14,62 @@ $ python3 --version
 Python 3.8.10
 ```
 
-## How to test OTA client on the development PC
+## How to build
 
-### Build the image for testing
+You can build the python wheel package as follow:
 
-Build the `ota-test_base` image for running tests under a container as follow:
+1. install `uv`: <https://docs.astral.sh/uv/getting-started/installation/>
+
+2. setup a venv environment:
 
 ```bash
-docker compose -f docker/test_base/docker-compose_tests.yml build
+uv sync --locked
 ```
 
-This `ota-test_base` image contains a copy of pre-build minimum `ota-image` under `/ota-image` folder, and pre-installed dependencies needed for running and testing OTA client.
-`tester` in the following commands is the service name of the test base container, which is defined in the `docker-compose_tests.yml`(e.g. `tester-ubuntu-22.04`).
+3. build the package
+
+```bash
+uv build --wheel
+```
+
+4. the built package will be placed under `./dist` folder
+
+## How to test OTA client on the development PC
+
+### Use docker compose to run tests in a container
+
+The test containers are defined in `docker/test_base/docker-compose_tests.yml`,
+Test containers for ubuntu 18.04, 20.04 and 22.04 are defined.
+
+The `./docker/test_base/entry_point.sh` will be mounted into the test container as entrypoint,
+you can adjust the script as needed.
 
 ### Run all tests at once
 
+The following example will run all tests in the container for ubuntu 20.04:
+
 ```bash
-docker compose -f docker/test_base/docker-compose_tests.yml run --rm tester
+# at project root directory
+docker compose -f docker/test_base/docker-compose_tests.yml run --rm tester-ubuntu-20.04
 ```
 
 ### Run specific tests manually by override the command
 
-Directly execute pytest is also possible by override the command:
+Specify to only run specific tests is also possible as follow:
 
 ```bash
-docker compose -f docker/test_base/docker-compose_tests.yml run --rm tester \
+# at project root directory
+docker compose -f docker/test_base/docker-compose_tests.yml run --rm tester-ubuntu-20.04 \
    tests/<specific_test_file>  [<test_file_2> [...]]
 ```
 
-### Run specific tests manually by dropping to bash shell
+### Control the test container interactively
 
 Directly drop to bash shell in the test base container as follow:
 
 ```bash
-docker compose -f docker/test_base/docker-compose_tests.yml run --entrypoint bash --rm tester
-```
-
-And then run specific tests as you want after copying the source code to the container based on the `entry_point.sh`:
-
-```bash
-# copy the source code to the container
-cp -r /otaclient_src /test_root
-# change the working directory to the test_root
-cd /test_root
-# create the hatch environment
-hatch env create dev
-# enter the hatch environment
-hatch shell dev
-# inside the container
-python3 -m pytest tests/<specific_test_file> [<test_file_2> [...]]
+# at the project root directory
+docker compose -f docker/test_base/docker-compose_tests.yml run --entrypoint=/bin/bash -it --rm tester-ubuntu-20.04
 ```
 
 ## How to update protobuf

--- a/docker/mini_ota_img/README.md
+++ b/docker/mini_ota_img/README.md
@@ -1,1 +1,14 @@
 # Mini OTA image for deterministic OTAClient test
+
+Repo: [ota_img_for_test](https://github.com/tier4/ota-client/pkgs/container/ota-client%2Fota_img_for_test)
+
+Old OTA image: `ghcr.io/tier4/ota-client/ota_img_for_test:ubuntu_22.04`
+New OTA image: `ghcr.io/tier4/ota-client/ota_img_for_test:ubuntu_22.04-ota_image_v1`
+
+## Build OTA image
+
+```bash
+# at the root of this repo
+sudo docker build \
+    -f docker/mini_ota_img/new_ota_image.Dockerfile -t ghcr.io/tier4/ota-client/ota_img_for_test:ubuntu_22.04-ota_image_v1 .
+```

--- a/docker/mini_ota_img/new_ota_image.Dockerfile
+++ b/docker/mini_ota_img/new_ota_image.Dockerfile
@@ -1,0 +1,89 @@
+ARG SYS_IMG=ghcr.io/tier4/ota-client/sys_img_for_test:ubuntu_22.04
+ARG UBUNTU_BASE=ubuntu:22.04
+
+#
+# ------ stage 1: prepare base image ------ #
+#
+
+FROM ${SYS_IMG} AS sys_img
+
+
+#
+# ------ stage 2: build new OTA image ------ #
+#
+
+FROM ${UBUNTU_BASE} AS ota_img_builder
+
+ARG OTA_IMAGE_BUILDER_RELEASE="https://github.com/tier4/ota-image-builder/releases/download/v0.3.2/ota-image-builder-x86_64"
+
+SHELL ["/bin/bash", "-c"]
+ENV DEBIAN_FRONTEND=noninteractive
+
+ENV OTA_IMAGE_BUILDER_RELEASE=${OTA_IMAGE_BUILDER_RELEASE}
+ENV OTA_IMAGE_SERVER_ROOT="/ota-image"
+ENV ROOTFS="/rootfs"
+ENV CERTS_DIR="/certs"
+ENV BUILD_ROOT="/tmp/build_root"
+
+COPY --chmod=755 ./tests/keys/gen_certs.sh ${CERTS_DIR}/gen_certs.sh
+COPY ./tests/data/ota_image_builder ${BUILD_ROOT}
+
+WORKDIR ${BUILD_ROOT}
+
+RUN --mount=type=bind,source=/,target=/rootfs,from=sys_img,rw \
+    set -eux; \
+    apt-get update -qq; \
+    apt-get install -y -qq --no-install-recommends \
+        ca-certificates wget; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*; \
+    wget ${OTA_IMAGE_BUILDER_RELEASE} -O ${BUILD_ROOT}/ota-image-builder; \
+    chmod +x ota-image-builder; \
+    # --- generate certs --- #
+    pushd ${CERTS_DIR}; \
+    bash ${CERTS_DIR}/gen_certs.sh; \
+    popd; \
+    # --- start to build the OTA image --- #
+    mkdir -p ${OTA_IMAGE_SERVER_ROOT}; \
+    ./ota-image-builder -d init \
+        --annotations-file full_annotations.yaml \
+        ${OTA_IMAGE_SERVER_ROOT}; \
+    ./ota-image-builder -d add-image \
+        --annotations-file full_annotations.yaml \
+        --release-key dev \
+        --sys-config "autoware:sys_config.yaml" \
+        --rootfs ${ROOTFS} \
+        ${OTA_IMAGE_SERVER_ROOT}; \
+    ./ota-image-builder -d add-image \
+        --annotations-file full_annotations.yaml \
+        --release-key prd \
+        --sys-config "autoware:sys_config.yaml" \
+        --rootfs ${ROOTFS}/var \
+        ${OTA_IMAGE_SERVER_ROOT}; \
+    ./ota-image-builder -d finalize ${OTA_IMAGE_SERVER_ROOT}; \
+    ./ota-image-builder -d sign \
+        --sign-cert ${CERTS_DIR}/sign.pem \
+        --sign-key ${CERTS_DIR}/sign.key \
+        --ca-cert ${CERTS_DIR}/test.interm.pem \
+        ${OTA_IMAGE_SERVER_ROOT}; \
+    # --- clean up --- #
+    # although the keys are only for tests, and only used for
+    #   this test OTA image, still clean it up.
+    rm -rf ${CERTS_DIR}/*.key
+
+#
+# ------ stage 4: output OTA image ------ #
+#
+
+# NOTE: use busybox so that the overall image size will not increase much,
+#       while enable us to examine the built OTA image.
+
+FROM ${UBUNTU_BASE}
+
+ARG SYS_IMG
+
+LABEL org.opencontainers.image.description=\
+"A mini OTA image v1 OTA image for OTAClient test, based on system image ${SYS_IMG}"
+
+COPY --from=ota_img_builder /ota-image /ota-image
+COPY --from=ota_img_builder /certs /certs

--- a/docker/test_base/Dockerfile
+++ b/docker/test_base/Dockerfile
@@ -1,23 +1,30 @@
 ARG UBUNTU_BASE
+ARG UV_VERSION=0.8.22
 
 FROM ghcr.io/tier4/ota-client/ota_img_for_test:ubuntu_22.04 AS ota_image
 
+FROM ghcr.io/tier4/ota-client/ota_img_for_test:ubuntu_22.04-ota_image_v1 AS ota_image_v1
+
 FROM ${UBUNTU_BASE}
 
+# NOTE: for fallback when no entry_point.sh is specified in compose file
+COPY --chmod=755 ./entry_point.sh /entry_point.sh
 COPY --from=ota_image /ota-image /ota-image
 COPY --from=ota_image /certs /certs
-
-# copy and setup the entry_point.sh
-COPY --chmod=755 ./entry_point.sh /entry_point.sh
+COPY --from=ota_image_v1 /ota-image /ota-image_v1
+COPY --from=ota_image_v1 /certs /certs_ota-image_v1
 
 # bootstrapping the python environment
 RUN set -eux; \
     apt-get update; \
     apt-get install -y -qq --no-install-recommends \
-        python3 \
-        python3-pip \
-        git; \
-    python3 -m pip install -U pip; \
-    python3 -m pip install uv
+        git ca-certificates wget python3 python3-setuptools; \
+    export UV_INSTALL_DIR=/usr/bin; \
+    wget -qO- "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh; \
+    apt-get clean; \
+    rm -rf; \
+        /tmp/* \
+        /var/lib/apt/lists/* \
+        /var/tmp/*
 
-ENTRYPOINT [ "/entry_point.sh" ]
+ENTRYPOINT [ "/bin/bash", "/entry_point.sh" ]

--- a/docker/test_base/docker-compose_build.yml
+++ b/docker/test_base/docker-compose_build.yml
@@ -1,0 +1,27 @@
+# compose file for building the test base images
+
+services:
+  tester-ubuntu-18.04:
+    build:
+      context: .
+      dockerfile: ubuntu-18.04.Dockerfile
+      args:
+        UBUNTU_BASE: ubuntu:18.04
+    pull_policy: never
+    image: ghcr.io/tier4/ota-client/test_base:ubuntu_18.04
+
+  tester-ubuntu-20.04:
+    build:
+      context: .
+      args:
+        UBUNTU_BASE: ubuntu:20.04
+    pull_policy: never
+    image: ghcr.io/tier4/ota-client/test_base:ubuntu_20.04
+
+  tester-ubuntu-22.04:
+    build:
+      context: .
+      args:
+        UBUNTU_BASE: ubuntu:22.04
+    pull_policy: never
+    image: ghcr.io/tier4/ota-client/test_base:ubuntu_22.04

--- a/docker/test_base/docker-compose_tests.yml
+++ b/docker/test_base/docker-compose_tests.yml
@@ -6,6 +6,7 @@ x-common: &_common
   volumes:
     - ../..:/otaclient_src:ro
     - ../../test_result:/test_result:rw
+    - ./entry_point.sh:/entry_point.sh:ro
 
 services:
   tester-ubuntu-18.04:

--- a/docker/test_base/ubuntu-18.04.Dockerfile
+++ b/docker/test_base/ubuntu-18.04.Dockerfile
@@ -1,23 +1,28 @@
 ARG UBUNTU_BASE
+ARG UV_VERSION=0.8.22
 
 FROM ghcr.io/tier4/ota-client/ota_img_for_test:ubuntu_22.04 AS ota_image
+
+FROM ghcr.io/tier4/ota-client/ota_img_for_test:ubuntu_22.04-ota_image_v1 AS ota_image_v1
 
 FROM ${UBUNTU_BASE}
 
 COPY --from=ota_image /ota-image /ota-image
 COPY --from=ota_image /certs /certs
-
-# copy and setup the entry_point.sh
-COPY --chmod=755 ./entry_point.sh /entry_point.sh
+COPY --from=ota_image_v1 /ota-image /ota-image_v1
+COPY --from=ota_image_v1 /certs /certs_ota-image_v1
 
 # bootstrapping the python environment
 RUN set -eux; \
     apt-get update; \
     apt-get install -y -qq --no-install-recommends \
-        python3.8 \
-        python3-pip \
-        git; \
-    python3.8 -m pip install -U pip; \
-    python3.8 -m pip install uv
+        git ca-certificates wget python3.8 python3.8-distutils; \
+    export UV_INSTALL_DIR=/usr/bin; \
+    wget -qO- "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh; \
+    apt-get clean; \
+    rm -rf; \
+        /tmp/* \
+        /var/lib/apt/lists/* \
+        /var/tmp/*
 
-ENTRYPOINT [ "/entry_point.sh" ]
+ENTRYPOINT [ "/bin/bash", "/entry_point.sh" ]

--- a/tests/data/ota_image_builder/full_annotations.yaml
+++ b/tests/data/ota_image_builder/full_annotations.yaml
@@ -1,0 +1,29 @@
+# Example annotations for build a full OTA image targetting one ECU.
+vnd.tier4.ota.ota-image-builder.version: "1.0.0"
+
+vnd.tier4.pilot-auto.platform: "example-platform"
+vnd.tier4.pilot-auto.project.source-repo: "https://github.com/tier4/ota-image-libs"
+vnd.tier4.pilot-auto.project.version: "1.0.0"
+vnd.tier4.pilot-auto.project.release-commit: "abcdef1234567890"
+vnd.tier4.pilot-auto.project.release-branch: "main"
+
+vnd.tier4.ota.release-key: "dev"
+vnd.tier4.web-auto.project: "some-project"
+vnd.tier4.web-auto.project.id: "some-project-id"
+vnd.tier4.web-auto.catalog: "some-catalog"
+vnd.tier4.web-auto.catalog.id: "some-catalog-id"
+vnd.tier4.web-auto.env: "dev"
+vnd.tier4.web-auto.cicd.release-id: "693ac51b-5c23-4d07-b0de-6fcf896b15b9"
+vnd.tier4.web-auto.cicd.release-name: "20250926123456-beta/ota"
+
+# for image-manifest
+vnd.tier4.pilot-auto.platform.ecu.hardware-model: "example-hardware-model"
+vnd.tier4.pilot-auto.platform.ecu.hardware-series: "example-hardware-series"
+vnd.tier4.pilot-auto.platform.ecu.architecture: "x86_64"
+
+# for image-config
+vnd.tier4.image.base-image: "ubuntu:22.04"
+vnd.tier4.image.os: "Ubuntu"
+vnd.tier4.image.os.version: "22.04"
+description: "Example OTA image with annotations for add-image cmd"
+created: "2025-07-15T15:43:32Z"

--- a/tests/data/ota_image_builder/sys_config.yaml
+++ b/tests/data/ota_image_builder/sys_config.yaml
@@ -1,0 +1,3 @@
+hostname: autoware
+persist_files:
+  - "/etc/netplan"


### PR DESCRIPTION
This PR backports #680 to branch v3.11.