### PR TITLE
chore(deps): update renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,6 +26,10 @@
         "pep621"
       ],
       "rangeStrategy": "widen"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions updates"
     }
   ],
   "labels": [


### PR DESCRIPTION
## Introduction

This PR updates renovate config as follow:
1. add `gitIgnoredAuthors` config also under `vulnerabilityAlerts` section, as `vulnerabilityAlerts` will ignore all top-level configurations, need to specify the corresponding settings under `vulnerabilityAlerts` section to force apply the config.
2. group `github-actions` related update into a one PR.