### PR TITLE
chore(deps): restrict to update python by renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,6 +30,12 @@
     {
       "matchManagers": ["github-actions"],
       "groupName": "github-actions updates"
+    },
+    // do not update Python version used for building whl
+    {
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["python"],
+      "enabled": false
     }
   ],
   "labels": [


### PR DESCRIPTION
### Why
When we closed https://github.com/tier4/ota-client/pull/804, renovate re-create https://github.com/tier4/ota-client/pull/805 .

### What
restrict to update Python version by renovate.