### PR TITLE
ci: fix release CI failed on release publishing 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,14 @@ jobs:
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs-on }}
     steps:
-      - name: checkout
+      - name: checkout (release)
+        if: ${{ github.event_name == 'release' }}
+        uses: actions/checkout@v5
+        # NOTE: when doing release, the tag will be created
+        #       at checkout, no need to fetch old tags
+
+      - name: checkout (non-release)
+        if: ${{ github.event_name != 'release' }}
         uses: actions/checkout@v5
         with:
           # NOTE: this should be enough to let hatch-vcs determines the


### PR DESCRIPTION
## Introduction

Fix release CI failed on release backed by tagging, release CI triggered manually is not affected.
The bug is introduced in https://github.com/tier4/ota-client/pull/693.

## Tests

- [x] release from tagging works: https://github.com/tier4/ota-client/actions/runs/18866772029/job/53835883188.
- [x] release from manually triggering CI works: https://github.com/tier4/ota-client/actions/runs/18866541244.