### PR TITLE
fix: wait for reboot instead of exiting

### DIFF
--- a/src/otaclient_common/cmdhelper.py
+++ b/src/otaclient_common/cmdhelper.py
@@ -412,7 +412,7 @@ def reboot(args: list[str] | None = None, *, chroot: str | None = None) -> NoRet
     try:
         subprocess_call(cmd, raise_exception=False, chroot=chroot)
     except Exception as e:
-        logger.error(f"failed to request reboot: {e!r}, exit now")
+        logger.exception(f"failed to request reboot: {e!r}, exit now")
         sys.exit(1)
 
     logger.info(

--- a/src/otaclient_common/cmdhelper.py
+++ b/src/otaclient_common/cmdhelper.py
@@ -371,16 +371,28 @@ def mkfs_ext4(
     subprocess_call(cmd, raise_exception=raise_exception)
 
 
-def reboot(
-    args: list[str] | None = None, *, chroot: str | None = None
-) -> NoReturn:  # pragma: no cover
+# The reboot command only requests the shutdown to the init system, the actual shutdown
+# is done asynchronously by the init system and can take a while(tens of seconds).
+# After the request is issued, otaclient waits for being terminated by the init system
+# instead of exiting by itself.
+WAIT_FOR_REBOOT_TIMEOUT = 60  # seconds
+WAIT_FOR_REBOOT_CHECK_INTERVAL = 1  # seconds
+
+
+def reboot(args: list[str] | None = None, *, chroot: str | None = None) -> NoReturn:
     """Reboot the system, with optional args passed to reboot command.
 
     This is implemented by calling:
         reboot [args[0], args[1], ...]
 
-    NOTE(20230614): this command makes otaclient exit immediately.
     NOTE(20240421): rpi_boot's reboot takes args.
+    NOTE(20260728): previously otaclient exited immediately after the reboot request.
+        As the reboot command only requests the shutdown, otaclient(including its status
+        API) disappeared while the system was still running, and the status API served
+        during that window no longer reported the ongoing OTA. This let the upper layer
+        treat the OTA as finished before the reboot actually happened.
+        Now we keep this process(and the status API) alive until the init system
+        terminates us during the shutdown.
 
     Args:
         args (Optional[list[str]], optional): args passed to reboot command.
@@ -388,7 +400,8 @@ def reboot(
         chroot (str | None, optional): the chroot path to use. Defaults to None.
 
     Raises:
-        SystemExit by sys.exit(0).
+        SystemExit(1) if the reboot request fails, or if the system doesn't reboot
+            within <WAIT_FOR_REBOOT_TIMEOUT> seconds after the request is issued.
     """
     cmd = ["reboot"]
     if args:
@@ -398,8 +411,23 @@ def reboot(
     logger.warning("system will reboot now!")
     try:
         subprocess_call(cmd, raise_exception=False, chroot=chroot)
-    finally:
-        sys.exit(0)
+    except Exception as e:
+        logger.error(f"failed to request reboot: {e!r}, exit now")
+        sys.exit(1)
+
+    logger.info(
+        f"reboot is requested, wait up to {WAIT_FOR_REBOOT_TIMEOUT}s for being terminated ..."
+    )
+    _deadline = time.time() + WAIT_FOR_REBOOT_TIMEOUT
+    while time.time() < _deadline:
+        time.sleep(WAIT_FOR_REBOOT_CHECK_INTERVAL)
+
+    # NOTE: exit with non-zero as the requested reboot doesn't happen, this should not
+    #       be treated as a normal finish of OTA.
+    logger.error(
+        f"system doesn't reboot within {WAIT_FOR_REBOOT_TIMEOUT}s after the reboot is requested, exit now"
+    )
+    sys.exit(1)
 
 
 #

--- a/tests/unit/test_otaclient_common/test_cmdhelper.py
+++ b/tests/unit/test_otaclient_common/test_cmdhelper.py
@@ -132,3 +132,54 @@ class TestEnsureMountpoint:
 
         mock_unlink.assert_called_once_with(missing_ok=True)
         mock_mkdir.assert_called_once_with(exist_ok=True, parents=True)
+
+
+class TestReboot:
+    def test_reboot_waits_for_being_terminated(self, mocker: MockerFixture):
+        """otaclient should not exit by itself right after the reboot is requested.
+
+        Exiting immediately tears down the status API while the system is still
+        running, which lets the upper layer see the OTA as no longer in progress
+        before the reboot actually happens.
+        """
+        mock_subprocess = mocker.patch(f"{MODULE}.subprocess_call")
+        # NOTE: patch the <time> name in the module's namespace, not the attributes of
+        #       the shared time module, to not interfere with other time users.
+        mock_time = mocker.patch(f"{MODULE}.time")
+        # 1st call: calculating the deadline, the rest: the loop condition checks
+        mock_time.time.side_effect = [0, 0, 1, cmdhelper.WAIT_FOR_REBOOT_TIMEOUT + 1]
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmdhelper.reboot()
+
+        mock_subprocess.assert_called_once_with(
+            ["reboot"], raise_exception=False, chroot=None
+        )
+        # waited until the deadline is reached, then exits with non-zero as the
+        # requested reboot doesn't happen
+        assert mock_time.sleep.call_count == 2
+        assert exc_info.value.code == 1
+
+    def test_reboot_with_args_and_chroot(self, mocker: MockerFixture):
+        mock_subprocess = mocker.patch(f"{MODULE}.subprocess_call")
+        mock_time = mocker.patch(f"{MODULE}.time")
+        mock_time.time.side_effect = [0, cmdhelper.WAIT_FOR_REBOOT_TIMEOUT + 1]
+
+        with pytest.raises(SystemExit):
+            cmdhelper.reboot(args=["0 tryboot"], chroot="/mnt/standby")
+
+        mock_subprocess.assert_called_once_with(
+            ["reboot", "0 tryboot"], raise_exception=False, chroot="/mnt/standby"
+        )
+
+    def test_reboot_exits_when_request_failed(self, mocker: MockerFixture):
+        """If the reboot cannot even be requested, exit to let the init system
+        restart otaclient, which then detects the unfinished switching boot."""
+        mocker.patch(f"{MODULE}.subprocess_call", side_effect=FileNotFoundError)
+        mock_time = mocker.patch(f"{MODULE}.time")
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmdhelper.reboot()
+
+        mock_time.sleep.assert_not_called()
+        assert exc_info.value.code == 1


### PR DESCRIPTION
## Description

Make `cmdhelper.reboot` wait for the init system to terminate otaclient, instead of calling `sys.exit(0)` right after issuing the reboot request.

The `reboot` command only *requests* the shutdown to the init system; the actual shutdown happens asynchronously and can take tens of seconds. During that window the system is still running, so otaclient (and its status API) must stay alive.

## Check list

- [x] test files that cover the bug case(s) are implemented.
- [x] local tests are passing.

## Bug fix

### Current behavior

`reboot` exits the otaclient process immediately after requesting the reboot:

```python
try:
    subprocess_call(cmd, raise_exception=False, chroot=chroot)
finally:
    sys.exit(0)
```
This causes the following problems:

otaclient disappears while the system is still up, so the status API is gone for the tens of seconds between the reboot request and the actual shutdown.
If **the systemd restarts original (legacy) otaclient** during that window, the status API served there no longer reports the ongoing OTA. The upper layer can then treat the OTA as already finished, before the reboot has actually happened.
Because of the finally, the process exits with 0 even when the reboot request itself fails — a failed reboot is indistinguishable from a normal OTA finish.
### Behavior after fix
After the reboot request succeeds, otaclient keeps running (and keeps serving the status API) and waits to be terminated by the init system during shutdown.
The wait is bounded by WAIT_FOR_REBOOT_TIMEOUT (60s, checked every 1s). If the system still hasn't rebooted by then, otaclient exits with 1.
If the reboot request itself fails, otaclient logs the error and exits with 1 immediately, letting the init system restart otaclient, which then detects the unfinished switching-boot.


### Related links & ticket
https://tier4.atlassian.net/browse/T4DEV-57865