### PR TITLE
chore: migrate tests for logging and metrics

### DIFF
--- a/test/integration/test_otaclient/test_logging.py
+++ b/test/integration/test_otaclient/test_logging.py
@@ -11,6 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Integration tests for the otaclient logging subsystem.
+
+The scope here is the full ``configure_logging()`` -> ``_LogTeeHandler``
+-> ``TransmitterGrpc`` -> live gRPC server flow.  A dummy
+``OTAClientIoTLoggingService`` runs in-process on a loopback port and
+captures the messages that the logging handler streams to it.
+"""
 
 from __future__ import annotations
 
@@ -52,22 +59,16 @@ class DummyQueueData:
 
 
 class DummyLogServerService(log_v1_grpc.OTAClientIoTLoggingServiceServicer):
-    def __init__(self, test_queue, data_ready):
+    def __init__(self, test_queue: Queue[DummyQueueData], data_ready: asyncio.Event):
         self._test_queue = test_queue
         self._data_ready = data_ready
 
     async def Check(self, request: log_pb2.HealthCheckRequest, context):
-        """
-        Dummy gRPC method for health check.
-        """
         return log_pb2.HealthCheckResponse(
             status=log_pb2.HealthCheckResponse.ServingStatus.SERVING
         )
 
     async def PutLog(self, request: log_pb2.PutLogRequest, context):
-        """
-        Dummy gRPC method to put a log message to the queue.
-        """
         self._test_queue.put_nowait(
             DummyQueueData(
                 ecu_id=request.ecu_id,
@@ -82,6 +83,7 @@ class DummyLogServerService(log_v1_grpc.OTAClientIoTLoggingServiceServicer):
 class TestLogClient:
     OTA_CLIENT_LOGGING_SERVER = "http://127.0.0.1:8083"
     OTA_CLIENT_LOGGING_SERVER_GRPC = "http://192.168.0.1:8084"
+    GRPC_BIND_URL = "http://127.0.0.1:8084"
     ECU_ID = "testclient"
 
     @pytest.fixture(autouse=True)
@@ -119,7 +121,7 @@ class TestLogClient:
             servicer=DummyLogServerService(self.test_queue, self.data_ready),
             server=server,
         )
-        parsed_url = urlparse("http://127.0.0.1:8084")
+        parsed_url = urlparse(TestLogClient.GRPC_BIND_URL)
         server.add_insecure_port(parsed_url.netloc)
         try:
             await server.start()
@@ -130,15 +132,14 @@ class TestLogClient:
 
     @pytest.fixture
     def restore_logging(self):
-        # confiure_logging() is called in the test, so we need to restore the original logging configuration
-        # Save the current logging configuration
+        # configure_logging() mutates the root logger; snapshot and restore so
+        # the global state is the same after each test.
         original_handlers = logging.root.handlers[:]
         original_level = logging.root.level
         original_formatters = [handler.formatter for handler in logging.root.handlers]
 
         yield
 
-        # Restore the original logging configuration
         logging.root.handlers = original_handlers
         logging.root.level = original_level
         for handler, formatter in zip(logging.root.handlers, original_formatters):
@@ -147,20 +148,23 @@ class TestLogClient:
     @pytest.mark.parametrize(
         "log_message, extra, expected_log_type",
         [
-            (
+            pytest.param(
                 "some log message without extra",
                 {},
                 log_pb2.LogType.LOG,
+                id="default-log-type",
             ),
-            (
+            pytest.param(
                 "some log message",
                 {"log_type": LogType.LOG},
                 log_pb2.LogType.LOG,
+                id="explicit-log-type",
             ),
-            (
+            pytest.param(
                 "some metrics message",
                 {"log_type": LogType.METRICS},
                 log_pb2.LogType.METRICS,
+                id="metrics-log-type",
             ),
         ],
     )
@@ -200,8 +204,8 @@ class TestLogClient:
         assert _response.log_type == expected_log_type
 
         if _response.log_type == log_pb2.LogType.LOG:
-            # Extract the message part from the JSON log format
-            # e.g. {"timestamp":"2022-01-01 00:00:00,000","level":"ERROR","logger":"test_log_client","function":"test_log_client","line":123,"message":"some log message"}
+            # The handler formats LOG records as JSON; extract `message` to
+            # compare against the original input.
             try:
                 log_data = json.loads(_response.message)
                 extracted_message = log_data["message"]
@@ -209,7 +213,7 @@ class TestLogClient:
                 pytest.fail(f"Failed to parse JSON log message: {e}")
             assert extracted_message == log_message
         elif _response.log_type == log_pb2.LogType.METRICS:
-            # Expect the message to be the same as the input
+            # METRICS records pass through unchanged.
             assert _response.message == log_message
         else:
             pytest.fail(f"Unexpected log type: {_response.log_type}")
@@ -223,6 +227,6 @@ class TestLogClient:
 
         mock_start_upload_thread.assert_called_once_with(
             logging_upload_endpoint=self._proxy_info.logging_server,
-            logging_upload_grpc_endpoint=AnyHttpUrl("http://127.0.0.1:8084"),
+            logging_upload_grpc_endpoint=AnyHttpUrl(TestLogClient.GRPC_BIND_URL),
             ecu_id=self._ecu_info.ecu_id,
         )

--- a/test/unit/test_otaclient/test_metrics.py
+++ b/test/unit/test_otaclient/test_metrics.py
@@ -21,6 +21,7 @@ mocked or constructed in-memory.
 from __future__ import annotations
 
 import json
+from dataclasses import fields
 
 import pytest
 from _otaclient_version import __version__
@@ -31,6 +32,24 @@ from otaclient._logging import LogType
 from otaclient.configs.cfg import ecu_info
 
 MODULE = metrics.__name__
+
+# Fields the shm snapshot carries; `shm_merge` copies each of these onto the
+# OTAMetricsData instance (they all also exist on OTAMetricsData, which is the
+# contract that makes the merge effective). Derived from the source dataclass
+# so new snapshot fields are exercised automatically.
+SHARED_CACHE_FIELDS = [f.name for f in fields(metrics.OTAMetricsSharedMemoryData)]
+
+
+class _BrokenShm:
+    """A snapshot stand-in whose every attribute read raises.
+
+    Simulates the real failure `shm_merge` guards against: a detached or
+    corrupt `multiprocessing.shared_memory` segment that throws when the
+    backing buffer is dereferenced.
+    """
+
+    def __getattr__(self, name: str):
+        raise RuntimeError("shared memory unavailable")
 
 
 @pytest.fixture
@@ -47,32 +66,45 @@ class TestOTAMetricsData:
         assert ota_metrics.ecu_id == ecu_info.ecu_id
         assert ota_metrics._already_published is False
 
-    def test_shm_merge_success(self, mock_logger):
+    # ------------------------------ shm_merge ------------------------------ #
+
+    @pytest.mark.parametrize(
+        "field", [pytest.param(name, id=name) for name in SHARED_CACHE_FIELDS]
+    )
+    def test_shm_merge_copies_each_shared_field(self, mock_logger, field: str):
+        """Every field the snapshot carries is merged onto the metrics data."""
         ota_metrics = metrics.OTAMetricsData()
 
         shm_metrics = metrics.OTAMetricsSharedMemoryData()
-        shm_metrics.cache_total_requests = 100
-        shm_metrics.cache_cdn_hits = 20
-        shm_metrics.cache_external_hits = 50
-        shm_metrics.cache_local_hits = 30
+        setattr(shm_metrics, field, 100)
 
         ota_metrics.shm_merge(shm_metrics)
 
-        assert ota_metrics.cache_total_requests == 100
-        assert ota_metrics.cache_cdn_hits == 20
-        assert ota_metrics.cache_external_hits == 50
-        assert ota_metrics.cache_local_hits == 30
+        assert getattr(ota_metrics, field) == 100
+        mock_logger.warning.assert_not_called()
 
-    def test_shm_merge_no_data(self, mock_logger):
+    def test_shm_merge_overwrites_even_with_shm_defaults(self, mock_logger):
+        """The snapshot is authoritative: a zeroed snapshot overwrites prior counters
+        (rather than merging max/only-if-set)."""
         ota_metrics = metrics.OTAMetricsData()
+        for field in SHARED_CACHE_FIELDS:
+            setattr(ota_metrics, field, 999)
 
-        initial_cache_requests = ota_metrics.cache_total_requests
-        initial_cache_hits = ota_metrics.cache_external_hits
+        # a freshly-constructed snapshot is all-zero
+        ota_metrics.shm_merge(metrics.OTAMetricsSharedMemoryData())
+
+        for field in SHARED_CACHE_FIELDS:
+            assert getattr(ota_metrics, field) == 0
+
+    def test_shm_merge_none_is_noop(self, mock_logger):
+        ota_metrics = metrics.OTAMetricsData()
+        initial = {f: getattr(ota_metrics, f) for f in SHARED_CACHE_FIELDS}
 
         ota_metrics.shm_merge(None)
 
-        assert ota_metrics.cache_total_requests == initial_cache_requests
-        assert ota_metrics.cache_external_hits == initial_cache_hits
+        for field, value in initial.items():
+            assert getattr(ota_metrics, field) == value
+        mock_logger.warning.assert_not_called()
 
     def test_shm_merge_preserves_non_shared_fields(self, mock_logger):
         ota_metrics = metrics.OTAMetricsData()
@@ -92,7 +124,18 @@ class TestOTAMetricsData:
         assert ota_metrics.current_firmware_version == "1.0.0"
         assert ota_metrics.downloaded_bytes == 1000
 
-    def test_publish(self, mock_logger):
+    def test_shm_merge_swallows_exception(self, mock_logger):
+        """A failure while reading the snapshot is logged, never propagated."""
+        ota_metrics = metrics.OTAMetricsData()
+
+        # must not raise even though every snapshot read throws
+        ota_metrics.shm_merge(_BrokenShm())
+
+        mock_logger.warning.assert_called_once()
+
+    # ------------------------------- publish ------------------------------- #
+
+    def test_publish_logs_metrics_payload(self, mock_logger):
         ota_metrics = metrics.OTAMetricsData()
         test_session_id = "test_session_id"
         ota_metrics.session_id = test_session_id
@@ -107,21 +150,42 @@ class TestOTAMetricsData:
         assert data_dict["session_id"] == test_session_id
         assert data_dict["ecu_id"] == ecu_info.ecu_id
         assert data_dict["otaclient_version"] == __version__
+        # the bookkeeping flag set in __post_init__ must not leak into the payload
+        assert "_already_published" not in data_dict
 
         assert log_extra["log_type"] == LogType.METRICS
 
         assert ota_metrics._already_published is True
 
-        mock_logger.reset_mock()
-        ota_metrics.publish()
-
-        mock_logger.info.assert_not_called()
-
-    def test_publish_multiple_times(self, mock_logger):
+    @pytest.mark.parametrize(
+        "n_calls", [pytest.param(2, id="2x"), pytest.param(5, id="5x")]
+    )
+    def test_publish_is_idempotent(self, mock_logger, n_calls: int):
+        """Publishing repeatedly only emits the metrics once."""
         ota_metrics = metrics.OTAMetricsData()
 
-        ota_metrics.publish()
-        assert mock_logger.info.call_count == 1
+        for _ in range(n_calls):
+            ota_metrics.publish()
 
+        mock_logger.info.assert_called_once()
+        assert ota_metrics._already_published is True
+
+    def test_publish_failure_is_retryable(self, mock_logger, mocker: MockerFixture):
+        """A failed publish is logged via error() and leaves the data un-published,
+        so a subsequent call retries instead of silently dropping the metrics."""
+        ota_metrics = metrics.OTAMetricsData()
+        mocker.patch(
+            f"{MODULE}.json.dumps",
+            side_effect=[RuntimeError("boom"), "{}"],
+        )
+
+        # first attempt fails: error logged, nothing emitted, flag not latched
         ota_metrics.publish()
-        assert mock_logger.info.call_count == 1
+        mock_logger.error.assert_called_once()
+        mock_logger.info.assert_not_called()
+        assert ota_metrics._already_published is False
+
+        # second attempt retries and succeeds
+        ota_metrics.publish()
+        mock_logger.info.assert_called_once()
+        assert ota_metrics._already_published is True

--- a/test/unit/test_otaclient/test_metrics.py
+++ b/test/unit/test_otaclient/test_metrics.py
@@ -11,14 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test module for OTA client metrics."""
+"""Unit tests for `otaclient.metrics`.
+
+Scope is `OTAMetricsData` only: every collaborator (the module-level
+`logger`, the `OTAMetricsSharedMemoryData` snapshot dataclass) is either
+mocked or constructed in-memory.
+"""
 
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
 
+import pytest
 from _otaclient_version import __version__
+from pytest_mock import MockerFixture
 
 from otaclient import metrics
 from otaclient._logging import LogType
@@ -27,119 +33,95 @@ from otaclient.configs.cfg import ecu_info
 MODULE = metrics.__name__
 
 
+@pytest.fixture
+def mock_logger(mocker: MockerFixture):
+    return mocker.patch(f"{MODULE}.logger")
+
+
 class TestOTAMetricsData:
     """Test class for OTAMetricsData functionality."""
 
     def test_init(self):
-        """Test initialization of OTAMetricsData."""
         ota_metrics = metrics.OTAMetricsData()
         assert ota_metrics.otaclient_version == __version__
         assert ota_metrics.ecu_id == ecu_info.ecu_id
         assert ota_metrics._already_published is False
 
-    @patch("otaclient.metrics.logger")
     def test_shm_merge_success(self, mock_logger):
-        """Test successful merge of shared memory data."""
         ota_metrics = metrics.OTAMetricsData()
 
-        # Create mock shared memory data
         shm_metrics = metrics.OTAMetricsSharedMemoryData()
         shm_metrics.cache_total_requests = 100
         shm_metrics.cache_cdn_hits = 20
         shm_metrics.cache_external_hits = 50
         shm_metrics.cache_local_hits = 30
 
-        # Test the merge
         ota_metrics.shm_merge(shm_metrics)
 
-        # Verify the data was merged
         assert ota_metrics.cache_total_requests == 100
         assert ota_metrics.cache_cdn_hits == 20
         assert ota_metrics.cache_external_hits == 50
         assert ota_metrics.cache_local_hits == 30
 
-    @patch("otaclient.metrics.logger")
     def test_shm_merge_no_data(self, mock_logger):
-        """Test merge when shared memory returns None."""
         ota_metrics = metrics.OTAMetricsData()
 
-        # Store initial values
         initial_cache_requests = ota_metrics.cache_total_requests
         initial_cache_hits = ota_metrics.cache_external_hits
 
-        # Test the merge with None
         ota_metrics.shm_merge(None)
 
-        # Verify the data was not changed
         assert ota_metrics.cache_total_requests == initial_cache_requests
         assert ota_metrics.cache_external_hits == initial_cache_hits
 
-    @patch("otaclient.metrics.logger")
     def test_shm_merge_preserves_non_shared_fields(self, mock_logger):
-        """Test that merge preserves fields not in shared memory data."""
         ota_metrics = metrics.OTAMetricsData()
 
-        # Set some initial values for non-shared fields
         ota_metrics.session_id = "test_session"
         ota_metrics.current_firmware_version = "1.0.0"
         ota_metrics.downloaded_bytes = 1000
 
-        # Create mock shared memory data
         shm_metrics = metrics.OTAMetricsSharedMemoryData()
         shm_metrics.cache_total_requests = 100
 
-        # Test the merge
         ota_metrics.shm_merge(shm_metrics)
 
-        # Verify shared fields were updated
         assert ota_metrics.cache_total_requests == 100
 
-        # Verify non-shared fields were preserved
         assert ota_metrics.session_id == "test_session"
         assert ota_metrics.current_firmware_version == "1.0.0"
         assert ota_metrics.downloaded_bytes == 1000
 
-    @patch("otaclient.metrics.logger")
     def test_publish(self, mock_logger):
-        """Test publish method of OTAMetricsData."""
         ota_metrics = metrics.OTAMetricsData()
         test_session_id = "test_session_id"
         ota_metrics.session_id = test_session_id
 
         ota_metrics.publish()
 
-        # Verify logger was called with JSON representation of data
         mock_logger.info.assert_called_once()
         log_message = mock_logger.info.call_args[0][0]
         log_extra = mock_logger.info.call_args[1]["extra"]
 
-        # Verify the log message is valid JSON and contains our data
         data_dict = json.loads(log_message)
         assert data_dict["session_id"] == test_session_id
         assert data_dict["ecu_id"] == ecu_info.ecu_id
         assert data_dict["otaclient_version"] == __version__
 
-        # Verify log type is correct
         assert log_extra["log_type"] == LogType.METRICS
 
-        # Verify already_published flag is set
         assert ota_metrics._already_published is True
 
-        # Reset the mock and call publish again
         mock_logger.reset_mock()
         ota_metrics.publish()
 
-        # Verify logger was not called again
         mock_logger.info.assert_not_called()
 
-    def test_publish_multiple_times(self):
-        """Test that publishing only happens once."""
+    def test_publish_multiple_times(self, mock_logger):
         ota_metrics = metrics.OTAMetricsData()
 
-        with patch("otaclient.metrics.logger") as mock_logger:
-            ota_metrics.publish()
-            assert mock_logger.info.call_count == 1
+        ota_metrics.publish()
+        assert mock_logger.info.call_count == 1
 
-            # Second publish should not call logger again
-            ota_metrics.publish()
-            assert mock_logger.info.call_count == 1
+        ota_metrics.publish()
+        assert mock_logger.info.call_count == 1


### PR DESCRIPTION
## Introduction

This PR migrates the tests for otaclient logging and metrics, categorized and re-arrange into integration tests and unit tests accordingly.