### PR TITLE
ci(workflow): add lock file management workflow for syncing uv.lock a…

### DIFF
--- a/.github/workflows/lock_file_management.yml
+++ b/.github/workflows/lock_file_management.yml
@@ -28,13 +28,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          # use repo scope deploy key for the later git operations, so that the pushed commit can trigger the
-          #   workflow as expected. The default action token GITHUB_TOKEN cannot trigger new workflows.
-          # For more details about this restriction, please refer to:
-          #   https://github.com/peter-evans/create-pull-request/issues/48 and
-          #   https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
-          persist-credentials: true
+
       - name: Install uv
         uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
         with:


### PR DESCRIPTION
## Description

Refactor the lock file syncing workflow. This PR renames the workflow file to a clearer name and simplifies the checkout step by dropping the repo-scoped deploy key, falling back to the default `GITHUB_TOKEN` for the git operations.

## Check list

- [ ] test file(s) that cover the change(s) are implemented.
- [x] local tests are passing.

## Changes

- Rename `.github/workflows/sync_lockfile.yaml` → `.github/workflows/lock_file_management.yml`.
- Remove the `ssh-key: ${{ secrets.DEPLOY_KEY }}` and `persist-credentials: true` options from the `actions/checkout` step; the job now relies on the default `GITHUB_TOKEN`.

## Behavior changes

Does this PR introduce behavior change(s)?

- [x] Yes, internal behavior (will not impact user experience).
- [ ] Yes, external behavior (will impact user experience).
- [ ] No.

### Previous behavior

The workflow checked out the repository using a repo-scoped deploy key(`secrets.DEPLOY_KEY`) with `persist-credentials: true`. Commits pushed by this workflow (updating `uv.lock` / `requirements.txt`) were authenticated with the deploy key, which allowed those pushes to trigger further workflow runs.

### Behavior with this PR

The workflow checks out and pushes using the default `GITHUB_TOKEN`. Commits pushed by this workflow will **not** trigger further workflow runs (a documented `GITHUB_TOKEN` restriction), removing the dependency on the `DEPLOY_KEY` secret.

## Breaking change

Does this PR introduce breaking change(s)?

- [ ] Yes.
- [x] No.

## Related links & tickets

- https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs