### PR TITLE
chore: increase SESSION_WD_TMPFS_SIZE_IN_MB to 1280 MB

### DIFF
--- a/src/otaclient/configs/_cfg_configurable.py
+++ b/src/otaclient/configs/_cfg_configurable.py
@@ -32,7 +32,7 @@ LOG_LEVEL_LITERAL = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
 class _OTAClientSettings(BaseModel):
     # ------ OTA session setting ------ #
-    SESSION_WD_TMPFS_SIZE_IN_MB: int = 700  # MB
+    SESSION_WD_TMPFS_SIZE_IN_MB: int = 1280  # MB
     OTACLIENT_APP_TMPFS_SIZE_IN_MB: int = 700  # MB
 
     #


### PR DESCRIPTION
## Description

Increase the default size of the OTA session working directory tmpfs (`SESSION_WD_TMPFS_SIZE_IN_MB`) from 700 MB to 1280 MB to prevent ENOSPC failures when processing large OTA images.

With a recent x2gen2 (autoware) OTA image, the decompressed `file_table.sqlite3` alone is ~740 MB, which already exceeds the previous 700 MB tmpfs budget. As a result, `OTAImageHelper.select_image_payload` fails inside `export_blob_from_resource_dir` with `[Errno 28] No space left on device`, surfaced as a misleading `ImageMetadataInvalid` error.

Peak tmpfs usage measured on the failing image:

| File | Size |
|---|---|
| `file_table.sqlite3` (decompressed) | 740.0 MB |
| `resource_table.sqlite3` (decompressed) | 48.8 MB |
| `file_table.sqlite3.zst` (compressed, transient) | 81.6 MB |
| `resource_table.sqlite3.zst` (compressed, transient) | 37.6 MB |
| `index.jwt` / `index.json` / `image_manifest` / `image_config` / `sys_config` | < 1.0 MB |
| `otaclient-*.squashfs` (when otaclient client-update is included) | ~60 MB |
| **Total peak** | **~969 MB** |

1280 MB gives a ~310 MB headroom for image growth and concurrent occupants without doubling the RAM footprint.

## Check list

- [ ] test file(s) that cover the change(s) are implemented.
- [x] local tests are passing.
generated test image with this change and verified the actual behavior
https://evaluation.ci.tier4.jp/evaluation/reports/a109cd7c-c61a-5a83-9cf3-cb41dcb9a419?project_id=x2_dev
```
Jun 04 06:44:25 autoware-ecu otaclient[1908]: {"timestamp":"2026-06-04 06:44:25,941","level":"INFO","logger":"ota_metadata.v1","function":"download_and_verify_image_index","line":"149","message":"verify index.json against index.jwt ..."}
Jun 04 06:44:26 autoware-ecu otaclient[1908]: {"timestamp":"2026-06-04 06:44:26,062","level":"INFO","logger":"ota_metadata.v1","function":"download_and_verify_image_index","line":"171","message":"parse verified index.json ..."}
Jun 04 06:44:26 autoware-ecu otaclient[1908]: {"timestamp":"2026-06-04 06:44:26,062","level":"INFO","logger":"otaclient_common.retry_task_map","function":"_dispatcher_thread","line":"309","message":"finish dispatch 2 tasks"}
Jun 04 06:44:30 autoware-ecu otaclient[1908]: {"timestamp":"2026-06-04 06:44:30,183","level":"INFO","logger":"otaclient_common.retry_task_map","function":"_dispatcher_thread","line":"309","message":"finish dispatch 4 tasks"}
Jun 04 06:44:30 autoware-ecu otaclient[1908]: {"timestamp":"2026-06-04 06:44:30,754","level":"INFO","logger":"otaclient.ota_core._updater_base","function":"_process_metadata","line":"409","message":"ota_metadata parsed finished:
```



## Changes

- `src/otaclient/configs/_cfg_configurable.py`: bump `SESSION_WD_TMPFS_SIZE_IN_MB` default from `700` to `1280`.

## Behavior changes

Does this PR introduce behavior change(s)?

- [x] Yes, internal behavior (will not impact user experience).
- [ ] Yes, external behavior (will impact user experience).
- [ ] No.

### Previous behavior

The tmpfs mounted at `/run/otaclient/update-session` was sized at 700 MB. Large OTA images whose decompressed metadata DBs exceed this budget caused OTA to abort during metadata processing with `image metadata invalid: file_table and/or resource_table are invalid: [Errno 28] No space left on device`.

### Behavior with this PR

The session tmpfs is sized at 1280 MB by default, which accommodates the current largest observed image (~969 MB peak) with margin. Target ECUs need ~580 MB additional RAM available for the session tmpfs compared to before; this is reclaimed when the session ends.

## Breaking change

Does this PR introduce breaking change(s)?

- [ ] Yes.
- [x] No.

ECUs that previously had only ~700 MB of free RAM available for the session tmpfs may fail to mount the larger tmpfs and fall back to `/run` (existing fallback at `src/otaclient/ota_core/_main.py:145-147`), so this is not a hard regression.

## Related links & tickets

<!-- Add internal ticket / Slack thread links here -->