### PR TITLE
chore: add gRPC server error log

### DIFF
--- a/src/otaclient/grpc/api_v2/main.py
+++ b/src/otaclient/grpc/api_v2/main.py
@@ -86,10 +86,13 @@ def grpc_server_process(
         _address_info = f"{ecu_info.ip_addr}:{cfg.OTA_API_SERVER_PORT}"
         server.add_insecure_port(_address_info)
 
-        logger.info(f"launch grpc API server at {_address_info}")
-        await server.start()
         try:
+            logger.info(f"launch grpc API server at {_address_info}")
+            await server.start()
+            logger.info("gRPC API server started successfully")
             await server.wait_for_termination()
+        except Exception as e:
+            logger.exception(f"gRPC server terminated with exception: {e}")
         finally:
             await server.stop(1)
             thread_pool.shutdown(wait=True)


### PR DESCRIPTION
### Why
https://star4.slack.com/archives/C06T083QWTT/p1761543042769749
A strange situation occurred: the gRPC server went down three seconds after starting.

### What
Add log for `start` and `wait_for_termination` for future.