### PR TITLE
refine(otaproxy): allow otaproxy to run even if sqlite3 DB init failed

### DIFF
--- a/src/ota_proxy/cache_index.py
+++ b/src/ota_proxy/cache_index.py
@@ -199,36 +199,54 @@ class CacheIndex:
 
         self._index: dict[str, CacheIndexEntry] = {}
 
-        if force_init_db:
-            logger.info("cache DB init requested ...")
-            self._force_init_db()
-        else:
-            # Validate DB and load, re-init on failure
-            self._ensure_db_and_load()
+        _use_db = True
+        try:
+            if force_init_db:
+                logger.info("cache DB init requested ...")
+                self._force_init_db()
+            else:
+                # Validate DB and load, re-init on failure
+                self._ensure_db_and_load()
+        except Exception as e:
+            logger.error(
+                f"failed to init DB, will disable DB for persisting cache meta: {e!r}"
+            )
+            _use_db = False
 
-        self._db_writer = _db_writer = CacheDBWriter(self._db_f)
-        self._db_thread = threading.Thread(
-            target=_db_writer.start_thread,
-            daemon=True,
-            name="cache_index_db_worker",
-        )
-        self._db_thread.start()
+        if _use_db:
+            self._db_writer = _db_writer = CacheDBWriter(self._db_f)
+            self._db_thread = threading.Thread(
+                target=_db_writer.start_thread,
+                daemon=True,
+                name="cache_index_db_worker",
+            )
+            self._db_thread.start()
+        else:
+            self._db_writer = None
+            self._db_thread = None
 
     def _force_init_db(self) -> None:
         """Delete and re-create the DB file with an empty table."""
         logger.info("force init cache DB ...")
-        self._db_f.unlink(missing_ok=True)
-        init_db(self._db_f, self._table_name)
-        logger.info(f"cache index: re-initialized DB at {self._db_f}")
+        try:
+            self._db_f.unlink(missing_ok=True)
+            init_db(self._db_f, self._table_name)
+            logger.info(f"cache index: re-initialized DB at {self._db_f}")
+        except Exception as e:
+            logger.exception(f"failed to force init DB file at {self._db_f}: {e!r}")
+            raise
 
     def _ensure_db_and_load(self) -> None:
         """Validate DB, load entries into index. Re-init DB on any failure."""
-        if not check_db(self._db_f, self._table_name):
-            logger.warning(
-                f"cache index: DB validation failed, re-initializing {self._db_f}"
-            )
-            self._force_init_db()
-            return
+        try:
+            _db_file_ok = check_db(self._db_f, self._table_name)
+        except Exception as e:
+            logger.exception(f"DB file broken, force init: {e!r}")
+            return self._force_init_db()
+
+        if not _db_file_ok:
+            logger.warning(f"{self._db_f} failed the integrity check, force init ...")
+            return self._force_init_db()
 
         try:
             _res, _exceed = self._preload_from_db()
@@ -242,7 +260,7 @@ class CacheIndex:
             logger.info("pre-load DB finished")
         except Exception as e:
             logger.exception(
-                f"cache index: failed to load from DB, re-initializing {self._db_f}: {e!r}"
+                f"cache index: failed to load from DB, force re-initializing {self._db_f}: {e!r}"
             )
 
             self._index.clear()
@@ -316,7 +334,8 @@ class CacheIndex:
     def remove_entry(self, file_sha256: str) -> None:
         """Remove entry from in-memory index and register remove from DB."""
         self._index.pop(file_sha256, None)
-        self._db_writer.remove_entry(file_sha256)
+        if self._db_writer:
+            self._db_writer.remove_entry(file_sha256)
 
     def commit_entry(self, entry: CacheMeta) -> bool:
         """Add entry to in-memory index and queue DB write."""
@@ -343,9 +362,11 @@ class CacheIndex:
 
         # with GIL, write to dict is atomic
         self._index[key] = index_entry
-        self._db_writer.register_entry(entry)
+        if self._db_writer:
+            self._db_writer.register_entry(entry)
         return True
 
     def close(self) -> None:
-        self._db_writer.close()
-        self._db_thread.join(timeout=DB_SHUTDOWN_TIMEOUT)
+        if self._db_writer and self._db_thread:
+            self._db_writer.close()
+            self._db_thread.join(timeout=DB_SHUTDOWN_TIMEOUT)

--- a/test/integration/test_otaproxy/test_cache_index.py
+++ b/test/integration/test_otaproxy/test_cache_index.py
@@ -284,3 +284,111 @@ class TestCacheIndexCommitAndRemove:
         for key in to_remove_keys:
             assert key not in remaining
         assert len(remaining) == DB_ENTRIES - ENTRIES_TO_REMOVE
+
+
+# ---- CacheIndex degraded-mode (DB init failure) ---- #
+
+
+class TestCacheIndexDBInitFailure:
+    """CacheIndex must gracefully degrade when DB init/validation fails.
+
+    Persistence is best-effort: the in-memory index is the source of truth
+    during a proxy session, and a broken SQLite file must not crash startup.
+    """
+
+    def test_force_init_failure_degrades(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """force_init_db=True with a failing init_db must disable DB persistence."""
+        mocker.patch(
+            "ota_proxy.cache_index.init_db",
+            side_effect=RuntimeError("simulated init_db failure"),
+        )
+
+        idx = CacheIndex(tmp_path / "cache.db", tmp_path / "ota-cache", force_init_db=True)
+        try:
+            assert idx._db_writer is None
+            assert idx._db_thread is None
+        finally:
+            idx.close()
+
+    def test_check_db_failure_then_reinit_failure_degrades(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """check_db raising + subsequent force-init failing must disable DB."""
+        mocker.patch(
+            "ota_proxy.cache_index.check_db",
+            side_effect=sqlite3.DatabaseError("simulated DB corruption"),
+        )
+        mocker.patch(
+            "ota_proxy.cache_index.init_db",
+            side_effect=RuntimeError("simulated init_db failure"),
+        )
+
+        idx = CacheIndex(tmp_path / "cache.db", tmp_path / "ota-cache")
+        try:
+            assert idx._db_writer is None
+            assert idx._db_thread is None
+        finally:
+            idx.close()
+
+    def test_check_db_invalid_then_reinit_failure_degrades(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """check_db returning False + force-init failing must disable DB."""
+        mocker.patch("ota_proxy.cache_index.check_db", return_value=False)
+        mocker.patch(
+            "ota_proxy.cache_index.init_db",
+            side_effect=RuntimeError("simulated init_db failure"),
+        )
+
+        idx = CacheIndex(tmp_path / "cache.db", tmp_path / "ota-cache")
+        try:
+            assert idx._db_writer is None
+            assert idx._db_thread is None
+        finally:
+            idx.close()
+
+    def test_degraded_mode_operations_are_safe(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """In degraded mode, commit/lookup/remove/close must all work in-memory only."""
+        mocker.patch(
+            "ota_proxy.cache_index.init_db",
+            side_effect=RuntimeError("simulated init_db failure"),
+        )
+
+        base_dir = tmp_path / "ota-cache"
+        idx = CacheIndex(tmp_path / "cache.db", base_dir, force_init_db=True)
+        try:
+            assert idx._db_writer is None
+
+            sample = [
+                CacheMeta(
+                    file_sha256=url_based_hash(f"http://example.com/degraded/{i}"),
+                    url=f"http://example.com/degraded/{i}",
+                    cache_size=1024,
+                    last_access=int(time.time()),
+                )
+                for i in range(5)
+            ]
+
+            # commit_entry populates the in-memory index and returns True
+            for e in sample:
+                assert idx.commit_entry(e) is True
+                assert idx.lookup_entry(e.file_sha256) is not None
+
+            # remove_entry clears the in-memory index entry
+            to_remove = sample[0]
+            idx.remove_entry(to_remove.file_sha256)
+            assert idx.lookup_entry(to_remove.file_sha256) is None
+
+            # remaining entries untouched
+            for e in sample[1:]:
+                assert idx.lookup_entry(e.file_sha256) is not None
+
+            # removing a key that isn't tracked must be a no-op
+            idx.remove_entry("nonexistent")
+        finally:
+            # close() must be a safe no-op even without writer/thread
+            idx.close()

--- a/test/integration/test_otaproxy/test_cache_index.py
+++ b/test/integration/test_otaproxy/test_cache_index.py
@@ -305,7 +305,9 @@ class TestCacheIndexDBInitFailure:
             side_effect=RuntimeError("simulated init_db failure"),
         )
 
-        idx = CacheIndex(tmp_path / "cache.db", tmp_path / "ota-cache", force_init_db=True)
+        idx = CacheIndex(
+            tmp_path / "cache.db", tmp_path / "ota-cache", force_init_db=True
+        )
         try:
             assert idx._db_writer is None
             assert idx._db_thread is None


### PR DESCRIPTION
## Description

<!-- Summarize the change this PR wants to introduce.

For better understanding, adding reason/motivation of this PR are also recommended.
-->

This PR adds safety guard around sqlite3 DB preload and init paths at CacheIndex starts up. The back storage sqlite3 DB now can be optional if somehow we cannot make the DB work, allows otaproxy to still run normally without a back sqlite3 DB.

## Check list

<!-- A list of things needed to be done before set the PR as ready-for-review. -->

- [x] test file(s) that cover the change(s) are implemented.
- [x] local tests are passing.