### PR TITLE
feat: add version detail handling

### DIFF
--- a/docker/app_img/README.md
+++ b/docker/app_img/README.md
@@ -4,6 +4,7 @@
 
 ```bash
 # at the project root
+export OTACLIENT_VERSION=<DESIRED_VERSION>
 sudo docker build \
     -f docker/app_img/Dockerfile \
     --no-cache \
@@ -16,7 +17,11 @@ sudo docker build \
 
 ```bash
 # at the project root
+sudo docker rm -f otaclient_app_export || true
 sudo docker create --name otaclient_app_export otaclient_app:${OTACLIENT_VERSION}
+
+mkdir -p dist
+rm -rf dist/otaclient_*.squashfs
 sudo docker export otaclient_app_export | mksquashfs - dist/otaclient_${OTACLIENT_VERSION}.squashfs \
     -tar -b 1M \
     -mkfs-time 1729810800 \

--- a/docker/app_img/README.md
+++ b/docker/app_img/README.md
@@ -4,7 +4,6 @@
 
 ```bash
 # at the project root
-export OTACLIENT_VERSION=<DESIRED_VERSION>
 sudo docker build \
     -f docker/app_img/Dockerfile \
     --no-cache \
@@ -17,11 +16,7 @@ sudo docker build \
 
 ```bash
 # at the project root
-sudo docker rm -f otaclient_app_export || true
 sudo docker create --name otaclient_app_export otaclient_app:${OTACLIENT_VERSION}
-
-mkdir -p dist
-rm -rf dist/otaclient_*.squashfs
 sudo docker export otaclient_app_export | mksquashfs - dist/otaclient_${OTACLIENT_VERSION}.squashfs \
     -tar -b 1M \
     -mkfs-time 1729810800 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "multidict<7.0,>=4.5",
   "msgpack>=1,<1.2",
   "otaclient_iot_logging_server_pb2 @ https://github.com/tier4/otaclient-iot-logging-server/releases/download/v1.3.0/otaclient_iot_logging_server_pb2-1.0.0-py3-none-any.whl#sha256:e5a2e6474a8b6f5656679877a5df40891e6a65c29830a31faed3d47d9973be60",
-  "otaclient_pb2 @ https://github.com/tier4/otaclient-api/releases/download/v1.0.0/otaclient_pb2-1.0.0-py3-none-any.whl#sha256:86a8095345c65ef5b91c658960723341eaa5e4588eb6b9c731f7401341ae8604",
+  "otaclient_pb2 @ https://github.com/tier4/otaclient-api/releases/download/v1.1.0/otaclient_pb2-1.1.0-py3-none-any.whl#sha256:f10ffc958ff18ca16ebf62b083e0e4903fb24a26c3fec0386c6ec2a05387fdc5",
   "ota-image-libs@https://github.com/tier4/ota-image-libs/releases/download/v0.3.0/ota_image_libs-0.3.0-py3-none-any.whl#sha256:98a411c53a01f313ddfbfcb8c8d20dcd9ced829c7282a01763c81f25c695d79c",
   "protobuf>=4.25.8,<7.35",
   "pydantic<3,>=2.10",

--- a/requirements.txt
+++ b/requirements.txt
@@ -118,7 +118,7 @@ ota-image-libs @ https://github.com/tier4/ota-image-libs/releases/download/v0.3.
     # via otaclient
 otaclient-iot-logging-server-pb2 @ https://github.com/tier4/otaclient-iot-logging-server/releases/download/v1.3.0/otaclient_iot_logging_server_pb2-1.0.0-py3-none-any.whl
     # via otaclient
-otaclient-pb2 @ https://github.com/tier4/otaclient-api/releases/download/v1.0.0/otaclient_pb2-1.0.0-py3-none-any.whl
+otaclient-pb2 @ https://github.com/tier4/otaclient-api/releases/download/v1.1.0/otaclient_pb2-1.1.0-py3-none-any.whl
     # via otaclient
 propcache==0.2.0 ; python_full_version < '3.9'
     # via yarl

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,5 +6,6 @@ sonar.tests=tests
 sonar.sourceEncoding=UTF-8
 sonar.python.version=3.8,3.9,3.10,3.11,3.12,3.13
 sonar.exclusions=**/*_pb2*
+sonar.cpd.exclusions=src/otaclient_api/v2/_types.py
 # Wait for quality gate result and fail if not passed
 sonar.qualitygate.wait=true

--- a/src/otaclient/_status_monitor.py
+++ b/src/otaclient/_status_monitor.py
@@ -32,6 +32,7 @@ from otaclient._types import (
     UpdatePhase,
     UpdateProgress,
     UpdateTiming,
+    VersionDetail,
 )
 from otaclient._utils import SharedOTAClientStatusWriter
 from otaclient_common._logging import get_burst_suppressed_logger
@@ -61,6 +62,7 @@ atexit.register(_global_shutdown)
 @dataclass
 class SetOTAClientMetaReport:
     firmware_version: str = ""
+    version_detail: VersionDetail | None = None
 
 
 @dataclass
@@ -268,6 +270,8 @@ class OTAClientStatusCollector:
         # ------ update otaclient meta ------ #
         if isinstance(payload, SetOTAClientMetaReport):
             status_storage.firmware_version = payload.firmware_version
+            if payload.version_detail is not None:
+                status_storage.version_detail = payload.version_detail
             return True
 
         # ------ on session start/end ------ #

--- a/src/otaclient/_types.py
+++ b/src/otaclient/_types.py
@@ -107,6 +107,15 @@ class AbortState(StrEnum):
 
 
 @dataclass
+class VersionDetail:
+    """Extended version metadata stored as version_detail JSON file."""
+
+    release_name: str = ""
+    release_id: str = ""
+    image_id: str = ""
+
+
+@dataclass
 class UpdateMeta:
     update_firmware_version: str = ""
     image_size_uncompressed: int = 0
@@ -148,6 +157,7 @@ class OTAClientStatus:
     ecu_id: ClassVar[str] = ecu_info.ecu_id
     otaclient_version: ClassVar[str] = __version__
     firmware_version: str = ""
+    version_detail: Optional[VersionDetail] = None
 
     ota_status: OTAStatus = OTAStatus.INITIALIZED
     session_id: str = ""
@@ -210,6 +220,9 @@ class UpdateRequestV2(IPCRequest):
     version: str
     url_base: str
     cookies_json: str
+    release_name: str = ""
+    release_id: str = ""
+    image_id: str = ""
 
 
 @dataclass
@@ -224,6 +237,9 @@ class ClientUpdateRequestV2(IPCRequest):
     version: str
     url_base: str
     cookies_json: str
+    release_name: str = ""
+    release_id: str = ""
+    image_id: str = ""
 
 
 @dataclass

--- a/src/otaclient/boot_control/_base.py
+++ b/src/otaclient/boot_control/_base.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import NoReturn
 
 from otaclient import errors as ota_errors
-from otaclient._types import OTAStatus
+from otaclient._types import OTAStatus, VersionDetail
 
 from ._ota_status_control import OTAStatusFilesControl
 from ._slot_mnt_helper import SlotMountHelper
@@ -67,6 +67,10 @@ class BootControllerBase(ABC):
     def load_version(self) -> str:
         """Read the version info from the current slot."""
         return self._ota_status_control.load_active_slot_version()
+
+    def load_version_detail(self) -> VersionDetail | None:
+        """Read the version detail from the current slot."""
+        return self._ota_status_control.load_active_slot_version_detail()
 
     def load_standby_slot_version(self) -> str:
         """Read the version info from the standby slot."""
@@ -133,7 +137,12 @@ class BootControllerBase(ABC):
                 _err_msg, module=self.__class__.__module__
             ) from e
 
-    def post_update(self, update_version: str):
+    def post_update(
+        self,
+        update_version: str,
+        *,
+        version_detail: VersionDetail | None = None,
+    ):
         """Template method for post-update setup.
 
         Common flow:
@@ -145,7 +154,10 @@ class BootControllerBase(ABC):
             logger.info(f"{self.bootloader_type}: post-update setup...")
 
             # Step 1: Update standby slot's ota-status
-            self._ota_status_control.post_update_standby(version=update_version)
+            self._ota_status_control.post_update_standby(
+                version=update_version,
+                version_detail=version_detail,
+            )
 
             # Step 2: Platform-specific operations (fstab, boot config, firmware, etc.)
             self._post_update_platform_specific(update_version=update_version)

--- a/src/otaclient/boot_control/_ota_status_control.py
+++ b/src/otaclient/boot_control/_ota_status_control.py
@@ -16,11 +16,12 @@
 from __future__ import annotations
 
 import contextlib
+import json
 import logging
 from pathlib import Path
 from typing import Callable, Optional, Union
 
-from otaclient._types import OTAStatus
+from otaclient._types import OTAStatus, VersionDetail
 from otaclient.configs.cfg import cfg
 from otaclient_common import _env
 from otaclient_common._io import read_str_from_file, write_str_to_file_atomic
@@ -213,6 +214,17 @@ class OTAStatusFilesControl:
             _version,
         )
 
+    def _store_standby_version_detail(self, version_detail: VersionDetail):
+        _data = {
+            "release_name": version_detail.release_name,
+            "release_id": version_detail.release_id,
+            "image_id": version_detail.image_id,
+        }
+        write_str_to_file_atomic(
+            self.standby_ota_status_dir / cfg.OTA_VERSION_DETAIL_FNAME,
+            json.dumps(_data),
+        )
+
     # helper methods
 
     def _is_switching_boot(self, active_slot: str) -> bool:
@@ -243,7 +255,12 @@ class OTAStatusFilesControl:
         self._store_current_status(OTAStatus.FAILURE)
         self._store_current_slot_in_use(self.standby_slot)
 
-    def post_update_standby(self, *, version: str):
+    def post_update_standby(
+        self,
+        *,
+        version: str,
+        version_detail: Optional[VersionDetail] = None,
+    ):
         """On pre_update stage, set standby slot's status to UPDATING,
         set slot_in_use to standby slot, and set version.
 
@@ -257,6 +274,8 @@ class OTAStatusFilesControl:
         # store status to standby slot
         self._store_standby_status(OTAStatus.UPDATING)
         self._store_standby_version(version)
+        if version_detail is not None:
+            self._store_standby_version_detail(version_detail)
         self._store_standby_slot_in_use(self.standby_slot)
 
     def pre_rollback_current(self):
@@ -278,6 +297,32 @@ class OTAStatusFilesControl:
             self.standby_ota_status_dir / cfg.OTA_VERSION_FNAME,
             _default=cfg.DEFAULT_VERSION_STR,
         )
+
+    def _load_version_detail_from_dir(
+        self, ota_status_dir: Path
+    ) -> Optional[VersionDetail]:
+        """Try to load version_detail JSON. Returns None if not available."""
+        _detail_str = read_str_from_file(
+            ota_status_dir / cfg.OTA_VERSION_DETAIL_FNAME, _default=""
+        )
+        if not _detail_str:
+            return None
+        try:
+            _data = json.loads(_detail_str)
+            return VersionDetail(
+                release_name=_data.get("release_name", ""),
+                release_id=_data.get("release_id", ""),
+                image_id=_data.get("image_id", ""),
+            )
+        except Exception:
+            logger.warning("failed to parse version_detail")
+            return None
+
+    def load_active_slot_version_detail(self) -> Optional[VersionDetail]:
+        return self._load_version_detail_from_dir(self.current_ota_status_dir)
+
+    def load_standby_slot_version_detail(self) -> Optional[VersionDetail]:
+        return self._load_version_detail_from_dir(self.standby_ota_status_dir)
 
     def on_failure(self):
         """Store FAILURE to status file on failure."""

--- a/src/otaclient/boot_control/protocol.py
+++ b/src/otaclient/boot_control/protocol.py
@@ -19,7 +19,7 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import Protocol
 
-from otaclient._types import OTAStatus
+from otaclient._types import OTAStatus, VersionDetail
 
 from ._ota_status_control import OTAStatusFilesControl
 
@@ -60,6 +60,10 @@ class BootControllerProtocol(Protocol):
         """Read the version info from the current slot."""
 
     @abstractmethod
+    def load_version_detail(self) -> VersionDetail | None:
+        """Read the version detail from the current slot."""
+
+    @abstractmethod
     def load_standby_slot_version(self) -> str:
         """Read the version info from the standby slot."""
 
@@ -79,7 +83,12 @@ class BootControllerProtocol(Protocol):
     def pre_update(self, *, standby_as_ref: bool, erase_standby: bool): ...
 
     @abstractmethod
-    def post_update(self, update_version: str) -> None: ...
+    def post_update(
+        self,
+        update_version: str,
+        *,
+        version_detail: VersionDetail | None = None,
+    ) -> None: ...
 
     @abstractmethod
     def finalizing_update(self, *, chroot: str | None = None) -> None:

--- a/src/otaclient/configs/_cfg_consts.py
+++ b/src/otaclient/configs/_cfg_consts.py
@@ -117,6 +117,7 @@ class Consts:
     # ota status files
     OTA_STATUS_FNAME = "status"
     OTA_VERSION_FNAME = "version"
+    OTA_VERSION_DETAIL_FNAME = "version_detail"
     SLOT_IN_USE_FNAME = "slot_in_use"
 
     DEFAULT_VERSION_STR = ""

--- a/src/otaclient/grpc/api_v2/_types.py
+++ b/src/otaclient/grpc/api_v2/_types.py
@@ -57,6 +57,11 @@ def convert_to_apiv2_status(_in: OTAClientStatus) -> api_types.StatusResponseEcu
         ota_status=api_types.StatusOta[_in.ota_status],
     )
 
+    if _in.version_detail is not None:
+        base_res.release_name = _in.version_detail.release_name
+        base_res.release_id = _in.version_detail.release_id
+        base_res.image_id = _in.version_detail.image_id
+
     if _in.ota_status != OTAStatus.UPDATING or not (
         _in.update_meta
         and _in.update_phase

--- a/src/otaclient/grpc/api_v2/servicer.py
+++ b/src/otaclient/grpc/api_v2/servicer.py
@@ -221,6 +221,9 @@ class OTAClientAPIServicer:
                 cookies_json=req_ecu.cookies,
                 request_id=request_id,
                 session_id=new_session_id,
+                release_name=req_ecu.release_name,
+                release_id=req_ecu.release_id,
+                image_id=req_ecu.image_id,
             )
         elif isinstance(req_ecu, api_types.RollbackRequestEcu) and (
             request_cls is RollbackRequestV2

--- a/src/otaclient/ota_core/_client_updater.py
+++ b/src/otaclient/ota_core/_client_updater.py
@@ -73,7 +73,10 @@ class OTAClientUpdater(LegacyOTAImageSupportMixin, OTAUpdateInitializer):
 
     def _execute_client_update(self):
         """Implementation of OTA updating."""
-        logger.info(f"execute local update({ecu_info.ecu_id=}): {self.update_version=}")
+        logger.info(
+            f"execute local update({ecu_info.ecu_id=}): "
+            f"{self.update_version=}, {self.release_name=}, {self.release_id=}, {self.image_id=}"
+        )
 
         try:
             self._process_metadata(only_metadata_verification=True)

--- a/src/otaclient/ota_core/_main.py
+++ b/src/otaclient/ota_core/_main.py
@@ -97,6 +97,8 @@ HOLD_REQ_HANDLING_ON_ACK_CLIENT_UPDATE_REQUEST = 4  # seconds
 WAIT_FOR_OTAPROXY_ONLINE = 3 * 60  # 3mins
 WAIT_BEFORE_DYNAMIC_CLIENT_EXIT = 6  # seconds
 
+SKIP_CLIENT_UPDATE = False  # for testing purpose, skip client update
+
 
 class OTAClient:
     """The adapter between OTAClient gRPC interface and the OTA implementation."""
@@ -201,11 +203,13 @@ class OTAClient:
         _boot_ctrl_loaded_ota_status = self.boot_controller.get_booted_ota_status()
         self._live_ota_status = _boot_ctrl_loaded_ota_status
         self.current_version = self.boot_controller.load_version()
+        self.current_version_detail = self.boot_controller.load_version_detail()
 
         status_report_queue.put_nowait(
             StatusReport(
                 payload=SetOTAClientMetaReport(
                     firmware_version=self.current_version,
+                    version_detail=self.current_version_detail,
                 ),
             )
         )
@@ -357,6 +361,9 @@ class OTAClient:
                 session_id=new_session_id,
                 metrics=self._metrics,
                 shm_metrics_reader=self._shm_metrics_reader,
+                release_name=request.release_name,
+                release_id=request.release_id,
+                image_id=request.image_id,
             )
 
             _no_ca_err = "no CA chains are installed, reject any OTA update"
@@ -447,6 +454,10 @@ class OTAClient:
         NOTE that client update API will not raise any exceptions. The failure information
             is available via status API.
         """
+        if SKIP_CLIENT_UPDATE:
+            logger.warning("SKIP_CLIENT_UPDATE is set to True, skip client update")
+            return
+
         if _env.is_running_as_downloaded_dynamic_app():
             # Duplicates client update should not be allowed.
             # TODO(airkei) [2025-06-19]: should return the dedicated error code for "client update"
@@ -505,6 +516,9 @@ class OTAClient:
                 client_update_control_flags=self._client_update_control_flags,
                 metrics=self._metrics,
                 shm_metrics_reader=self._shm_metrics_reader,
+                release_name=request.release_name,
+                release_id=request.release_id,
+                image_id=request.image_id,
             ).execute()
         except ota_errors.OTAError:
             logger.warning("client update failed")

--- a/src/otaclient/ota_core/_main.py
+++ b/src/otaclient/ota_core/_main.py
@@ -97,8 +97,6 @@ HOLD_REQ_HANDLING_ON_ACK_CLIENT_UPDATE_REQUEST = 4  # seconds
 WAIT_FOR_OTAPROXY_ONLINE = 3 * 60  # 3mins
 WAIT_BEFORE_DYNAMIC_CLIENT_EXIT = 6  # seconds
 
-SKIP_CLIENT_UPDATE = False  # for testing purpose, skip client update
-
 
 class OTAClient:
     """The adapter between OTAClient gRPC interface and the OTA implementation."""
@@ -454,10 +452,6 @@ class OTAClient:
         NOTE that client update API will not raise any exceptions. The failure information
             is available via status API.
         """
-        if SKIP_CLIENT_UPDATE:
-            logger.warning("SKIP_CLIENT_UPDATE is set to True, skip client update")
-            return
-
         if _env.is_running_as_downloaded_dynamic_app():
             # Duplicates client update should not be allowed.
             # TODO(airkei) [2025-06-19]: should return the dedicated error code for "client update"

--- a/src/otaclient/ota_core/_updater.py
+++ b/src/otaclient/ota_core/_updater.py
@@ -35,7 +35,7 @@ from otaclient._status_monitor import (
     SetUpdateMetaReport,
     StatusReport,
 )
-from otaclient._types import AbortState, UpdatePhase
+from otaclient._types import AbortState, UpdatePhase, VersionDetail
 from otaclient._utils import wait_and_log
 from otaclient.boot_control._jetson_common import parse_nv_tegra_release
 from otaclient.boot_control._jetson_uefi import JetsonUEFIBootControl
@@ -311,7 +311,17 @@ class OTAUpdaterBase(OTAUpdateInitializer):
         os.chmod(self._ota_meta_store_on_standby, 0o700)
 
         self._preserve_client_squashfs_at_post_update()
-        self._boot_controller.post_update(self.update_version)
+        _version_detail: VersionDetail | None = None
+        if self.release_name and self.release_id and self.image_id:
+            _version_detail = VersionDetail(
+                release_name=self.release_name,
+                release_id=self.release_id,
+                image_id=self.image_id,
+            )
+        self._boot_controller.post_update(
+            self.update_version,
+            version_detail=_version_detail,
+        )
 
     def _finalize_update(self) -> None:
         """Finalize-Update: wait for all sub ECUs, and then reboot."""
@@ -363,7 +373,10 @@ class OTAUpdaterBase(OTAUpdateInitializer):
         zone transition methods (enter/exit_critical_zone, enter_final_phase)
         which raise OTAAbortSignal if abort is in progress.
         """
-        logger.info(f"execute local update({ecu_info.ecu_id=}): {self.update_version=}")
+        logger.info(
+            f"execute local update({ecu_info.ecu_id=}): "
+            f"{self.update_version=}, {self.release_name=}, {self.release_id=}, {self.image_id=}"
+        )
         try:
             self._process_metadata()
 

--- a/src/otaclient/ota_core/_updater_base.py
+++ b/src/otaclient/ota_core/_updater_base.py
@@ -66,6 +66,9 @@ class OTAUpdateInterfaceArgs(TypedDict):
     session_id: str
     metrics: OTAMetricsData
     shm_metrics_reader: SharedOTAClientMetricsReader
+    release_name: str
+    release_id: str
+    image_id: str
 
 
 class OTAUpdateInitializer:
@@ -83,8 +86,14 @@ class OTAUpdateInitializer:
         session_id: str,
         metrics: OTAMetricsData,
         shm_metrics_reader: SharedOTAClientMetricsReader,
+        release_name: str = "",
+        release_id: str = "",
+        image_id: str = "",
     ) -> None:
         self.update_version = version
+        self.release_name = release_name
+        self.release_id = release_id
+        self.image_id = image_id
         self.update_start_timestamp = int(time.time())
         self.session_id = session_id
         self._status_report_queue = status_report_queue

--- a/src/otaclient_api/v2/_types.py
+++ b/src/otaclient_api/v2/_types.py
@@ -299,6 +299,9 @@ class StatusResponseEcuV2(ECUStatusSummary, MessageWrapper[pb2.StatusResponseEcu
     ota_status: StatusOta
     otaclient_version: str
     update_status: UpdateStatus
+    release_name: str
+    release_id: str
+    image_id: str
 
     def __init__(
         self,
@@ -310,6 +313,9 @@ class StatusResponseEcuV2(ECUStatusSummary, MessageWrapper[pb2.StatusResponseEcu
         failure_reason: _Optional[str] = ...,
         failure_traceback: _Optional[str] = ...,
         update_status: _Optional[_Union[UpdateStatus, _Mapping]] = ...,
+        release_name: _Optional[str] = ...,
+        release_id: _Optional[str] = ...,
+        image_id: _Optional[str] = ...,
     ) -> None: ...
 
     @property
@@ -382,6 +388,9 @@ class UpdateRequestEcu(MessageWrapper[pb2.UpdateRequestEcu]):
     ecu_id: str
     url: str
     version: str
+    release_name: str
+    release_id: str
+    image_id: str
 
     def __init__(
         self,
@@ -390,6 +399,9 @@ class UpdateRequestEcu(MessageWrapper[pb2.UpdateRequestEcu]):
         version: _Optional[str] = ...,
         url: _Optional[str] = ...,
         cookies: _Optional[str] = ...,
+        release_name: _Optional[str] = ...,
+        release_id: _Optional[str] = ...,
+        image_id: _Optional[str] = ...,
     ) -> None: ...
 
 
@@ -453,6 +465,9 @@ class ClientUpdateRequestEcu(MessageWrapper[pb2.UpdateRequestEcu]):
     ecu_id: str
     url: str
     version: str
+    release_name: str
+    release_id: str
+    image_id: str
 
     def __init__(
         self,
@@ -461,6 +476,9 @@ class ClientUpdateRequestEcu(MessageWrapper[pb2.UpdateRequestEcu]):
         version: _Optional[str] = ...,
         url: _Optional[str] = ...,
         cookies: _Optional[str] = ...,
+        release_name: _Optional[str] = ...,
+        release_id: _Optional[str] = ...,
+        image_id: _Optional[str] = ...,
     ) -> None: ...
 
 

--- a/tests/test_otaclient/test_boot_control/test_base.py
+++ b/tests/test_otaclient/test_boot_control/test_base.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from otaclient import errors as ota_errors
-from otaclient._types import OTAStatus
+from otaclient._types import OTAStatus, VersionDetail
 from otaclient.boot_control._base import BootControllerBase
 from otaclient.boot_control._ota_status_control import OTAStatusFilesControl
 from otaclient.boot_control._slot_mnt_helper import SlotMountHelper
@@ -80,6 +80,22 @@ class TestBootControllerBase:
         # Test load_version
         assert controller.load_version() == "1.0.0"
         controller._ota_status_control.load_active_slot_version.assert_called_once()
+
+        # Test load_version_detail
+        _mock_detail = VersionDetail(
+            release_name="r1", release_id="rid1", image_id="img1"
+        )
+        controller._ota_status_control.load_active_slot_version_detail.return_value = (
+            _mock_detail
+        )
+        assert controller.load_version_detail() == _mock_detail
+        controller._ota_status_control.load_active_slot_version_detail.assert_called_once()
+
+        # Test load_version_detail returns None
+        controller._ota_status_control.load_active_slot_version_detail.return_value = (
+            None
+        )
+        assert controller.load_version_detail() is None
 
         # Test get_booted_ota_status
         assert controller.get_booted_ota_status() == OTAStatus.SUCCESS
@@ -144,6 +160,22 @@ class TestBootControllerBase:
         controller._mp_control.umount_all.assert_called_once()
 
         # Verify platform-specific method was called
+        assert controller.post_update_platform_called is True
+
+    def test_post_update_with_version_detail(self):
+        """Test post_update passes version_detail to ota_status_control."""
+        controller = ConcreteBootController()
+
+        _version_detail = VersionDetail(
+            release_name="r1", release_id="rid1", image_id="img1"
+        )
+        controller.post_update(update_version="2.0.0", version_detail=_version_detail)
+
+        controller._ota_status_control.post_update_standby.assert_called_once_with(
+            version="2.0.0",
+            version_detail=_version_detail,
+        )
+        controller._mp_control.umount_all.assert_called_once()
         assert controller.post_update_platform_called is True
 
     def test_post_update_failure_handling(self):

--- a/tests/test_otaclient/test_boot_control/test_ota_status_control.py
+++ b/tests/test_otaclient/test_boot_control/test_ota_status_control.py
@@ -24,7 +24,7 @@ from unittest.mock import patch
 
 import pytest
 
-from otaclient._types import OTAStatus
+from otaclient._types import OTAStatus, VersionDetail
 from otaclient.boot_control._ota_status_control import OTAStatusFilesControl
 from otaclient.configs.cfg import cfg as otaclient_cfg
 from otaclient_common._io import read_str_from_file, write_str_to_file_atomic
@@ -66,6 +66,16 @@ class TestOTAStatusFilesControl:
         self.finalize_switch_boot_flag = threading.Event()
         self.finalize_switch_boot_func = partial(
             _dummy_finalize_switch_boot, self.finalize_switch_boot_flag
+        )
+
+    def _make_status_control(self) -> OTAStatusFilesControl:
+        return OTAStatusFilesControl(
+            active_slot=self.slot_a,
+            standby_slot=self.slot_b,
+            current_ota_status_dir=self.slot_a_ota_status_dir,
+            standby_ota_status_dir=self.slot_b_ota_status_dir,
+            finalize_switching_boot=partial(self.finalize_switch_boot_func, True),
+            force_initialize=False,
         )
 
     @pytest.mark.parametrize(
@@ -368,3 +378,73 @@ class TestOTAStatusFilesControl:
         # Both current and standby status files should be set to FAILURE
         assert read_str_from_file(self.slot_a_status_file) == OTAStatus.FAILURE
         assert read_str_from_file(self.slot_b_status_file) == OTAStatus.FAILURE
+
+    def test_post_update_with_version_detail(self):
+        """Test that post_update_standby stores version_detail JSON file."""
+        status_control = self._make_status_control()
+
+        # ------ execution ------ #
+        _version_detail = VersionDetail(
+            release_name="release_v1",
+            release_id="rid_001",
+            image_id="img_001",
+        )
+        status_control.post_update_standby(
+            version="dummy_version",
+            version_detail=_version_detail,
+        )
+
+        # ------ assertion ------ #
+        assert read_str_from_file(self.slot_b_status_file) == OTAStatus.UPDATING
+        assert read_str_from_file(self.slot_b_slot_in_use_file) == self.slot_b
+
+        # version_detail file should exist on standby slot
+        loaded = status_control.load_standby_slot_version_detail()
+        assert loaded is not None
+        assert loaded.release_name == "release_v1"
+        assert loaded.release_id == "rid_001"
+        assert loaded.image_id == "img_001"
+
+    def test_post_update_without_version_detail(self):
+        """Test that post_update_standby without version_detail does not create the file."""
+        status_control = self._make_status_control()
+
+        status_control.post_update_standby(version="dummy_version")
+
+        # version_detail should be None when no file exists
+        assert status_control.load_standby_slot_version_detail() is None
+
+    def test_load_version_detail_from_active_slot(self):
+        """Test loading version_detail from the active slot."""
+        import json
+
+        # ------ setup ------ #
+        _data = {
+            "release_name": "active_release",
+            "release_id": "active_rid",
+            "image_id": "active_img",
+        }
+        write_str_to_file_atomic(
+            self.slot_a_ota_status_dir / otaclient_cfg.OTA_VERSION_DETAIL_FNAME,
+            json.dumps(_data),
+        )
+
+        loaded = self._make_status_control().load_active_slot_version_detail()
+
+        # ------ assertion ------ #
+        assert loaded is not None
+        assert loaded.release_name == "active_release"
+        assert loaded.release_id == "active_rid"
+        assert loaded.image_id == "active_img"
+
+    def test_load_version_detail_returns_none_when_missing(self):
+        """Test that load_version_detail returns None when file is missing."""
+        assert self._make_status_control().load_active_slot_version_detail() is None
+
+    def test_load_version_detail_returns_none_on_invalid_json(self):
+        """Test that load_version_detail returns None on invalid JSON."""
+        write_str_to_file_atomic(
+            self.slot_a_ota_status_dir / otaclient_cfg.OTA_VERSION_DETAIL_FNAME,
+            "not valid json{{{",
+        )
+        assert self._make_status_control().load_active_slot_version_detail() is None

--- a/tests/test_otaclient/test_ota_core/test_otaclient_update.py
+++ b/tests/test_otaclient/test_ota_core/test_otaclient_update.py
@@ -101,6 +101,9 @@ class TestOTAClientUpdater:
             metrics=OTAMetricsData(),
             standby_slot_dev="dummy_dev",
             shm_metrics_reader=None,  # type: ignore
+            release_name="",
+            release_id="",
+            image_id="",
         )
 
         # Patch the _session_workdir attribute after instance creation

--- a/tests/test_otaclient/test_ota_core/test_updater.py
+++ b/tests/test_otaclient/test_ota_core/test_updater.py
@@ -84,6 +84,9 @@ class TestOTAUpdaterWithAbortHandler:
         updater._status_report_queue = self.status_report_queue
         updater.session_id = "test_session_id"
         updater.update_version = "test_version"
+        updater.release_name = ""
+        updater.release_id = ""
+        updater.image_id = ""
         updater.ecu_status_flags = mocker.MagicMock()
         updater._metrics = mocker.MagicMock()
         updater._shm_metrics_reader = None

--- a/tests/test_otaclient/test_performance/conftest.py
+++ b/tests/test_otaclient/test_performance/conftest.py
@@ -25,7 +25,7 @@ from typing import Any
 
 import pytest
 
-from otaclient._types import OTAStatus
+from otaclient._types import OTAStatus, VersionDetail
 
 logger = logging.getLogger(__name__)
 
@@ -320,8 +320,15 @@ class MockBootController:
         )
         self._standby_slot_path.mkdir(parents=True, exist_ok=True)
 
-    def post_update(self, update_version: str) -> None:
-        logger.info(f"MockBootController: post_update(version={update_version})")
+    def post_update(
+        self,
+        update_version: str,
+        *,
+        version_detail: VersionDetail | None = None,
+    ) -> None:
+        logger.info(
+            f"MockBootController: post_update(version={update_version}, version_detail={version_detail})"
+        )
         self._standby_version = update_version
 
     def finalizing_update(self, *, chroot: str | None = None) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3303,7 +3303,7 @@ requires-dist = [
     { name = "multidict", specifier = ">=4.5,<7.0" },
     { name = "ota-image-libs", url = "https://github.com/tier4/ota-image-libs/releases/download/v0.3.0/ota_image_libs-0.3.0-py3-none-any.whl" },
     { name = "otaclient-iot-logging-server-pb2", url = "https://github.com/tier4/otaclient-iot-logging-server/releases/download/v1.3.0/otaclient_iot_logging_server_pb2-1.0.0-py3-none-any.whl" },
-    { name = "otaclient-pb2", url = "https://github.com/tier4/otaclient-api/releases/download/v1.0.0/otaclient_pb2-1.0.0-py3-none-any.whl" },
+    { name = "otaclient-pb2", url = "https://github.com/tier4/otaclient-api/releases/download/v1.1.0/otaclient_pb2-1.1.0-py3-none-any.whl" },
     { name = "protobuf", specifier = ">=4.25.8,<7.35" },
     { name = "pydantic", specifier = ">=2.10,<3" },
     { name = "pydantic-settings", specifier = ">=2.3,<3" },
@@ -3339,10 +3339,10 @@ wheels = [
 
 [[package]]
 name = "otaclient-pb2"
-version = "1.0.0"
-source = { url = "https://github.com/tier4/otaclient-api/releases/download/v1.0.0/otaclient_pb2-1.0.0-py3-none-any.whl" }
+version = "1.1.0"
+source = { url = "https://github.com/tier4/otaclient-api/releases/download/v1.1.0/otaclient_pb2-1.1.0-py3-none-any.whl" }
 wheels = [
-    { url = "https://github.com/tier4/otaclient-api/releases/download/v1.0.0/otaclient_pb2-1.0.0-py3-none-any.whl", hash = "sha256:86a8095345c65ef5b91c658960723341eaa5e4588eb6b9c731f7401341ae8604" },
+    { url = "https://github.com/tier4/otaclient-api/releases/download/v1.1.0/otaclient_pb2-1.1.0-py3-none-any.whl", hash = "sha256:f10ffc958ff18ca16ebf62b083e0e4903fb24a26c3fec0386c6ec2a05387fdc5" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Persist and restore an extended `version_detail` metadata file (`release_name`, `release_id`, `image_id`) alongside the existing `version` file on each OTA slot. The upper layer may attach these fields to an `Update` / `ClientUpdate` request; when present, they are stored on the standby slot at post-update and can be read back via the Status API after reboot.

Motivation: `version` alone is not enough to identify which release / image a slot was built from. Exposing the richer triple through the Status API lets the upper layer (FMS) correlate a running slot with the release it originated from.

## Check list

- [x] test file(s) that cover the change(s) are implemented.
- [x] local tests are passing.
- [x] design docs/implementation docs are prepared.
- [x] executed OTA and verified that both `version` and `version_detail` are stored in the expected location.
```
autoware@autoware-ecu:~$ cat /boot/ota-slot_b/version
20260422153720-test/ota/beta/v4.4
autoware@autoware-ecu:~$ cat /boot/ota-slot_b/version_detail 
{"release_name": "20260422153720-test/ota/beta/v4.4", "release_id": "014caa00-b8b7-4660-ab69-6d3349538a0b", "image_id": "7d0368d9-b6b4-46e7-9466-2a8b91c2a070"}
```
- [x] detail version information is stored in Status API response
```
Apr 23 09:08:13 autoware-ecu otaclient[2880]: {"timestamp":"2026-04-23 09:08:13,963","level":"INFO","logger":"otaclient._status_monitor","function":"_ota_status_logging_thread","line":"355","message":
"ongoing OTA: OTAClientStatus(
firmware_version='20260422153720-test/ota/beta/v4.4',
version_detail=VersionDetail(release_name='20260422153720-test/ota/beta/v4.4', release_id='014caa00-b8b7-4660-ab69-6d3349538a0b', image_id='7d0368d9-b6b4-46e7-9466-2a8b91c2a070'),
...
```

## Documents

https://tier4.atlassian.net/wiki/spaces/OTA/pages/5151260680/ECU-level+Firmware+Update+History+Management

## Changes

- Add `VersionDetail` dataclass (`release_name`, `release_id`, `image_id`) in `otaclient/_types.py`.
- Add `version_detail` field to `OTAClientStatus` and propagate it through `_status_monitor`, gRPC API v2 types, and the servicer.
- Add `OTA_VERSION_DETAIL_FNAME` config constant.
- `OTAStatusFilesControl`: add `_store_standby_version_detail`, `load_active_slot_version_detail`, `load_standby_slot_version_detail`; extend `post_update_standby` to accept an optional `VersionDetail` and write it as JSON only when provided.
- `BootControllerProtocol.post_update` / `_base.py`: accept and forward `version_detail`; expose `load_version_detail()` for active slot.
- `ota_core/_updater.py`: construct `VersionDetail` at post-update **only when `release_name`, `release_id`, and `image_id` are all non-empty**; otherwise pass `None` and no file is written.
- Plumb `release_name` / `release_id` / `image_id` from `UpdateRequestV2` / `ClientUpdateRequestV2` through `_main.py` into `OTAUpdateInitializer`.
- Tests: new cases in `test_ota_status_control.py` (store with/without detail, load from active slot, missing file, invalid JSON) and `test_base.py` (load_version_detail, post_update forwarding).

## Behavior changes

Does this PR introduce behavior change(s)?

- [x] Yes, internal behavior (will not impact user experience).
- [ ] Yes, external behavior (will impact user experience).
- [ ] No.

### Previous behavior

Only the firmware `version` string was stored per slot. `release_name` / `release_id` / `image_id` supplied in an update request were not persisted and were not observable after reboot.

### Behavior with this PR

When all three fields are supplied on an update request, a `version_detail` JSON file is written to the standby slot's OTA status directory at post-update. After reboot, it is loaded and exposed through the Status API as `OTAClientStatus.version_detail`. If any of the three fields is empty, the file is not written and `version_detail` is reported as `None` — preserving backward compatibility with callers that do not set these fields.

## Breaking change

Does this PR introduce breaking change(s)?

- [ ] Yes.
- [x] No.

The new fields are optional on both the request and the status response. Existing callers and existing on-disk state (slots with no `version_detail` file) continue to work unchanged.

## Related links & tickets
https://tier4.atlassian.net/browse/T4DEV-52538
<!-- TODO: link the relevant ticket -->