### PR TITLE
fix: otaclient dynamic app launch: remove `RefuseManualStart` setting

### DIFF
--- a/src/otaclient/main.py
+++ b/src/otaclient/main.py
@@ -402,6 +402,9 @@ def main() -> None:  # pragma: no cover
                         #       exits, this is for handling user manually `systemctl stop otaclient`.
                         "-p", "PartOf=otaclient.service",
                         "-p", "Type=simple",
+                        # NOTE: prevent the dynamic otaclient APP being stop manually, the stop should
+                        #       be done by stop the main otaclient.service instead. Restart is also prohibited.
+                        "-p", "RefuseManualStop=true",
                         # NOTE: subprocess_call here will do a chroot back to host_root.
                         "-p", f"RootImage={cfg.DYNAMIC_CLIENT_SQUASHFS_FILE}",
                         "-p", "ExecStartPre=/bin/mkdir -p /run/otaclient/mnt/active_slot",


### PR DESCRIPTION
## Introduction

This PR fixes dynamic app launching failed due to `RefuseManualStart` is set, this directory also prevents `systemd-run` itself from starting the service(`systemd-run` is considered as a type of manual start).

## Tests

- [x] dynamic otaclient update is working, systemd-run works as previous.
- [x] dynamic launched otaclient service cannot be stop/restart.