### PR TITLE
ci: fix to use gh instead of unauthenticated access to create patches

### DIFF
--- a/.github/actions/build_patches/action.yml
+++ b/.github/actions/build_patches/action.yml
@@ -31,6 +31,8 @@ runs:
 
     - name: get released versions
       shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         RELEASED_VERSIONS=$(gh release list --repo tier4/ota-client \
           --exclude-pre-releases --json tagName \


### PR DESCRIPTION
### Why
Currently, using unauthenticated Github access to create package patch files.
Sometimes this requests were failed.
<img width="720" height="354" alt="image" src="https://github.com/user-attachments/assets/cc948fc7-1a96-4ca9-aa2b-fdf7e8f73976" />

### What
Change to use `gh` instead of unauthenticated Github access. According to [the official documents](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-github_token-in-github-actions):
- unauthenticated requests(current): 60 requests per hour
- The rate limit for GITHUB_TOKEN via `gh`: 1,000 requests per hour per repository

### Test
- confirmed that the release was succeeded
https://github.com/tier4/ota-client/actions/runs/19318421968/job/55254509568
- confirmed that the versions were retrieved as expected
<img width="1433" height="682" alt="image" src="https://github.com/user-attachments/assets/b973cc39-0f22-49e8-8d6b-78b175a1f71e" />
