### PR TITLE
test: free disk by cleaning up the slots after e2e testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,7 +171,7 @@ def run_ota_image_v1_server():
 
 
 @pytest.fixture
-def ab_slots(tmp_path_factory: pytest.TempPathFactory) -> SlotMeta:
+def ab_slots(tmp_path_factory: pytest.TempPathFactory) -> Generator[SlotMeta]:
     """Prepare AB slots for the whole test session.
 
     The slot_a will be the active slot, it will be populated
@@ -224,12 +224,17 @@ def ab_slots(tmp_path_factory: pytest.TempPathFactory) -> SlotMeta:
     slot_b_boot_dir.mkdir()
     (slot_b_boot_dir / "grub").mkdir()
 
-    return SlotMeta(
-        slot_a=str(slot_a),
-        slot_b=str(slot_b),
-        slot_a_boot_dev=str(slot_a_boot_dev),
-        slot_b_boot_dev=str(slot_b_boot_dev),
-    )
+    try:
+        yield SlotMeta(
+            slot_a=str(slot_a),
+            slot_b=str(slot_b),
+            slot_a_boot_dev=str(slot_a_boot_dev),
+            slot_b_boot_dev=str(slot_b_boot_dev),
+        )
+    finally:
+        # do explicit cleanup after the use
+        shutil.rmtree(slot_a, ignore_errors=True)
+        shutil.rmtree(slot_b, ignore_errors=True)
 
 
 class ThreadpoolExecutorFixtureMixin:

--- a/tests/test_otaclient/test_ota_core/test_update_e2e.py
+++ b/tests/test_otaclient/test_ota_core/test_update_e2e.py
@@ -71,10 +71,6 @@ class TestOTAUpdater:
             otaclient_cfg.OTA_RESOURCES_STORE
         ).relative_to("/")
 
-        yield
-        # cleanup slot_b after test
-        shutil.rmtree(self.slot_b, ignore_errors=True)
-
     @pytest.fixture(autouse=True)
     def mock_setup(self, mocker: pytest_mock.MockerFixture, prepare_ab_slots):
         # ------ mock boot_controller ------ #


### PR DESCRIPTION
### Why
recent CI was failed due to low disk space.
https://github.com/tier4/ota-client/actions/runs/19499079471/job/55808449726?pr=719

### What
When doing OTA e2e, explicitly cleaning up the slot_a/slot_b folders during e2e test.