### PR TITLE
feat: boot_control.jetson-uefi: for Jetson device using QSPI for OTA BOOTDEV, force reset slot boot flags before OTA reboot

### DIFF
--- a/src/otaclient/boot_control/_jetson_uefi.py
+++ b/src/otaclient/boot_control/_jetson_uefi.py
@@ -20,10 +20,12 @@ But firmware update is only supported after BSP R35.2.
 from __future__ import annotations
 
 import contextlib
+import fcntl
 import logging
 import os
 import re
 import shutil
+import struct
 import subprocess
 from pathlib import Path
 from typing import Any, ClassVar, Generator, Literal, NoReturn
@@ -328,6 +330,118 @@ def _detect_ota_bootdev_is_qspi(nvboot_ctrl_conf: str) -> bool | None:
         return True
 
     logger.warning(f"device uses unknown TEGRA_OTA_BOOT_DEVICE: {ota_bootdev}")
+
+
+class RootfsBootStatusControl:
+    """Helper for force-resetting rootfs slots' boot status UEFI variables.
+
+    On Jetson UEFI, the RootfsStatusSlot{A,B} efivars track each rootfs slot's
+    boot status. UEFI marks a slot "unbootable" after repeated failed boots and
+    stops booting into it. Before an OTA reboot we force-reset these flags so the
+    freshly updated standby slot gets a clean boot-retry state on next reboot.
+
+    IMPORTANT: this mechanism is ONLY valid/safe for devices using QSPI flash as
+        TEGRA_OTA_BOOT_DEVICE. The caller MUST ensure the device uses QSPI before
+        calling reset_unbootable_flag(). For device using internal emmc or an
+        unknown/undetectable OTA_BOOTDEV, the RootfsStatus efivars MUST NOT be
+        touched, otherwise undefined behaviors will occur.
+
+    reference: https://docs.nvidia.com/jetson/archives/r38.2.1/DeveloperGuide/SD/Bootloader/UEFI.html#set-the-uefi-variable-in-the-recovery-kernel-shell
+    """
+
+    # Linux inode attribute ioctls, see
+    #   https://github.com/torvalds/linux/blob/master/include/uapi/linux/fs.h.
+    FS_IOC_GETFLAGS: ClassVar[int] = 0x80086601
+    """_IOR('f', 1, long): read inode attribute flags."""
+    FS_IOC_SETFLAGS: ClassVar[int] = 0x40086602
+    """_IOW('f', 2, long): write inode attribute flags."""
+    FS_IMMUTABLE_FL: ClassVar[int] = 0x00000010
+    """The immutable(chattr +i) attribute bit."""
+
+    @classmethod
+    @contextlib.contextmanager
+    def _immutable_flag_cleared(
+        cls, var_fpath: StrOrPath
+    ) -> Generator[None, Any, None]:  # pragma: no cover
+        """Temporarily clear the immutable attribute on <var_fpath>.
+
+        efivarfs marks existing UEFI variables immutable; the attribute must be
+        cleared before the variable can be rewritten, and restored afterwards.
+        This is the Python equivalent of `chattr -i` / `chattr +i`.
+        """
+        # NOTE: an immutable file cannot be opened for writing, but O_RDONLY is
+        #   enough to issue the GETFLAGS/SETFLAGS ioctls.
+        fd = os.open(var_fpath, os.O_RDONLY)
+        try:
+            (_orig_flags,) = struct.unpack(
+                "i", fcntl.ioctl(fd, cls.FS_IOC_GETFLAGS, struct.pack("i", 0))
+            )
+            fcntl.ioctl(
+                fd,
+                cls.FS_IOC_SETFLAGS,
+                struct.pack("i", _orig_flags & ~cls.FS_IMMUTABLE_FL),
+            )
+            try:
+                yield
+            finally:
+                # restore the original attribute flags(re-add immutable)
+                fcntl.ioctl(
+                    fd,
+                    cls.FS_IOC_SETFLAGS,
+                    struct.pack("i", _orig_flags | cls.FS_IMMUTABLE_FL),
+                )
+        finally:
+            os.close(fd)
+
+    @classmethod
+    def _reset_slot_boot_flag(cls, slot_name: str, var_fpath: Path) -> None:
+        """Reset a single rootfs slot's boot status efivar to "normal/bootable".
+
+        efivars payload = 4-byte attribute header(0x07) + 4-byte data(0x00000000).
+        The efivar is immutable by default; clear the immutable attribute, rewrite
+        the payload, sync, then restore the immutable attribute.
+
+        This is best-effort: any failure is logged and swallowed so it never blocks
+        the OTA reboot.
+        """
+        if not var_fpath.is_file():
+            logger.warning(
+                f"{slot_name} efivar not found at {var_fpath}, skip resetting"
+            )
+            return
+
+        try:
+            with cls._immutable_flag_cleared(var_fpath):
+                # NOTE: open WITHOUT O_TRUNC(matching `dd conv=notrunc`); efivarfs
+                #   requires the whole payload to be written in a single write().
+                fd = os.open(var_fpath, os.O_WRONLY)
+                try:
+                    os.write(fd, boot_cfg.RESET_ROOTFS_STATUS_PAYLOAD)
+                    os.fsync(fd)
+                finally:
+                    os.close(fd)
+            logger.info(f"reset {slot_name} boot flag to bootable at {var_fpath}")
+        except Exception as e:
+            logger.warning(
+                f"failed to reset {slot_name} boot flag at {var_fpath}: {e!r}"
+            )
+
+    @classmethod
+    def reset_unbootable_flag(cls) -> None:  # pragma: no cover
+        """Force reset both rootfs slots' boot status flag to "normal/bootable".
+
+        IMPORTANT: only call this for devices using QSPI flash as OTA_BOOTDEV.
+            See the class docstring for details.
+        """
+        with _ensure_efivarfs_mounted():
+            cls._reset_slot_boot_flag(
+                "RootfsStatusSlotA",
+                Path(EFIVARS_SYS_MOUNT_POINT) / boot_cfg.ROOTFS_STATUS_SLOT_A_EFIVAR,
+            )
+            cls._reset_slot_boot_flag(
+                "RootfsStatusSlotB",
+                Path(EFIVARS_SYS_MOUNT_POINT) / boot_cfg.ROOTFS_STATUS_SLOT_B_EFIVAR,
+            )
 
 
 class L4TLauncherBSPVersionControl(BaseModel):
@@ -1066,6 +1180,26 @@ class JetsonUEFIBootControl(BootControllerBase):
                 internal_emmc_devpath=self._uefi_control.standby_internal_emmc_devpath,
                 standby_slot_boot_dirpath=self._mp_control.standby_slot_mount_point
                 / "boot",
+            )
+
+        # ------ force reset rootfs unbootable flag before reboot ------ #
+        # NOTE: ONLY devices using QSPI flash as TEGRA_OTA_BOOT_DEVICE support the
+        #   reset unbootable flag mechanism. For device using internal emmc or an
+        #   unknown/undetectable OTA_BOOTDEV, we MUST NOT touch the RootfsStatus
+        #   efivars.
+        device_uses_qspi = _detect_ota_bootdev_is_qspi(
+            self._uefi_control.nvbootctrl_conf
+        )
+        if device_uses_qspi:
+            logger.info(
+                "device uses QSPI as OTA_BOOTDEV, "
+                "force reset rootfs unbootable flag before reboot ..."
+            )
+            RootfsBootStatusControl.reset_unbootable_flag()
+        else:
+            logger.info(
+                "device does not use QSPI as OTA_BOOTDEV (emmc or unknown), "
+                "skip resetting rootfs unbootable flag (OTA continuing ...)"
             )
 
     def finalizing_update(self, *, chroot: str | None = None) -> NoReturn:

--- a/src/otaclient/boot_control/_jetson_uefi.py
+++ b/src/otaclient/boot_control/_jetson_uefi.py
@@ -699,7 +699,7 @@ class UEFIFirmwareUpdater:
 
     # APIs
 
-    def firmware_update(self) -> bool:
+    def firmware_update(self, use_qspi: bool | None) -> bool:
         """Trigger firmware update in next boot if configured.
 
         Only when the following conditions met the firmware update will be configured:
@@ -790,12 +790,11 @@ class UEFIFirmwareUpdater:
                 self._update_l4tlauncher()
 
         # write special UEFI variable to trigger firmware update on next reboot
-        device_uses_qspi = _detect_ota_bootdev_is_qspi(self.nvbootctrl_conf)
-        if device_uses_qspi is None:
+        if use_qspi is None:
             logger.warning("failed to detect OTA_BOOTDEV, skip firmware update")
             return False
 
-        if device_uses_qspi:
+        if use_qspi:
             firmware_update_triggerred = _trigger_capsule_update_qspi_ota_bootdev()
         else:
             firmware_update_triggerred = _trigger_capsule_update_non_qspi_ota_bootdev(
@@ -843,6 +842,9 @@ class _UEFIBootControl:
             raise JetsonUEFIBootControlError(_err_msg)
         self.nvbootctrl_conf = nvbootctrl_conf_fpath.read_text()
         logger.info(f"nvboot_ctrl_conf: \n{self.nvbootctrl_conf}")
+
+        self.use_qspi = _detect_ota_bootdev_is_qspi(self.nvbootctrl_conf)
+        logger.info("device uses QSPI for OTA BOOTDEV")
 
         # ------ check current slot BSP version ------ #
         # check current slot firmware BSP version
@@ -1073,7 +1075,7 @@ class JetsonUEFIBootControl(BootControllerBase):
             firmware_manifest=firmware_manifest,
             nvbootctrl_conf=self._uefi_control.nvbootctrl_conf,
         )
-        return firmware_updater.firmware_update()
+        return firmware_updater.firmware_update(use_qspi=self._uefi_control.use_qspi)
 
     # APIs
 
@@ -1187,10 +1189,7 @@ class JetsonUEFIBootControl(BootControllerBase):
         #   reset unbootable flag mechanism. For device using internal emmc or an
         #   unknown/undetectable OTA_BOOTDEV, we MUST NOT touch the RootfsStatus
         #   efivars.
-        device_uses_qspi = _detect_ota_bootdev_is_qspi(
-            self._uefi_control.nvbootctrl_conf
-        )
-        if device_uses_qspi:
+        if self._uefi_control.use_qspi:
             logger.info(
                 "device uses QSPI as OTA_BOOTDEV, "
                 "force reset rootfs unbootable flag before reboot ..."

--- a/src/otaclient/boot_control/configs.py
+++ b/src/otaclient/boot_control/configs.py
@@ -115,6 +115,22 @@ class JetsonUEFIBootControlConfig(JetsonBootCommon):
     CAPSULE_PAYLOAD_AT_ESP = "EFI/UpdateCapsule"
     L4TLAUNCHER_VER_FNAME = "l4tlauncher_version"
 
+    # --- reset rootfs unbootable flag (QSPI OTA_BOOTDEV only) --- #
+    # UEFI variables tracking each rootfs slot's boot status. Resetting these
+    #   clears any "unbootable" state UEFI may have set on a slot after previous
+    #   failed boots, giving the freshly updated standby slot a clean boot-retry
+    #   state on next reboot.
+    # reference: https://docs.nvidia.com/jetson/archives/r38.2.1/DeveloperGuide/SD/Bootloader/UEFI.html#set-the-uefi-variable-in-the-recovery-kernel-shell
+    ROOTFS_STATUS_SLOT_A_EFIVAR = (
+        "RootfsStatusSlotA-781e084c-a330-417c-b678-38e696380cb9"
+    )
+    ROOTFS_STATUS_SLOT_B_EFIVAR = (
+        "RootfsStatusSlotB-781e084c-a330-417c-b678-38e696380cb9"
+    )
+    # efivars payload to reset a rootfs slot's boot flag to "normal/bootable":
+    #   4-byte attribute header(0x00000007) + 4-byte data(0x00000000).
+    RESET_ROOTFS_STATUS_PAYLOAD = b"\x07\x00\x00\x00\x00\x00\x00\x00"
+
 
 class RPIBootControlConfig:
     BOOTLOADER = BootloaderType.RPI_BOOT

--- a/tests/unit/test_otaclient/test_boot_control/test_jetson_uefi.py
+++ b/tests/unit/test_otaclient/test_boot_control/test_jetson_uefi.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 
 import pytest
@@ -31,10 +32,12 @@ from otaclient.boot_control._jetson_uefi import (
     JetsonUEFIBootControlError,
     L4TLauncherBSPVersionControl,
     NVBootctrlJetsonUEFI,
+    RootfsBootStatusControl,
     _detect_esp_dev,
     _detect_ota_bootdev_is_qspi,
     _l4tlauncher_version_control,
 )
+from otaclient.boot_control.configs import jetson_uefi_cfg as boot_cfg
 
 MODULE = _jetson_uefi.__name__
 
@@ -391,3 +394,122 @@ class TestJetsonUEFIBootControlBSPVersionCheck:
         )
 
         assert result is True
+
+
+class TestRootfsBootStatusControl:
+    """Test the force-reset rootfs unbootable flag mechanism (QSPI only)."""
+
+    def test__reset_slot_boot_flag_writes_payload(
+        self, tmp_path: Path, mocker: MockerFixture
+    ):
+        """The efivar payload is rewritten to the bootable value in-place."""
+        var_f = tmp_path / boot_cfg.ROOTFS_STATUS_SLOT_A_EFIVAR
+        # pre-populate with a different value of the same length
+        var_f.write_bytes(b"\x07\x00\x00\x00\x01\x00\x00\x00")
+
+        # the immutable-flag ioctl only works on real efivarfs, bypass it here
+        mocker.patch.object(
+            RootfsBootStatusControl,
+            "_immutable_flag_cleared",
+            return_value=contextlib.nullcontext(),
+        )
+        mock_sync = mocker.patch(f"{MODULE}.os.sync")
+
+        RootfsBootStatusControl._reset_slot_boot_flag("RootfsStatusSlotA", var_f)
+
+        assert var_f.read_bytes() == boot_cfg.RESET_ROOTFS_STATUS_PAYLOAD
+        assert var_f.read_bytes() == b"\x07\x00\x00\x00\x00\x00\x00\x00"
+        mock_sync.assert_called_once()
+
+    def test__reset_slot_boot_flag_missing_efivar(
+        self, tmp_path: Path, mocker: MockerFixture
+    ):
+        """Missing efivar is skipped without touching the immutable flag."""
+        var_f = tmp_path / "does_not_exist"
+        mock_immutable = mocker.patch.object(
+            RootfsBootStatusControl, "_immutable_flag_cleared"
+        )
+
+        # should not raise
+        RootfsBootStatusControl._reset_slot_boot_flag("RootfsStatusSlotA", var_f)
+        mock_immutable.assert_not_called()
+
+    def test__reset_slot_boot_flag_swallow_error(
+        self, tmp_path: Path, mocker: MockerFixture
+    ):
+        """Any failure is best-effort: logged and swallowed, never raised."""
+        var_f = tmp_path / boot_cfg.ROOTFS_STATUS_SLOT_A_EFIVAR
+        var_f.write_bytes(b"\x00" * 8)
+        mocker.patch.object(
+            RootfsBootStatusControl,
+            "_immutable_flag_cleared",
+            side_effect=PermissionError("no permission"),
+        )
+
+        # should not propagate the exception
+        RootfsBootStatusControl._reset_slot_boot_flag("RootfsStatusSlotA", var_f)
+
+    def test_reset_unbootable_flag_resets_both_slots(self, mocker: MockerFixture):
+        """Both slot A and slot B are reset, within the efivarfs mount."""
+        mocker.patch(
+            f"{MODULE}._ensure_efivarfs_mounted",
+            return_value=contextlib.nullcontext(),
+        )
+        mock_reset_slot = mocker.patch.object(
+            RootfsBootStatusControl, "_reset_slot_boot_flag"
+        )
+
+        RootfsBootStatusControl.reset_unbootable_flag()
+
+        assert mock_reset_slot.call_count == 2
+        reset_slot_names = [c.args[0] for c in mock_reset_slot.call_args_list]
+        assert reset_slot_names == ["RootfsStatusSlotA", "RootfsStatusSlotB"]
+
+    @pytest.mark.parametrize(
+        "device_uses_qspi, expect_reset",
+        (
+            # QSPI device: reset unbootable flag
+            (True, True),
+            # internal emmc device: DO NOT reset
+            (False, False),
+            # unknown/undetectable OTA_BOOTDEV: DO NOT reset
+            (None, False),
+        ),
+    )
+    def test__post_update_reset_flag_gating(
+        self,
+        device_uses_qspi: bool | None,
+        expect_reset: bool,
+        mocker: MockerFixture,
+    ):
+        """Only QSPI-equipped devices force-reset the unbootable flag."""
+        boot_control = mocker.MagicMock(spec=JetsonUEFIBootControl)
+        boot_control._uefi_control = mocker.MagicMock()
+        boot_control._uefi_control.nvbootctrl_conf = "dummy nvbootctrl conf"
+        # avoid the active-vs-current bootloader slot mismatch branch
+        boot_control._uefi_control.active_bootloader_slot = None
+        boot_control._uefi_control.external_rootfs = False
+        boot_control._mp_control = mocker.MagicMock()
+        boot_control._firmware_update.return_value = False
+
+        # patch collaborators unrelated to the gating under test
+        mocker.patch(f"{MODULE}.update_standby_slot_extlinux_cfg")
+        mocker.patch(f"{MODULE}.preserve_ota_config_files_to_standby")
+        mocker.patch(f"{MODULE}.replace_root", return_value="/dummy")
+        mocker.patch(f"{MODULE}.NVBootctrlJetsonUEFI")
+        mocker.patch(f"{MODULE}._env.get_dynamic_client_chroot_path", return_value=None)
+        mocker.patch(
+            f"{MODULE}._detect_ota_bootdev_is_qspi", return_value=device_uses_qspi
+        )
+        mock_reset = mocker.patch.object(
+            RootfsBootStatusControl, "reset_unbootable_flag"
+        )
+
+        JetsonUEFIBootControl._post_update_platform_specific(
+            boot_control, update_version="v1"
+        )
+
+        if expect_reset:
+            mock_reset.assert_called_once()
+        else:
+            mock_reset.assert_not_called()


### PR DESCRIPTION
## Introduction

This PR introduces mechanism and logic to unconditionally reset the boot flags for both slots before OTA reboot.
Reference: https://docs.nvidia.com/jetson/archives/r38.2.1/DeveloperGuide/SD/Bootloader/UEFI.html#set-the-uefi-variable-in-the-recovery-kernel-shell