### PR TITLE
deps: bump ota-image-libs to v0.3.0 (backport v3.13.x)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "multidict<7.0,>=4.5",
   "msgpack>=1,<1.2",
   "otaclient_iot_logging_server_pb2 @ https://github.com/tier4/otaclient-iot-logging-server/releases/download/v1.3.0/otaclient_iot_logging_server_pb2-1.0.0-py3-none-any.whl#sha256:e5a2e6474a8b6f5656679877a5df40891e6a65c29830a31faed3d47d9973be60",
-  "ota-image-libs@https://github.com/tier4/ota-image-libs/releases/download/v0.2.6/ota_image_libs-0.2.6-py3-none-any.whl#sha256:ecbe997a5aa08c2e001ce69e9e9837fc6906f75543a1b88a09d7775894d2ac4b",
+  "ota-image-libs@https://github.com/tier4/ota-image-libs/releases/download/v0.3.0/ota_image_libs-0.3.0-py3-none-any.whl#sha256:98a411c53a01f313ddfbfcb8c8d20dcd9ced829c7282a01763c81f25c695d79c",
   "protobuf>=4.25.8,<6.34",
   "pydantic<3,>=2.10",
   "pydantic-settings<3,>=2.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.8"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -1745,8 +1745,8 @@ wheels = [
 
 [[package]]
 name = "ota-image-libs"
-version = "0.2.6"
-source = { url = "https://github.com/tier4/ota-image-libs/releases/download/v0.2.6/ota_image_libs-0.2.6-py3-none-any.whl" }
+version = "0.3.0"
+source = { url = "https://github.com/tier4/ota-image-libs/releases/download/v0.3.0/ota_image_libs-0.3.0-py3-none-any.whl" }
 dependencies = [
     { name = "cryptography" },
     { name = "msgpack" },
@@ -1761,7 +1761,7 @@ dependencies = [
     { name = "zstandard" },
 ]
 wheels = [
-    { url = "https://github.com/tier4/ota-image-libs/releases/download/v0.2.6/ota_image_libs-0.2.6-py3-none-any.whl", hash = "sha256:ecbe997a5aa08c2e001ce69e9e9837fc6906f75543a1b88a09d7775894d2ac4b" },
+    { url = "https://github.com/tier4/ota-image-libs/releases/download/v0.3.0/ota_image_libs-0.3.0-py3-none-any.whl", hash = "sha256:98a411c53a01f313ddfbfcb8c8d20dcd9ced829c7282a01763c81f25c695d79c" },
 ]
 
 [package.metadata]
@@ -1835,7 +1835,7 @@ requires-dist = [
     { name = "grpcio", specifier = "==1.70.0" },
     { name = "msgpack", specifier = ">=1,<1.2" },
     { name = "multidict", specifier = ">=4.5,<7.0" },
-    { name = "ota-image-libs", url = "https://github.com/tier4/ota-image-libs/releases/download/v0.2.6/ota_image_libs-0.2.6-py3-none-any.whl" },
+    { name = "ota-image-libs", url = "https://github.com/tier4/ota-image-libs/releases/download/v0.3.0/ota_image_libs-0.3.0-py3-none-any.whl" },
     { name = "otaclient-iot-logging-server-pb2", url = "https://github.com/tier4/otaclient-iot-logging-server/releases/download/v1.3.0/otaclient_iot_logging_server_pb2-1.0.0-py3-none-any.whl" },
     { name = "protobuf", specifier = ">=4.25.8,<6.34" },
     { name = "pydantic", specifier = ">=2.10,<3" },


### PR DESCRIPTION
## Introduction

This PR bumps ota-image-libs to version v0.3.0.
With this PR, otaclient will also be able to support the OTA image build with ota-image-libs >= v0.3.0. The support for previous built OTA image will be kept as it.

See https://github.com/tier4/ota-image-libs/pull/30 for more details.

## Tests

- [x] e2e OTA tests([test report](https://tier4.atlassian.net/wiki/x/kQAMIQE)).
- [x] full OTA downloading test([test report](https://tier4.atlassian.net/wiki/x/tABpIQE)).

## Tickets

https://tier4.atlassian.net/browse/T4DEV-45978